### PR TITLE
#61: Use Try-With-Resources without catching clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 1. [#60](https://github.com/influxdata/influxdb-client-java/pull/60): Writes performance optimized
+1. [#61](https://github.com/influxdata/influxdb-client-java/pull/61): Use Try-With-Resources without catching clause
 
 ### API
 1. [#58](https://github.com/influxdata/influxdb-client-java/pull/58): Updated swagger to latest version

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
@@ -23,13 +23,14 @@ package com.influxdb.client.kotlin
 
 import com.influxdb.LogLevel
 import com.influxdb.client.domain.HealthCheck
+import java.io.Closeable
 
 /**
  * The reference Kotlin client that allows query and write for the InfluxDB 2.0 by Kotlin Channel coroutines.
  * 
  * @author Jakub Bednar (bednar@github) (07/02/2019 13:11)
  */
-interface InfluxDBClientKotlin {
+interface InfluxDBClientKotlin : Closeable {
 
     /**
      * Get the Query client.
@@ -86,5 +87,5 @@ interface InfluxDBClientKotlin {
     /**
      * Shutdown and close the client.
      */
-    fun close()
+    override fun close()
 }

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
@@ -37,14 +37,13 @@ import retrofit2.Retrofit
  * @author Jakub Bednar (bednar@github) (30/10/2018 08:32)
  */
 @RunWith(JUnitPlatform::class)
-class InfluxDBClientKotlinFactoryTest: AbstractTest() {
+class InfluxDBClientKotlinFactoryTest : AbstractTest() {
 
     @Test
-    fun connect()
-    {
+    fun connect() {
         val client = InfluxDBClientKotlinFactory.create("http://localhost:9999")
 
-        AssertionsForClassTypes.assertThat<InfluxDBClientKotlin>(client).isNotNull
+        AssertionsForClassTypes.assertThat(client).isNotNull
     }
 
     @Test
@@ -59,8 +58,8 @@ class InfluxDBClientKotlinFactoryTest: AbstractTest() {
         Assertions.assertThat(options.org).isEqualTo("my-org")
         Assertions.assertThat(options.bucket).isEqualTo("my-bucket")
         Assertions.assertThat(options.token).isEqualTo("my-token".toCharArray())
-        AssertionsForClassTypes.assertThat<LogLevel>(options.logLevel).isEqualTo(LogLevel.BASIC)
-        AssertionsForClassTypes.assertThat<LogLevel>(influxDBClient.getLogLevel()).isEqualTo(LogLevel.BASIC)
+        AssertionsForClassTypes.assertThat(options.logLevel).isEqualTo(LogLevel.BASIC)
+        AssertionsForClassTypes.assertThat(influxDBClient.getLogLevel()).isEqualTo(LogLevel.BASIC)
 
         val retrofit = getDeclaredField<Retrofit>(influxDBClient, "retrofit", AbstractInfluxDBClient::class.java)
         val okHttpClient = retrofit.callFactory() as OkHttpClient
@@ -68,5 +67,13 @@ class InfluxDBClientKotlinFactoryTest: AbstractTest() {
         Assertions.assertThat(okHttpClient.readTimeoutMillis()).isEqualTo(5000)
         Assertions.assertThat(okHttpClient.writeTimeoutMillis()).isEqualTo(60000)
         Assertions.assertThat(okHttpClient.connectTimeoutMillis()).isEqualTo(5000)
+    }
+
+    @Test
+    fun autoClosable() {
+        val client = InfluxDBClientKotlinFactory.create()
+        client.use {
+            Assertions.assertThat(it).isNotNull
+        }
     }
 }

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
@@ -109,4 +109,10 @@ public interface InfluxDBClientReactive extends AutoCloseable {
      * @return true if gzip is enabled.
      */
     boolean isGzipEnabled();
+
+    /**
+     * Shutdown and close the client.
+     */
+    @Override
+    void close();
 }

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
@@ -84,4 +84,11 @@ class InfluxDBClientReactiveFactoryTest extends AbstractTest {
         Assertions.assertThat(okHttpClient.writeTimeoutMillis()).isEqualTo(10_000);
         Assertions.assertThat(okHttpClient.connectTimeoutMillis()).isEqualTo(5_000);
     }
+
+    @Test
+    public void autoClosable() {
+        try (InfluxDBClientReactive client = InfluxDBClientReactiveFactory.create("http://localhost:9999")){
+            Assertions.assertThat(client).isNotNull();
+        } 
+    }
 }

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -265,4 +265,10 @@ public interface InfluxDBClient extends AutoCloseable {
      * @return true if gzip is enabled.
      */
     boolean isGzipEnabled();
+
+    /**
+     * Shutdown and close the client.
+     */
+    @Override
+    void close();
 }

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
@@ -165,4 +165,11 @@ class InfluxDBClientTest extends AbstractInfluxDBClientTest {
 
         Assertions.assertThat(operationLogs.getLogs()).hasSize(1);
     }
+
+    @Test
+    public void autoClosable() {
+        try (InfluxDBClient client = InfluxDBClientFactory.create(mockServer.url("/").url().toString())){
+            Assertions.assertThat(client).isNotNull();
+        }
+    }
 }


### PR DESCRIPTION
Use Try-With-Resources without catching clause:

```java
try (InfluxDBClient client = InfluxDBClientFactory.create(mockServer.url("/").url().toString())){
      ...
}
```

instead

```
try (InfluxDBClient client = InfluxDBClientFactory.create(mockServer.url("/").url().toString())){
      ...
} catch (Exception e) {
      ...            
}
```

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)