### PR TITLE
fix: InfluxDBClient.close also dispose a created writeApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.5.0 [unreleased]
 
+### Features
+1. [#33](https://github.com/influxdata/influxdb-client-java/issues/33): InfluxDBClient.close also dispose a created writeApi
+
 ## 1.4.0 [2020-01-17]
 
 ### Features

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
@@ -110,7 +110,6 @@ internal class ITQueryKotlinApi : AbstractITInfluxDBClientKotlin() {
 
         val writeApi = client.writeApi
         writeApi.writeRecord(bucket.name, organization.id, WritePrecision.NS, records)
-        writeApi.close()
 
         client.close()
 

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -227,7 +227,6 @@ public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
 
         Thread.sleep(30_000);
 
-        writeApi.close();
         influxDBClient.close();
     }
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
@@ -65,7 +65,7 @@ public class InfluxDBClientReactiveImpl extends AbstractInfluxDBClient
 
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 
-        return new WriteReactiveApiImpl(writeOptions, retrofit.create(WriteService.class), options);
+        return new WriteReactiveApiImpl(writeOptions, retrofit.create(WriteService.class), options, autoCloseables);
     }
 
     @Nonnull

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client.reactive.internal;
 
+import java.util.Collection;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
@@ -46,9 +47,9 @@ public class WriteReactiveApiImpl extends AbstractWriteClient implements WriteRe
 
     WriteReactiveApiImpl(@Nonnull final WriteOptions writeOptions,
                          @Nonnull final WriteService service,
-                         @Nonnull final InfluxDBClientOptions options) {
+                         @Nonnull final InfluxDBClientOptions options, final Collection<AutoCloseable> autoCloseables) {
 
-        super(writeOptions, options, writeOptions.getWriteScheduler(), service);
+        super(writeOptions, options, writeOptions.getWriteScheduler(), service, autoCloseables);
     }
 
     @Override

--- a/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
@@ -99,7 +99,6 @@ class ITQueryScalaApiQuery extends AbstractITQueryScalaApi with Matchers {
 
     val writeApi = client.getWriteApi
     writeApi.writeRecord(bucket.getName, organization.getId, WritePrecision.NS, records)
-    writeApi.close()
 
     client.close()
 

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -117,7 +117,7 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
 
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 
-        return new WriteApiImpl(writeOptions, retrofit.create(WriteService.class), options);
+        return new WriteApiImpl(writeOptions, retrofit.create(WriteService.class), options, autoCloseables);
     }
 
     @Nonnull

--- a/client/src/main/java/com/influxdb/client/internal/WriteApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/WriteApiImpl.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client.internal;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -48,9 +49,9 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
 
     WriteApiImpl(@Nonnull final WriteOptions writeOptions,
                  @Nonnull final WriteService service,
-                 @Nonnull final InfluxDBClientOptions options) {
+                 @Nonnull final InfluxDBClientOptions options, final Collection<AutoCloseable> autoCloseables) {
 
-        super(writeOptions, options, writeOptions.getWriteScheduler(), service);
+        super(writeOptions, options, writeOptions.getWriteScheduler(), service, autoCloseables);
     }
 
     @Override

--- a/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
@@ -54,7 +54,7 @@ class ITWriteApiBlocking extends AbstractITClientTest {
     private String token;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
 
         organization = findMyOrg();
 
@@ -200,7 +200,7 @@ class ITWriteApiBlocking extends AbstractITClientTest {
     }
 
     @Test
-    void defaultTags() throws Exception {
+    void defaultTags() {
 
         influxDBClient.close();
 

--- a/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
@@ -791,8 +791,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
         WriteApi writeApi = client.getWriteApi();
 
         writeApi.writeRecord(bucket.getName(), organization.getId(), WritePrecision.NS, "temperature,location=north value=60.0 1");
-        writeApi.close();
-        
+
         client.close();
 
         List<FluxTable> query = queryApi.query(

--- a/examples/src/main/java/example/InfluxDB2ReactiveExampleWriteEveryTenSeconds.java
+++ b/examples/src/main/java/example/InfluxDB2ReactiveExampleWriteEveryTenSeconds.java
@@ -30,7 +30,6 @@ import com.influxdb.annotations.Measurement;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
-import com.influxdb.client.reactive.QueryReactiveApi;
 import com.influxdb.client.reactive.WriteReactiveApi;
 
 import io.reactivex.Flowable;
@@ -62,7 +61,6 @@ public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
 
         Thread.sleep(30_000);
 
-        writeApi.close();
         influxDBClient.close();
     }
 


### PR DESCRIPTION
Closes #78
Closes #33

Calling `InfluxDBClient.close` should also close a created `writeApi`:

```java
InfluxDBClient influxDBClient = InfluxDBClientFactory.create(influxdbConfig.getAddress(), influxdbConfig.getToken().toCharArray());

WriteApi writeApi = influxDBClient.getWriteApi();
writeApi.writeRecord("b1", "org1", WritePrecision.NS,"h2o_feet water_level=1.0 1")

# unnecessary
writeApi.close();

influxDBClient.close();
```

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)