### PR TITLE
Support "inf" in Duration

### DIFF
--- a/client-core/src/main/java/com/influxdb/Arguments.java
+++ b/client-core/src/main/java/com/influxdb/Arguments.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  */
 public final class Arguments {
 
-    private static final Pattern DURATION_PATTERN = Pattern.compile("([-+]?)([0-9]+(\\.[0-9]*)?[a-z]+)+",
+    private static final Pattern DURATION_PATTERN = Pattern.compile("([-+]?)([0-9]+(\\.[0-9]*)?[a-z]+)+|inf",
             Pattern.CASE_INSENSITIVE);
 
     private static final String DURATION_MESSAGE = "Expecting a duration string for %s. But got: %s";


### PR DESCRIPTION
Closes #

"inf" is required to implement the "aggregateWindow" function manually.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)