### PR TITLE
feat: The closing message of the `WriteApi` has `Fine` log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.9.0 [unreleased]
 
+### Bug Fixes
+
+1. [#115](https://github.com/influxdata/influxdb-client-java/pull/115): The closing message of the `WriteApi` has `Fine` log level
+
 ### Dependencies
 
 1. [#112](https://github.com/influxdata/influxdb-client-java/pull/112): Update dependencies: akka: 2.6.5, assertj-core: 3.16.1, 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -199,7 +199,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
 
     public void close() {
 
-        LOG.log(Level.INFO, "Flushing any cached BatchWrites before shutdown.");
+        LOG.log(Level.FINE, "Flushing any cached BatchWrites before shutdown.");
 
         autoCloseables.remove(this);
 


### PR DESCRIPTION
Closes #114 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)