### PR TITLE
Instant.now() return is MilliSeconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ public class InfluxDB2Example {
             //
             // Write by LineProtocol
             //
-            writeApi.writeRecord(WritePrecision.NS, "temperature,location=north value=60.0");
+            writeApi.writeRecord(WritePrecision.MS, "temperature,location=north value=60.0");
 
             //
             // Write by POJO
@@ -158,7 +158,7 @@ public class InfluxDB2Example {
             temperature.value = 62D;
             temperature.time = Instant.now();
 
-            writeApi.writeMeasurement(WritePrecision.NS, temperature);
+            writeApi.writeMeasurement(WritePrecision.MS, temperature);
         }
 
         //


### PR DESCRIPTION
this example  : temperature.time = Instant.now(); is MilliSeconds , so  use WritePrecision.MS.

Closes #

_Briefly describe your proposed changes:_

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)