### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.10.0 [unreleased]
 
+### Bug Fixes
+1. [#129](https://github.com/influxdata/influxdb-client-java/pull/129): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+
 ### Dependencies
 
 1. [#124](https://github.com/influxdata/influxdb-client-java/pull/124): Update dependencies: akka: 2.6.6, commons-io: 2.7, spring: 5.2.7.RELEASE, retrofit: 2.9.0, okhttp3: 4.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.10.0 [unreleased]
 
 ### Bug Fixes
-1. [#129](https://github.com/influxdata/influxdb-client-java/pull/129): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+1. [#129](https://github.com/influxdata/influxdb-client-java/pull/129): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 
 
 ### Dependencies
 

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -303,7 +303,7 @@ public final class Point {
 
         StringBuilder sb = new StringBuilder();
 
-        escapeKey(sb, name);
+        escapeKey(sb, name, false);
         appendTags(sb, pointSettings);
         boolean appendedFields = appendFields(sb);
         if (!appendedFields) {
@@ -421,24 +421,34 @@ public final class Point {
     }
 
     private void escapeKey(@Nonnull final StringBuilder sb, @Nonnull final String key) {
+        escapeKey(sb, key, true);
+    }
+
+    private void escapeKey(@Nonnull final StringBuilder sb, @Nonnull final String key, final boolean escapeEqual) {
         for (int i = 0; i < key.length(); i++) {
             switch (key.charAt(i)) {
                 case '\n':
                     sb.append("\\n");
-                    break;
+                    continue;
                 case '\r':
                     sb.append("\\r");
-                    break;
+                    continue;
                 case '\t':
                     sb.append("\\t");
-                    break;
+                    continue;
                 case ' ':
                 case ',':
-                case '=':
                     sb.append('\\');
+                    break;
+                case '=':
+                    if (escapeEqual) {
+                        sb.append('\\');
+                    }
+                    break;
                 default:
-                    sb.append(key.charAt(i));
             }
+
+            sb.append(key.charAt(i));
         }
     }
 

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -423,6 +423,15 @@ public final class Point {
     private void escapeKey(@Nonnull final StringBuilder sb, @Nonnull final String key) {
         for (int i = 0; i < key.length(); i++) {
             switch (key.charAt(i)) {
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
                 case ' ':
                 case ',':
                 case '=':

--- a/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
@@ -101,6 +101,17 @@ class MeasurementMapperTest {
         Assertions.assertThat(mapper.toPoint(pojo, WritePrecision.NS).toLineProtocol()).isEqualTo("pojo,tag=value value=\"15\" 43658216763800123456");
     }
 
+    @Test
+    public void escapingTags() {
+
+        Pojo pojo = new Pojo();
+        pojo.tag = "mad\nrid";
+        pojo.value = 5;
+
+        String lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("pojo,tag=mad\\nrid value=\"5\"");
+    }
+
     @Measurement(name = "pojo")
     private static class Pojo {
 

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -54,7 +54,7 @@ class PointTest {
                 .addTag("", "warn")
                 .addField("level", 2);
 
-        Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2\\=o,location=europe level=2i");
+        Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2=o,location=europe level=2i");
 
         point = Point.measurement("h2,o")
                 .addTag("location", "europe")
@@ -97,6 +97,17 @@ class PointTest {
 
         Assertions.assertThat(point.toLineProtocol())
                 .isEqualTo("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\rreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i");
+    }
+
+    @Test
+    public void equalSignEscaping() {
+
+        Point point = Point.measurement("h=2o")
+                .addTag("l=ocation", "e=urope")
+                .addField("l=evel", 2);
+
+        Assertions.assertThat(point.toLineProtocol())
+                .isEqualTo("h=2o,l\\=ocation=e\\=urope l\\=evel=2i");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -87,6 +87,19 @@ class PointTest {
     }
 
     @Test
+    public void tagEscapingKeyAndValue() {
+
+        Point point = Point.measurement("h\n2\ro\t_data")
+                .addTag("new\nline", "new\nline")
+                .addTag("carriage\rreturn", "carriage\rreturn")
+                .addTag("t\tab", "t\tab")
+                .addField("level", 2);
+
+        Assertions.assertThat(point.toLineProtocol())
+                .isEqualTo("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\rreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i");
+    }
+
+    @Test
     void fieldTypes() {
 
         Point point = Point.measurement("h2o").addTag("location", "europe")


### PR DESCRIPTION
Closes #127 

* serialization of `\n`, `\r` and `\t` to Line Protocol
* `=` is valid sign for measurement name 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)