### PR TITLE
fix: put columns into cache after full initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#136](https://github.com/influxdata/influxdb-client-java/pull/136): Data Point: measurement name is requiring in constructor
+1. [#132](https://github.com/influxdata/influxdb-client-java/pull/132): Fixed thread safe issue in MeasurementMapper 
 
 ## 1.10.0 [2020-07-17]
 

--- a/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
+++ b/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
@@ -122,13 +122,7 @@ class MeasurementMapper {
             if (CLASS_FIELD_CACHE.containsKey(measurementType.getName())) {
                 continue;
             }
-            ConcurrentMap<String, Field> initialMap = new ConcurrentHashMap<>();
-            ConcurrentMap<String, Field> influxColumnAndFieldMap = CLASS_FIELD_CACHE
-                    .putIfAbsent(measurementType.getName(), initialMap);
-            if (influxColumnAndFieldMap == null) {
-                influxColumnAndFieldMap = initialMap;
-            }
-
+            ConcurrentMap<String, Field> map = new ConcurrentHashMap<>();
             Class<?> currentMeasurementType = measurementType;
             while (currentMeasurementType != null) {
                 for (Field field : currentMeasurementType.getDeclaredFields()) {
@@ -138,12 +132,14 @@ class MeasurementMapper {
                         if (name.isEmpty()) {
                             name = field.getName();
                         }
-                        influxColumnAndFieldMap.put(name, field);
+                        map.put(name, field);
                     }
                 }
 
                 currentMeasurementType = currentMeasurementType.getSuperclass();
             }
+
+            CLASS_FIELD_CACHE.putIfAbsent(measurementType.getName(), map);
         }
     }
 }


### PR DESCRIPTION
Put columns into cache after full initialization.

see - https://github.com/influxdata/influxdb-java/pull/685

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)