### PR TITLE
fix: Data Point: measurement name is requiring in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.11.0 [unreleased]
 
+### Bug Fixes
+1. [#136](https://github.com/influxdata/influxdb-client-java/pull/136): Data Point: measurement name is requiring in constructor
+
 ## 1.10.0 [2020-07-17]
 
 ### Bug Fixes

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -73,6 +73,18 @@ public final class Point {
     private WritePrecision precision = DEFAULT_WRITE_PRECISION;
 
     /**
+     * Create a new Point with specified a measurement name.
+     *
+     * @param measurementName the measurement name
+     */
+    public Point(@Nonnull final String measurementName) {
+
+        Arguments.checkNotNull(measurementName, "measurement");
+
+        this.name = measurementName;
+    }
+
+    /**
      * Create a new Point withe specified a measurement name.
      *
      * @param measurementName the measurement name
@@ -83,10 +95,7 @@ public final class Point {
 
         Arguments.checkNotNull(measurementName, "measurement");
 
-        Point point = new Point();
-        point.name = measurementName;
-
-        return point;
+        return new Point(measurementName);
     }
 
     /**

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -65,6 +65,23 @@ class PointTest {
     }
 
     @Test
+    public void createByConstructor() {
+        Point point = new Point("h2o")
+                .addTag("location", "europe")
+                .addField("level", 2);
+
+        Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2o,location=europe level=2i");
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void createByConstructorMeasurementRequired() {
+        Assertions.assertThatThrownBy(() -> new Point(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Expecting a not null reference for measurement");
+    }
+
+    @Test
     void tagEmptyKey() {
 
         Point point = Point.measurement("h2o")
@@ -124,7 +141,7 @@ class PointTest {
                 .addField("integer", 7)
                 .addField("integerObject", Integer.valueOf("8"))
                 .addField("boolean", false)
-                .addField("booleanObject", Boolean.parseBoolean("true"))
+                .addField("booleanObject", Boolean.TRUE)
                 .addField("string", "string value");
 
         String expected = "h2o,location=europe bigDecimal=33.45,boolean=false,booleanObject=true,double=2.0,doubleObject=5.0,"


### PR DESCRIPTION
Related-to #135

## Proposed Changes

The `measurement name` has to be specified.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
