### PR TITLE
feat: marked Apis as @ThreadSafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.11.0 [unreleased]
 
 ### Features
-1. [#138](https://github.com/influxdata/influxdb-client-java/pull/138): Marked Apis as @ThreadSafe
+1. [#139](https://github.com/influxdata/influxdb-client-java/pull/139): Marked Apis as @ThreadSafe
 
 ### Bug Fixes
 1. [#136](https://github.com/influxdata/influxdb-client-java/pull/136): Data Point: measurement name is requiring in constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.11.0 [unreleased]
 
+### Features
+1. [#138](https://github.com/influxdata/influxdb-client-java/pull/138): Marked Apis as @ThreadSafe
+
 ### Bug Fixes
 1. [#136](https://github.com/influxdata/influxdb-client-java/pull/136): Data Point: measurement name is requiring in constructor
 

--- a/client-legacy/src/main/java/com/influxdb/client/flux/FluxClient.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/FluxClient.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.Cancellable;
 import com.influxdb.LogLevel;
@@ -37,6 +38,7 @@ import com.influxdb.query.FluxTable;
  *
  * @author Jakub Bednar (bednar@github) (01/10/2018 12:17)
  */
+@ThreadSafe
 public interface FluxClient {
 
     /**

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client.reactive;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.domain.Dialect;
@@ -36,6 +37,7 @@ import org.reactivestreams.Publisher;
  *
  * @author Jakub Bednar (bednar@github) (21/11/2018 07:19)
  */
+@ThreadSafe
 public interface QueryReactiveApi {
 
     /**

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
@@ -22,6 +22,7 @@
 package com.influxdb.client.reactive;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteApi;
@@ -45,6 +46,7 @@ import org.reactivestreams.Publisher;
  *
  * @author Jakub Bednar (bednar@github) (22/11/2018 06:49)
  */
+@ThreadSafe
 public interface WriteReactiveApi extends AutoCloseable {
 
     /**

--- a/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
+++ b/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Authorization;
 import com.influxdb.client.domain.Organization;
@@ -35,6 +36,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (17/09/2018 11:09)
  */
+@ThreadSafe
 public interface AuthorizationsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/BucketsApi.java
+++ b/client/src/main/java/com/influxdb/client/BucketsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.BucketRetentionRules;
@@ -41,6 +42,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (13/09/2018 10:31)
  */
+@ThreadSafe
 public interface BucketsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/ChecksApi.java
+++ b/client/src/main/java/com/influxdb/client/ChecksApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Check;
 import com.influxdb.client.domain.CheckPatch;
@@ -39,6 +40,7 @@ import com.influxdb.client.domain.ThresholdCheck;
  *
  * @author Jakub Bednar (18/09/2019 08:07)
  */
+@ThreadSafe
 public interface ChecksApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/DashboardsApi.java
+++ b/client/src/main/java/com/influxdb/client/DashboardsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Cell;
 import com.influxdb.client.domain.CellUpdate;
@@ -43,6 +44,7 @@ import com.influxdb.client.domain.View;
  *
  * @author Jakub Bednar (bednar@github) (01/04/2019 10:47)
  */
+@ThreadSafe
 public interface DashboardsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/DeleteApi.java
+++ b/client/src/main/java/com/influxdb/client/DeleteApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.time.OffsetDateTime;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.DeletePredicateRequest;
@@ -33,6 +34,7 @@ import com.influxdb.client.domain.Organization;
  *
  * @author Pavlina Rolincova (rolincova@github) (25/10/2019).
  */
+@ThreadSafe
 public interface DeleteApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.LogLevel;
 import com.influxdb.client.domain.Authorization;
@@ -52,6 +53,7 @@ import com.influxdb.exceptions.UnprocessableEntityException;
  *
  * @author Jakub Bednar (bednar@github) (11/10/2018 08:56)
  */
+@ThreadSafe
 public interface InfluxDBClient extends AutoCloseable {
 
     /**

--- a/client/src/main/java/com/influxdb/client/LabelsApi.java
+++ b/client/src/main/java/com/influxdb/client/LabelsApi.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelCreateRequest;
@@ -36,6 +37,7 @@ import com.influxdb.client.domain.Organization;
  *
  * @author Jakub Bednar (bednar@github) (28/01/2019 10:37)
  */
+@ThreadSafe
 public interface LabelsApi {
 
     /**
@@ -43,7 +45,7 @@ public interface LabelsApi {
      *
      * @param name       name of a label
      * @param properties properties of a label
-     * @param orgID
+     * @param orgID      ID of the org
      * @return Label created
      */
     @Nonnull

--- a/client/src/main/java/com/influxdb/client/NotificationEndpointsApi.java
+++ b/client/src/main/java/com/influxdb/client/NotificationEndpointsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.HTTPNotificationEndpoint;
 import com.influxdb.client.domain.HTTPNotificationEndpoint.MethodEnum;
@@ -40,6 +41,7 @@ import com.influxdb.client.domain.SlackNotificationEndpoint;
  *
  * @author Jakub Bednar (11/09/2019 09:20)
  */
+@ThreadSafe
 public interface NotificationEndpointsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/NotificationRulesApi.java
+++ b/client/src/main/java/com/influxdb/client/NotificationRulesApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.HTTPNotificationEndpoint;
 import com.influxdb.client.domain.HTTPNotificationRule;
@@ -43,6 +44,7 @@ import com.influxdb.client.domain.TagRule;
  *
  * @author Jakub Bednar (23/09/2019 10:43)
  */
+@ThreadSafe
 public interface NotificationRulesApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/OrganizationsApi.java
+++ b/client/src/main/java/com/influxdb/client/OrganizationsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelResponse;
@@ -39,6 +40,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 14:58)
  */
+@ThreadSafe
 public interface OrganizationsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/QueryApi.java
+++ b/client/src/main/java/com/influxdb/client/QueryApi.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.Cancellable;
 import com.influxdb.client.domain.Dialect;
@@ -38,6 +39,7 @@ import com.influxdb.query.FluxTable;
  *
  * @author Jakub Bednar (bednar@github) (01/10/2018 12:17)
  */
+@ThreadSafe
 public interface QueryApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/ScraperTargetsApi.java
+++ b/client/src/main/java/com/influxdb/client/ScraperTargetsApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelResponse;
@@ -39,6 +40,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (22/01/2019 08:08)
  */
+@ThreadSafe
 public interface ScraperTargetsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/SourcesApi.java
+++ b/client/src/main/java/com/influxdb/client/SourcesApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.HealthCheck;
@@ -34,6 +35,7 @@ import com.influxdb.client.domain.Source;
  *
  * @author Jakub Bednar (bednar@github) (18/09/2018 09:01)
  */
+@ThreadSafe
 public interface SourcesApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/TasksApi.java
+++ b/client/src/main/java/com/influxdb/client/TasksApi.java
@@ -25,6 +25,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelResponse;
@@ -44,6 +45,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 07:54)
  */
+@ThreadSafe
 public interface TasksApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/TelegrafsApi.java
+++ b/client/src/main/java/com/influxdb/client/TelegrafsApi.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelResponse;
@@ -70,6 +71,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (28/02/2019 08:38)
  */
+@ThreadSafe
 public interface TelegrafsApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/TemplatesApi.java
+++ b/client/src/main/java/com/influxdb/client/TemplatesApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Document;
 import com.influxdb.client.domain.DocumentCreate;
@@ -35,6 +36,7 @@ import com.influxdb.client.domain.Organization;
 /**
  * @author Jakub Bednar (bednar@github) (25/03/2019 09:11)
  */
+@ThreadSafe
 public interface TemplatesApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/UsersApi.java
+++ b/client/src/main/java/com/influxdb/client/UsersApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.User;
 
@@ -31,6 +32,7 @@ import com.influxdb.client.domain.User;
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 10:05)
  */
+@ThreadSafe
 public interface UsersApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/VariablesApi.java
+++ b/client/src/main/java/com/influxdb/client/VariablesApi.java
@@ -23,6 +23,7 @@ package com.influxdb.client;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.Organization;
@@ -33,6 +34,7 @@ import com.influxdb.client.domain.Variable;
  *
  * @author Jakub Bednar (27/03/2019 09:35)
  */
+@ThreadSafe
 public interface VariablesApi {
 
     /**

--- a/client/src/main/java/com/influxdb/client/WriteApi.java
+++ b/client/src/main/java/com/influxdb/client/WriteApi.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
@@ -43,6 +44,7 @@ import com.influxdb.client.write.events.WriteSuccessEvent;
  *
  * @author Jakub Bednar (bednar@github) (20/09/2018 10:58)
  */
+@ThreadSafe
 public interface WriteApi extends AutoCloseable {
 
     /**

--- a/client/src/main/java/com/influxdb/client/WriteApiBlocking.java
+++ b/client/src/main/java/com/influxdb/client/WriteApiBlocking.java
@@ -24,6 +24,7 @@ package com.influxdb.client;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
@@ -38,6 +39,7 @@ import com.influxdb.exceptions.InfluxException;
  *
  * @author Jakub Bednar (bednar@github) (20/09/2018 10:58)
  */
+@ThreadSafe
 public interface WriteApiBlocking {
 
     /**


### PR DESCRIPTION
Closes #137

## Proposed Changes

The APIs are marked as ``@ThreadSafe``.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
