### PR TITLE
feat: validate OffsetDateTime to satisfy RFC 3339

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#139](https://github.com/influxdata/influxdb-client-java/pull/139): Marked Apis as @ThreadSafe
+1. [#140](https://github.com/influxdata/influxdb-client-java/pull/140): Validate OffsetDateTime to satisfy RFC 3339
 
 ### Bug Fixes
 1. [#136](https://github.com/influxdata/influxdb-client-java/pull/136): Data Point: measurement name is requiring in constructor

--- a/client/src/generated/java/com/influxdb/client/JSON.java
+++ b/client/src/generated/java/com/influxdb/client/JSON.java
@@ -15,6 +15,7 @@ package com.influxdb.client;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
@@ -34,7 +35,9 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
@@ -163,6 +166,9 @@ public class JSON {
      */
     public static class OffsetDateTimeTypeAdapter extends TypeAdapter<OffsetDateTime> {
 
+        private static final OffsetDateTime ZERO = LocalDateTime.of(0, 1, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC);
+
         private DateTimeFormatter formatter;
 
         public OffsetDateTimeTypeAdapter() {
@@ -182,6 +188,12 @@ public class JSON {
             if (date == null) {
                 out.nullValue();
             } else {
+                if (date.getYear() > 9999 || date.isBefore(ZERO)) {
+                    // https://tools.ietf.org/html/rfc3339
+                    throw new JsonIOException("All dates and times are assumed to be in the \"current era\", "
+                            + "somewhere between 0000AD and 9999AD.");
+                }
+
                 out.value(formatter.format(date));
             }
         }

--- a/client/src/generated/java/com/influxdb/client/JSON.java
+++ b/client/src/generated/java/com/influxdb/client/JSON.java
@@ -190,8 +190,8 @@ public class JSON {
             } else {
                 if (date.getYear() > 9999 || date.isBefore(ZERO)) {
                     // https://tools.ietf.org/html/rfc3339
-                    throw new JsonIOException("All dates and times are assumed to be in the \"current era\", "
-                            + "somewhere between 0000AD and 9999AD.");
+                    throw new JsonIOException("OffsetDateTime is out of range. All dates and times are assumed to be "
+                            + "in the \"current era\", somewhere between 0000AD and 9999AD.");
                 }
 
                 out.value(formatter.format(date));

--- a/client/src/test/java/com/influxdb/client/OffsetDateTimeTypeAdapterTest.java
+++ b/client/src/test/java/com/influxdb/client/OffsetDateTimeTypeAdapterTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.OffsetDateTime;
+
+import com.google.gson.stream.JsonWriter;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jakub Bednar (25/06/2020 13:47)
+ */
+public class OffsetDateTimeTypeAdapterTest {
+
+    @Test
+    public void max() throws IOException {
+        JSON.OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new JSON.OffsetDateTimeTypeAdapter();
+
+        StringWriter writer = new StringWriter();
+        offsetDateTimeTypeAdapter.write(new JsonWriter(writer), OffsetDateTime.MAX);
+
+        Assertions.assertThat(writer.toString()).isEqualTo("\"+999999999-12-31T23:59:59.999999999-18:00\"");
+    }
+
+    @Test
+    public void min() throws IOException {
+        JSON.OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new JSON.OffsetDateTimeTypeAdapter();
+
+        StringWriter writer = new StringWriter();
+        offsetDateTimeTypeAdapter.write(new JsonWriter(writer), OffsetDateTime.MIN);
+
+        Assertions.assertThat(writer.toString()).isEqualTo("\"-999999999-01-01T00:00:00+18:00\"");
+    }
+}

--- a/client/src/test/java/com/influxdb/client/OffsetDateTimeTypeAdapterTest.java
+++ b/client/src/test/java/com/influxdb/client/OffsetDateTimeTypeAdapterTest.java
@@ -64,7 +64,8 @@ public class OffsetDateTimeTypeAdapterTest {
 
         Assertions.assertThatThrownBy(() -> adapter.write(new JsonWriter(writer), time))
                 .isInstanceOf(JsonIOException.class)
-                .hasMessage("All dates and times are assumed to be in the \"current era\", somewhere between 0000AD and 9999AD.");
+                .hasMessage("OffsetDateTime is out of range. All dates and times are assumed to be in the "
+                        + "\"current era\", somewhere between 0000AD and 9999AD.");
     }
 
     @Test
@@ -72,7 +73,8 @@ public class OffsetDateTimeTypeAdapterTest {
 
         Assertions.assertThatThrownBy(() -> adapter.write(new JsonWriter(writer), OffsetDateTime.MAX))
                 .isInstanceOf(JsonIOException.class)
-                .hasMessage("All dates and times are assumed to be in the \"current era\", somewhere between 0000AD and 9999AD.");
+                .hasMessage("OffsetDateTime is out of range. All dates and times are assumed to be in the "
+                        + "\"current era\", somewhere between 0000AD and 9999AD.");
     }
 
     @Test
@@ -90,7 +92,8 @@ public class OffsetDateTimeTypeAdapterTest {
                 .atOffset(ZoneOffset.UTC);
         Assertions.assertThatThrownBy(() -> adapter.write(new JsonWriter(writer), time))
                 .isInstanceOf(JsonIOException.class)
-                .hasMessage("All dates and times are assumed to be in the \"current era\", somewhere between 0000AD and 9999AD.");
+                .hasMessage("OffsetDateTime is out of range. All dates and times are assumed to be in the "
+                        + "\"current era\", somewhere between 0000AD and 9999AD.");
 
     }
 
@@ -98,7 +101,8 @@ public class OffsetDateTimeTypeAdapterTest {
     public void min_offset() {
         Assertions.assertThatThrownBy(() -> adapter.write(new JsonWriter(writer), OffsetDateTime.MIN))
                 .isInstanceOf(JsonIOException.class)
-                .hasMessage("All dates and times are assumed to be in the \"current era\", somewhere between 0000AD and 9999AD.");
+                .hasMessage("OffsetDateTime is out of range. All dates and times are assumed to be in the "
+                        + "\"current era\", somewhere between 0000AD and 9999AD.");
 
     }
 }

--- a/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -4,6 +4,7 @@ package {{invokerPackage}};
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
@@ -38,7 +39,9 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 {{#java8}}
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 {{/java8}}
 import java.util.Date;
@@ -236,6 +239,9 @@ public class JSON {
      */
     public static class OffsetDateTimeTypeAdapter extends TypeAdapter<OffsetDateTime> {
 
+        private static final OffsetDateTime ZERO = LocalDateTime.of(0, 1, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC);
+
         private DateTimeFormatter formatter;
 
         public OffsetDateTimeTypeAdapter() {
@@ -255,6 +261,12 @@ public class JSON {
             if (date == null) {
                 out.nullValue();
             } else {
+                if (date.getYear() > 9999 || date.isBefore(ZERO)) {
+                    // https://tools.ietf.org/html/rfc3339
+                    throw new JsonIOException("All dates and times are assumed to be in the \"current era\", "
+                            + "somewhere between 0000AD and 9999AD.");
+                }
+
                 out.value(formatter.format(date));
             }
         }

--- a/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -263,8 +263,8 @@ public class JSON {
             } else {
                 if (date.getYear() > 9999 || date.isBefore(ZERO)) {
                     // https://tools.ietf.org/html/rfc3339
-                    throw new JsonIOException("All dates and times are assumed to be in the \"current era\", "
-                            + "somewhere between 0000AD and 9999AD.");
+                    throw new JsonIOException("OffsetDateTime is out of range. All dates and times are assumed to be "
+                            + "in the \"current era\", somewhere between 0000AD and 9999AD.");
                 }
 
                 out.value(formatter.format(date));


### PR DESCRIPTION
Closes #128

## Proposed Changes

Validate OffsetDateTime to satisfy RFC 3339.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
