### PR TITLE
fix: always close pure OkHttp3 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### API
 1. [#139](https://github.com/influxdata/influxdb-client-java/pull/148): Changed default port from 9999 to 8086
 
+### Bug Fixes
+1. [#151](https://github.com/influxdata/influxdb-client-java/pull/151): Fixed closing OkHttp3 response body
+
 ## 1.11.0 [2020-08-14]
 
 ### Features

--- a/client-core/src/test/java/com/influxdb/internal/ITUserAgentInterceptor.java
+++ b/client-core/src/test/java/com/influxdb/internal/ITUserAgentInterceptor.java
@@ -27,6 +27,7 @@ import com.influxdb.test.AbstractMockServerTest;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
@@ -57,13 +58,14 @@ class ITUserAgentInterceptor extends AbstractMockServerTest {
     @Test
     public void userAgent() throws IOException, InterruptedException {
 
-        mockServer.enqueue(new MockResponse()                );
+        mockServer.enqueue(new MockResponse());
 
         Request request = new Request.Builder()
                 .url(url)
                 .build();
 
-        client.newCall(request).execute();
+        Response response = client.newCall(request).execute();
+        response.close();
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
         String userAgent = recordedRequest.getHeader("User-Agent");

--- a/client-test/src/main/java/com/influxdb/test/AbstractTest.java
+++ b/client-test/src/main/java/com/influxdb/test/AbstractTest.java
@@ -159,9 +159,7 @@ public abstract class AbstractTest {
         Assertions.assertThat(request).isNotNull();
 
         OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
-        Response response;
-        try {
-            response = okHttpClient.newCall(request).execute();
+        try (Response response = okHttpClient.newCall(request).execute()) {
             Assertions.assertThat(response.isSuccessful())
                     .withFailMessage("Failed response <%s>. Body: <%s>", response, response.body())
                     .isTrue();

--- a/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
@@ -31,6 +31,7 @@ import okhttp3.Cookie;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
@@ -67,7 +68,8 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
                 .get()
                 .build();
 
-        buildOkHttpClient(options).newCall(request).execute();
+        Response response = buildOkHttpClient(options).newCall(request).execute();
+        response.close();
 
         Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(1);
 
@@ -103,7 +105,8 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
                 .get()
                 .build();
 
-        buildOkHttpClient(options).newCall(request).execute();
+        Response response = buildOkHttpClient(options).newCall(request).execute();
+        response.close();
 
         // Sign in request
         RecordedRequest requestToSignIn = mockServer.takeRequest();
@@ -138,7 +141,8 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
                 .get()
                 .build();
 
-        buildOkHttpClient(options).newCall(request).execute();
+        Response response = buildOkHttpClient(options).newCall(request).execute();
+        response.close();
 
         // Sign in request in init
         RecordedRequest requestToSignIn = mockServer.takeRequest();
@@ -213,7 +217,8 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
                 .get()
                 .build();
 
-        buildOkHttpClient(options).newCall(request).execute();
+        Response response = buildOkHttpClient(options).newCall(request).execute();
+        response.close();
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
         Assertions.assertThat(recordedRequest.getHeader("Authorization")).isEqualTo("Token xyz");

--- a/client/src/test/java/com/influxdb/client/internal/GzipInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/GzipInterceptorTest.java
@@ -30,6 +30,7 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
@@ -111,7 +112,8 @@ class GzipInterceptorTest extends AbstractMockServerTest {
                 .post(RequestBody.create(MediaType.parse("application/json"), "{name: \"Tom Type\"}"))
                 .build();
 
-        okHttpClient.newCall(request).execute();
+        Response execute = okHttpClient.newCall(request).execute();
+        execute.close();
 
         return mockServer.takeRequest();
     }


### PR DESCRIPTION
Closes #146 

## Proposed Changes

The pure OkHttp3 response (not Retrofit) should be always closed.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
