### PR TITLE
feat: add exponential backoff strategy for retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#150](https://github.com/influxdata/influxdb-client-java/pull/150): flux-dsl: added support for an offset parameter to limit operator, aggregates accept only a 'column' parameter
+1. [#156](https://github.com/influxdata/influxdb-client-java/pull/156): Added exponential backoff strategy for batching writes. Default value for `retryInterval` is 5_000 milliseconds.
 
 ### API
 1. [#139](https://github.com/influxdata/influxdb-client-java/pull/148): Changed default port from 9999 to 8086

--- a/client/README.md
+++ b/client/README.md
@@ -351,6 +351,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **jitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 5000 |
 | **maxRetries** | the number of max retries when write fails | 3 |
+| **maxRetryDelay** | the maximum delay between each retry attempt in milliseconds | 180_000 |
 | **exponentialBase** | the base for the exponential retry delay, the next delay is computed as `retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)` | 5 |
 | **bufferLimit** | the maximum number of unwritten stored points | 10000 |
 | **backpressureStrategy** | the strategy to deal with buffer overflow | DROP_OLDEST |

--- a/client/README.md
+++ b/client/README.md
@@ -339,7 +339,7 @@ For writing data we use [WriteApi](https://influxdata.github.io/influxdb-client-
     - `WriteSuccessEvent` - published when arrived the success response from Platform server
     - `BackpressureEvent` - published when is **client** backpressure applied
     - `WriteErrorEvent` - published when occurs a unhandled exception
-    - `WriteRetriableErrorEvent` - published when exceed a maximal number of retries
+    - `WriteRetriableErrorEvent` - published when occurs a retriable error
 5. use GZIP compression for data
 
 The writes are processed in batches which are configurable by `WriteOptions`:

--- a/client/README.md
+++ b/client/README.md
@@ -350,7 +350,8 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **jitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 1000 |
-| **maxRetries** | the number of max retries when write fails| 3 |
+| **maxRetries** | the number of max retries when write fails | 3 |
+| **exponentialBase** | the base for the exponential retry delay, the next delay is computed as `retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)` | 5 |
 | **bufferLimit** | the maximum number of unwritten stored points | 10000 |
 | **backpressureStrategy** | the strategy to deal with buffer overflow | DROP_OLDEST |
 

--- a/client/README.md
+++ b/client/README.md
@@ -339,7 +339,7 @@ For writing data we use [WriteApi](https://influxdata.github.io/influxdb-client-
     - `WriteSuccessEvent` - published when arrived the success response from Platform server
     - `BackpressureEvent` - published when is **client** backpressure applied
     - `WriteErrorEvent` - published when occurs a unhandled exception
-    - `WriteRetriableErrorEvent` - published when occurs a retriable error
+    - `WriteRetriableErrorEvent` - published when exceed a maximal number of retries
 5. use GZIP compression for data
 
 The writes are processed in batches which are configurable by `WriteOptions`:
@@ -350,6 +350,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **jitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 1000 |
+| **maxRetries** | the number of max retries when write fails| 3 |
 | **bufferLimit** | the maximum number of unwritten stored points | 10000 |
 | **backpressureStrategy** | the strategy to deal with buffer overflow | DROP_OLDEST |
 

--- a/client/README.md
+++ b/client/README.md
@@ -349,7 +349,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **batchSize** | the number of data point to collect in batch | 1000 |
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **jitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
-| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 1000 |
+| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 5000 |
 | **maxRetries** | the number of max retries when write fails | 3 |
 | **exponentialBase** | the base for the exponential retry delay, the next delay is computed as `retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)` | 5 |
 | **bufferLimit** | the maximum number of unwritten stored points | 10000 |

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -39,7 +39,7 @@ import io.reactivex.schedulers.Schedulers;
  * <ul>
  * <li>batchSize = 1000</li>
  * <li>flushInterval = 1000 ms</li>
- * <li>retryInterval = 1000 ms</li>
+ * <li>retryInterval = 5000 ms</li>
  * <li>jitterInterval = 0</li>
  * <li>bufferLimit = 10_000</li>
  * </ul>
@@ -55,7 +55,7 @@ public final class WriteOptions {
     private static final int DEFAULT_BATCH_SIZE = 1000;
     private static final int DEFAULT_FLUSH_INTERVAL = 1000;
     private static final int DEFAULT_JITTER_INTERVAL = 0;
-    private static final int DEFAULT_RETRY_INTERVAL = 1000;
+    private static final int DEFAULT_RETRY_INTERVAL = 5000;
     private static final int DEFAULT_MAX_RETRIES = 3;
     private static final int DEFAULT_EXPONENTIAL_BASE = 5;
     private static final int DEFAULT_BUFFER_LIMIT = 10000;

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -56,6 +56,7 @@ public final class WriteOptions {
     private static final int DEFAULT_FLUSH_INTERVAL = 1000;
     private static final int DEFAULT_JITTER_INTERVAL = 0;
     private static final int DEFAULT_RETRY_INTERVAL = 1000;
+    private static final int DEFAULT_MAX_RETRIES = 3;
     private static final int DEFAULT_BUFFER_LIMIT = 10000;
 
     /**
@@ -67,6 +68,7 @@ public final class WriteOptions {
     private final int flushInterval;
     private final int jitterInterval;
     private final int retryInterval;
+    private final int maxRetries;
     private final int bufferLimit;
     private final Scheduler writeScheduler;
     private final BackpressureOverflowStrategy backpressureStrategy;
@@ -95,7 +97,6 @@ public final class WriteOptions {
         return jitterInterval;
     }
 
-
     /**
      * The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
      * <br>
@@ -106,6 +107,16 @@ public final class WriteOptions {
      */
     public int getRetryInterval() {
         return retryInterval;
+    }
+
+    /**
+     * The number of max retries when write fails.
+     *
+     * @return number of max retries
+     * @see WriteOptions.Builder#maxRetries(int)
+     */
+    public int getMaxRetries() {
+        return maxRetries;
     }
 
     /**
@@ -142,6 +153,7 @@ public final class WriteOptions {
         flushInterval = builder.flushInterval;
         jitterInterval = builder.jitterInterval;
         retryInterval = builder.retryInterval;
+        maxRetries = builder.maxRetries;
         bufferLimit = builder.bufferLimit;
         writeScheduler = builder.writeScheduler;
         backpressureStrategy = builder.backpressureStrategy;
@@ -167,6 +179,7 @@ public final class WriteOptions {
         private int flushInterval = DEFAULT_FLUSH_INTERVAL;
         private int jitterInterval = DEFAULT_JITTER_INTERVAL;
         private int retryInterval = DEFAULT_RETRY_INTERVAL;
+        private int maxRetries = DEFAULT_MAX_RETRIES;
         private int bufferLimit = DEFAULT_BUFFER_LIMIT;
         private Scheduler writeScheduler = Schedulers.newThread();
         private BackpressureOverflowStrategy backpressureStrategy = BackpressureOverflowStrategy.DROP_OLDEST;
@@ -226,6 +239,19 @@ public final class WriteOptions {
         public Builder retryInterval(final int retryInterval) {
             Arguments.checkPositiveNumber(retryInterval, "retryInterval");
             this.retryInterval = retryInterval;
+            return this;
+        }
+
+        /**
+         * The number of max retries when write fails.
+         *
+         * @param maxRetries number of max retries
+         * @return {@code this}
+         */
+        @Nonnull
+        public Builder maxRetries(final int maxRetries) {
+            Arguments.checkPositiveNumber(maxRetries, "maxRetries");
+            this.maxRetries = maxRetries;
             return this;
         }
 

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -57,6 +57,7 @@ public final class WriteOptions {
     private static final int DEFAULT_JITTER_INTERVAL = 0;
     private static final int DEFAULT_RETRY_INTERVAL = 1000;
     private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final int DEFAULT_EXPONENTIAL_BASE = 5;
     private static final int DEFAULT_BUFFER_LIMIT = 10000;
 
     /**
@@ -69,6 +70,7 @@ public final class WriteOptions {
     private final int jitterInterval;
     private final int retryInterval;
     private final int maxRetries;
+    private final int exponentialBase;
     private final int bufferLimit;
     private final Scheduler writeScheduler;
     private final BackpressureOverflowStrategy backpressureStrategy;
@@ -120,6 +122,18 @@ public final class WriteOptions {
     }
 
     /**
+     * The base for the exponential retry delay.
+     *
+     * The next delay is computed as: retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)
+     *
+     * @return exponential base
+     * @see WriteOptions.Builder#exponentialBase(int)
+     */
+    public int getExponentialBase() {
+        return exponentialBase;
+    }
+
+    /**
      * @return Maximum number of points stored in the retry buffer.
      * @see WriteOptions.Builder#bufferLimit(int)
      */
@@ -154,6 +168,7 @@ public final class WriteOptions {
         jitterInterval = builder.jitterInterval;
         retryInterval = builder.retryInterval;
         maxRetries = builder.maxRetries;
+        exponentialBase = builder.exponentialBase;
         bufferLimit = builder.bufferLimit;
         writeScheduler = builder.writeScheduler;
         backpressureStrategy = builder.backpressureStrategy;
@@ -180,6 +195,7 @@ public final class WriteOptions {
         private int jitterInterval = DEFAULT_JITTER_INTERVAL;
         private int retryInterval = DEFAULT_RETRY_INTERVAL;
         private int maxRetries = DEFAULT_MAX_RETRIES;
+        private int exponentialBase = DEFAULT_EXPONENTIAL_BASE;
         private int bufferLimit = DEFAULT_BUFFER_LIMIT;
         private Scheduler writeScheduler = Schedulers.newThread();
         private BackpressureOverflowStrategy backpressureStrategy = BackpressureOverflowStrategy.DROP_OLDEST;
@@ -252,6 +268,19 @@ public final class WriteOptions {
         public Builder maxRetries(final int maxRetries) {
             Arguments.checkPositiveNumber(maxRetries, "maxRetries");
             this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * The base for the exponential retry delay.
+         *
+         * @param exponentialBase exponential base
+         * @return {@code this}
+         */
+        @Nonnull
+        public Builder exponentialBase(final int exponentialBase) {
+            Arguments.checkPositiveNumber(exponentialBase, "exponentialBase");
+            this.exponentialBase = exponentialBase;
             return this;
         }
 

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -57,6 +57,7 @@ public final class WriteOptions {
     private static final int DEFAULT_JITTER_INTERVAL = 0;
     private static final int DEFAULT_RETRY_INTERVAL = 5000;
     private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final int DEFAULT_MAX_RETRY_DELAY = 180_000;
     private static final int DEFAULT_EXPONENTIAL_BASE = 5;
     private static final int DEFAULT_BUFFER_LIMIT = 10000;
 
@@ -70,6 +71,7 @@ public final class WriteOptions {
     private final int jitterInterval;
     private final int retryInterval;
     private final int maxRetries;
+    private final int maxRetryDelay;
     private final int exponentialBase;
     private final int bufferLimit;
     private final Scheduler writeScheduler;
@@ -122,6 +124,16 @@ public final class WriteOptions {
     }
 
     /**
+     * The maximum delay between each retry attempt in milliseconds.
+     *
+     * @return maximum delay
+     * @see WriteOptions.Builder#maxRetryDelay(int)
+     */
+    public int getMaxRetryDelay() {
+        return maxRetryDelay;
+    }
+
+    /**
      * The base for the exponential retry delay.
      *
      * The next delay is computed as: retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)
@@ -168,6 +180,7 @@ public final class WriteOptions {
         jitterInterval = builder.jitterInterval;
         retryInterval = builder.retryInterval;
         maxRetries = builder.maxRetries;
+        maxRetryDelay = builder.maxRetryDelay;
         exponentialBase = builder.exponentialBase;
         bufferLimit = builder.bufferLimit;
         writeScheduler = builder.writeScheduler;
@@ -195,6 +208,7 @@ public final class WriteOptions {
         private int jitterInterval = DEFAULT_JITTER_INTERVAL;
         private int retryInterval = DEFAULT_RETRY_INTERVAL;
         private int maxRetries = DEFAULT_MAX_RETRIES;
+        private int maxRetryDelay = DEFAULT_MAX_RETRY_DELAY;
         private int exponentialBase = DEFAULT_EXPONENTIAL_BASE;
         private int bufferLimit = DEFAULT_BUFFER_LIMIT;
         private Scheduler writeScheduler = Schedulers.newThread();
@@ -268,6 +282,19 @@ public final class WriteOptions {
         public Builder maxRetries(final int maxRetries) {
             Arguments.checkPositiveNumber(maxRetries, "maxRetries");
             this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * The maximum delay between each retry attempt in milliseconds.
+         *
+         * @param maxRetryDelay  maximum delay
+         * @return {@code this}
+         */
+        @Nonnull
+        public Builder maxRetryDelay(final int maxRetryDelay) {
+            Arguments.checkPositiveNumber(maxRetryDelay, "maxRetryDelay");
+            this.maxRetryDelay = maxRetryDelay;
             return this;
         }
 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
@@ -82,6 +82,8 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
         this.gzipInterceptor = new GzipInterceptor();
 
         this.okHttpClient = options.getOkHttpClient()
+                // Connection errors are handled by RetryAttempt in AbstractWriteClient.
+                .retryOnConnectionFailure(false)
                 .addInterceptor(new UserAgentInterceptor(clientType))
                 .addInterceptor(this.loggingInterceptor)
                 .addInterceptor(this.authenticateInterceptor)

--- a/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
+++ b/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.internal;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.influxdb.client.WriteOptions;
+
+import retrofit2.HttpException;
+
+/**
+ * RetryConfiguration.
+ *
+ * @author Jakub Bednar (29/09/2020 14:19)
+ */
+final class RetryAttempt {
+    private static final Integer ABLE_TO_RETRY_ERROR = 429;
+    private static final Logger LOG = Logger.getLogger(AbstractWriteClient.class.getName());
+
+    private final Throwable throwable;
+    private final int count;
+    private final WriteOptions writeOptions;
+
+    RetryAttempt(final Throwable throwable, final int count, final WriteOptions writeOptions) {
+        this.throwable = throwable;
+        this.count = count;
+        this.writeOptions = writeOptions;
+    }
+
+    /**
+     * Is this request retryable?
+     *
+     * @return true if its retryable otherwise false
+     */
+    boolean isRetry() {
+        if (!(throwable instanceof HttpException)) {
+            return false;
+        }
+
+        HttpException he = (HttpException) throwable;
+
+        //
+        // Retry HTTP error codes >= 429
+        //
+        if (he.code() < ABLE_TO_RETRY_ERROR) {
+            return false;
+        }
+
+        //
+        // Max retries exceeded.
+        //
+        if (count > writeOptions.getMaxRetries()) {
+            String msg = String.format("Max write retries exceeded. Response: [%d]: %s", he.code(), he.message());
+            LOG.log(Level.WARNING, msg);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get current retry interval.
+     *
+     * @return retry interval to sleep
+     */
+    long getRetryInterval() {
+
+        long retryInterval;
+
+        String retryAfter = ((HttpException) throwable).response().headers().get("Retry-After");
+        // from header
+        if (retryAfter != null) {
+
+            retryInterval = TimeUnit.MILLISECONDS.convert(Integer.parseInt(retryAfter),
+                    TimeUnit.SECONDS);
+            // from default conf
+        } else {
+
+            retryInterval = writeOptions.getRetryInterval();
+
+            String msg = "The InfluxDB does not specify \"Retry-After\". "
+                    + "Use the default retryInterval: {0}";
+            LOG.log(Level.FINEST, msg, retryInterval);
+        }
+
+        retryInterval = retryInterval * (long) (Math.pow(writeOptions.getExponentialBase(), count - 1))
+                + jitterDelay(writeOptions.getJitterInterval());
+
+        return retryInterval;
+    }
+
+    /**
+     * @return current throwable
+     */
+    Throwable getThrowable() {
+        return throwable;
+    }
+
+    /**
+     * @param jitterInterval batch flush jitter interval
+     * @return randomized delay
+     */
+    static int jitterDelay(final int jitterInterval) {
+
+        return (int) (Math.random() * jitterInterval);
+    }
+}

--- a/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
+++ b/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
@@ -97,15 +97,17 @@ final class RetryAttempt {
             // from default conf
         } else {
 
-            retryInterval = writeOptions.getRetryInterval();
+            retryInterval = writeOptions.getRetryInterval()
+                    * (long) (Math.pow(writeOptions.getExponentialBase(), count - 1));
+
+            retryInterval = Math.min(retryInterval, writeOptions.getMaxRetryDelay());
 
             String msg = "The InfluxDB does not specify \"Retry-After\". "
                     + "Use the default retryInterval: {0}";
             LOG.log(Level.FINEST, msg, retryInterval);
         }
 
-        retryInterval = retryInterval * (long) (Math.pow(writeOptions.getExponentialBase(), count - 1))
-                + jitterDelay(writeOptions.getJitterInterval());
+        retryInterval = retryInterval + jitterDelay(writeOptions.getJitterInterval());
 
         return retryInterval;
     }

--- a/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
@@ -43,6 +43,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getBufferLimit()).isEqualTo(10000);
         Assertions.assertThat(writeOptions.getFlushInterval()).isEqualTo(1000);
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(0);
+        Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(3);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.newThread());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.DROP_OLDEST);
     }
@@ -56,6 +57,7 @@ class WriteOptionsTest {
                 .flushInterval(500)
                 .jitterInterval(1_000)
                 .retryInterval(2_000)
+                .maxRetries(5)
                 .writeScheduler(Schedulers.computation())
                 .backpressureStrategy(BackpressureOverflowStrategy.ERROR)
                 .build();
@@ -65,6 +67,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getFlushInterval()).isEqualTo(500);
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(1_000);
         Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(2_000);
+        Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(5);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.computation());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.ERROR);
     }

--- a/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
@@ -44,6 +44,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getFlushInterval()).isEqualTo(1000);
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(0);
         Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(3);
+        Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(5);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.newThread());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.DROP_OLDEST);
     }
@@ -58,6 +59,7 @@ class WriteOptionsTest {
                 .jitterInterval(1_000)
                 .retryInterval(2_000)
                 .maxRetries(5)
+                .exponentialBase(2)
                 .writeScheduler(Schedulers.computation())
                 .backpressureStrategy(BackpressureOverflowStrategy.ERROR)
                 .build();
@@ -68,6 +70,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(1_000);
         Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(2_000);
         Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(5);
+        Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(2);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.computation());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.ERROR);
     }

--- a/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
@@ -45,6 +45,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(0);
         Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(5_000);
         Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(3);
+        Assertions.assertThat(writeOptions.getMaxRetryDelay()).isEqualTo(180_000);
         Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(5);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.newThread());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.DROP_OLDEST);
@@ -60,6 +61,7 @@ class WriteOptionsTest {
                 .jitterInterval(1_000)
                 .retryInterval(2_000)
                 .maxRetries(5)
+                .maxRetryDelay(250_123)
                 .exponentialBase(2)
                 .writeScheduler(Schedulers.computation())
                 .backpressureStrategy(BackpressureOverflowStrategy.ERROR)
@@ -71,6 +73,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(1_000);
         Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(2_000);
         Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(5);
+        Assertions.assertThat(writeOptions.getMaxRetryDelay()).isEqualTo(250_123);
         Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(2);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.computation());
         Assertions.assertThat(writeOptions.getBackpressureStrategy()).isEqualTo(BackpressureOverflowStrategy.ERROR);

--- a/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
@@ -43,6 +43,7 @@ class WriteOptionsTest {
         Assertions.assertThat(writeOptions.getBufferLimit()).isEqualTo(10000);
         Assertions.assertThat(writeOptions.getFlushInterval()).isEqualTo(1000);
         Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(0);
+        Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(5_000);
         Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(3);
         Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(5);
         Assertions.assertThat(writeOptions.getWriteScheduler()).isEqualTo(Schedulers.newThread());

--- a/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
@@ -23,7 +23,7 @@ package com.influxdb.client.internal;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.client.internal.AbstractWriteClient.RetryAttempt;
+import com.influxdb.client.WriteOptions;
 
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -41,48 +41,96 @@ import retrofit2.Response;
  */
 @RunWith(JUnitPlatform.class)
 class RetryAttemptTest {
+    
+    private final WriteOptions DEFAULT = WriteOptions.builder().build();
 
     @Test
     public void throwableType() {
-        RetryAttempt retry = new RetryAttempt(new NullPointerException(""), 1, 3);
-
+        RetryAttempt retry = new RetryAttempt(new NullPointerException(""), 1, DEFAULT);
         Assertions.assertThat(retry.isRetry()).isFalse();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
-
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, DEFAULT);
         Assertions.assertThat(retry.isRetry()).isTrue();
     }
 
     @Test
     public void retryableHttpErrorCodes() {
-        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, 3);
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, DEFAULT);
         Assertions.assertThat(retry.isRetry()).isFalse();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, DEFAULT);
         Assertions.assertThat(retry.isRetry()).isTrue();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(504)), 1, 3);
+        retry = new RetryAttempt(new HttpException(errorResponse(504)), 1, DEFAULT);
         Assertions.assertThat(retry.isRetry()).isTrue();
     }
 
     @Test
     public void maxRetries() {
 
-        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
+        WriteOptions options = WriteOptions.builder().maxRetries(5).build();
+
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, options);
         Assertions.assertThat(retry.isRetry()).isTrue();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(429)), 2, 3);
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 2, options);
         Assertions.assertThat(retry.isRetry()).isTrue();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(429)), 3, 3);
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 3, options);
         Assertions.assertThat(retry.isRetry()).isTrue();
 
-        retry = new RetryAttempt(new HttpException(errorResponse(429)), 4, 3);
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 4, options);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 5, options);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 6, options);
         Assertions.assertThat(retry.isRetry()).isFalse();
+    }
+
+    @Test
+    public void headerHasPriority() {
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(428, 10)), 1, DEFAULT);
+
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(10000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, DEFAULT);
+
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(1000L);
+    }
+
+    @Test
+    public void exponentialBase() {
+
+        WriteOptions options = WriteOptions.builder().retryInterval(5_000).exponentialBase(5).build();
+
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(5000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 2, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(25000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 3, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(125000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 4, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(625000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 5, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(3125000L);
+
+        retry = new RetryAttempt(new HttpException(errorResponse(428)), 6, options);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(15625000L);
     }
 
     @Nonnull
     private Response<Object> errorResponse(final int httpErrorCode) {
+        return errorResponse(httpErrorCode, null);
+    }
+
+    @Nonnull
+    private Response<Object> errorResponse(final Integer httpErrorCode, final Integer retryAfter) {
 
         okhttp3.Response.Builder builder = new okhttp3.Response.Builder() //
                 .code(httpErrorCode)
@@ -91,6 +139,10 @@ class RetryAttemptTest {
                 .request(new Request.Builder().url("http://localhost/").build());
 
         ResponseBody body = ResponseBody.create("error", MediaType.parse("application/json"));
+
+        if (retryAfter != null) {
+            builder.addHeader("Retry-After", retryAfter.toString());
+        }
 
         return Response.error(body, builder.build());
     }

--- a/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.internal;
+
+import javax.annotation.Nonnull;
+
+import com.influxdb.client.internal.AbstractWriteClient.RetryAttempt;
+
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import retrofit2.HttpException;
+import retrofit2.Response;
+
+/**
+ * @author Jakub Bednar (29/09/2020 11:21)
+ */
+@RunWith(JUnitPlatform.class)
+class RetryAttemptTest {
+
+    @Test
+    public void throwableType() {
+        RetryAttempt retry = new RetryAttempt(new NullPointerException(""), 1, 3);
+
+        Assertions.assertThat(retry.isRetry()).isFalse();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
+
+        Assertions.assertThat(retry.isRetry()).isTrue();
+    }
+
+    @Test
+    public void retryableHttpErrorCodes() {
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, 3);
+        Assertions.assertThat(retry.isRetry()).isFalse();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(504)), 1, 3);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+    }
+
+    @Test
+    public void maxRetries() {
+
+        RetryAttempt retry = new RetryAttempt(new HttpException(errorResponse(429)), 1, 3);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 2, 3);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 3, 3);
+        Assertions.assertThat(retry.isRetry()).isTrue();
+
+        retry = new RetryAttempt(new HttpException(errorResponse(429)), 4, 3);
+        Assertions.assertThat(retry.isRetry()).isFalse();
+    }
+
+    @Nonnull
+    private Response<Object> errorResponse(final int httpErrorCode) {
+
+        okhttp3.Response.Builder builder = new okhttp3.Response.Builder() //
+                .code(httpErrorCode)
+                .message("Response.error()")
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://localhost/").build());
+
+        ResponseBody body = ResponseBody.create("error", MediaType.parse("application/json"));
+
+        return Response.error(body, builder.build());
+    }
+}

--- a/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
@@ -97,7 +97,7 @@ class RetryAttemptTest {
 
         retry = new RetryAttempt(new HttpException(errorResponse(428)), 1, DEFAULT);
 
-        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(1000L);
+        Assertions.assertThat(retry.getRetryInterval()).isEqualTo(5000L);
     }
 
     @Test


### PR DESCRIPTION
Related to #145

## Proposed Changes

1. default value for `retryInterval` is 5_000
1. added exponential backoff strategy for batch writes
   1. added `maxRetries` - the number of max retries when write fails - `3`
   1. added `maxRetryDelay` -  the maximum delay between each retry attempt in milliseconds - `180_000`
   1. added `exponentialBase` -  the base for the exponential retry delay, the next delay is computed as `retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)` 
   1. retry also network strategy
1. other http request doesn't have retry strategy


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
