### PR TITLE
fix: Offset param could be 0 - FluxDSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#163](https://github.com/influxdata/influxdb-client-java/pull/163): Improved logging message for retries
 
+### Bug Fixes
+1. [#161](https://github.com/influxdata/influxdb-client-java/pull/161): Offset param could be 0 - FluxDSL
+
 ## 1.12.0 [2020-10-02]
 
 ### Features

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
@@ -78,7 +78,7 @@ public final class LimitFlux extends AbstractParametrizedFlux {
     @Nonnull
     public LimitFlux withOffset(final int offset) {
 
-        Arguments.checkPositiveNumber(offset, "The number of records to skip");
+        Arguments.checkNotNegativeNumber(offset, "The number of records to skip");
 
         this.withPropertyValue("offset", offset);
 

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LimitFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LimitFluxTest.java
@@ -58,6 +58,17 @@ class LimitFluxTest {
     }
 
     @Test
+    void limitOffsetZero() {
+
+        Flux flux = Flux
+                .from("telegraf")
+                .limit(100, 0);
+
+        Assertions.assertThat(flux.toString())
+                .isEqualToIgnoringWhitespace("from(bucket:\"telegraf\") |> limit(n: 100, offset:0)");
+    }
+
+    @Test
     void limitPositive() {
         Assertions.assertThatThrownBy(() -> Flux.from("telegraf").limit(-5))
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Closes #160 

## Proposed Changes

Offset param could be 0 - FluxDSL

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
