### PR TITLE
feat: improved logging message for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.13.0 [unreleased]
+1. [#163](https://github.com/influxdata/influxdb-client-java/pull/163): Improved logging message for retries
 
 ## 1.12.0 [2020-10-02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 1.13.0 [unreleased]
+
+### Features
 1. [#163](https://github.com/influxdata/influxdb-client-java/pull/163): Improved logging message for retries
 
 ## 1.12.0 [2020-10-02]

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -520,7 +520,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
 
                         long retryInterval = attempt.getRetryInterval();
 
-                        publish(new WriteRetriableErrorEvent(throwable, retryInterval));
+                        publish(new WriteRetriableErrorEvent(toInfluxException(throwable), retryInterval));
 
                         return Flowable.just("notify").delay(retryInterval, TimeUnit.MILLISECONDS, retryScheduler);
                     }

--- a/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
@@ -67,7 +67,7 @@ public final class WriteRetriableErrorEvent extends AbstractWriteEvent {
 
     @Override
     public void logEvent() {
-        String msg = "The retriable error occurred during writing of data. Retry in: {0} [ms]";
-        LOG.log(Level.WARNING, msg, retryInterval);
+        String msg = "The retriable error occurred during writing of data. Reason: '{0}'. Retry in: {1}ms.";
+        LOG.log(Level.WARNING, msg, new Object[]{throwable.getMessage(), retryInterval});
     }
 }

--- a/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
@@ -66,8 +66,9 @@ public final class WriteRetriableErrorEvent extends AbstractWriteEvent {
     }
 
     @Override
+    @SuppressWarnings("MagicNumber")
     public void logEvent() {
-        String msg = "The retriable error occurred during writing of data. Reason: '{0}'. Retry in: {1}ms.";
-        LOG.log(Level.WARNING, msg, new Object[]{throwable.getMessage(), retryInterval});
+        String msg = "The retriable error occurred during writing of data. Reason: ''{0}''. Retry in: {1}s.";
+        LOG.log(Level.WARNING, msg, new Object[]{throwable.getMessage(), (double) retryInterval / 1000});
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITQueryService.java
+++ b/client/src/test/java/com/influxdb/client/ITQueryService.java
@@ -41,7 +41,6 @@ import com.influxdb.client.service.QueryService;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -155,13 +154,10 @@ class ITQueryService extends AbstractITClientTest {
         FluxSuggestion suggestion = queryService.getQuerySuggestionsName("range", null).execute().body();
         Assertions.assertThat(suggestion).isNotNull();
         Assertions.assertThat(suggestion.getParams())
-                .hasSize(6)
+                .hasSize(3)
                 .hasEntrySatisfying("start", value -> Assertions.assertThat(value).isEqualTo("invalid"))
-                .hasEntrySatisfying("startColumn", value -> Assertions.assertThat(value).isEqualTo("string"))
                 .hasEntrySatisfying("stop", value -> Assertions.assertThat(value).isEqualTo("invalid"))
-                .hasEntrySatisfying("stopColumn", value -> Assertions.assertThat(value).isEqualTo("string"))
-                .hasEntrySatisfying("tables", value -> Assertions.assertThat(value).isEqualTo("array"))
-                .hasEntrySatisfying("timeColumn", value -> Assertions.assertThat(value).isEqualTo("string"));
+                .hasEntrySatisfying("tables", value -> Assertions.assertThat(value).isEqualTo("array"));
 
     }
 }

--- a/client/src/test/java/com/influxdb/client/MockLogHandler.java
+++ b/client/src/test/java/com/influxdb/client/MockLogHandler.java
@@ -19,44 +19,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.influxdb.client.internal;
+package com.influxdb.client;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
-import com.influxdb.client.MockLogHandler;
-
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
- * @author Jakub Bednar (28/01/2020 14:47)
+ * @author Jakub Bednar (12/10/2020 13:49)
  */
-@RunWith(JUnitPlatform.class)
-class WaitToConditionTest {
-    
-    @Test
-    public void waitToCondition()
-    {
-        MockLogHandler handler = new MockLogHandler();
-        
-        final Logger logger = Logger.getLogger(AbstractWriteClient.class.getName());
-        logger.addHandler(handler);
+public class MockLogHandler extends Handler {
+    private final Map<Level, List<LogRecord>> levels = new HashMap<>();
 
-        AbstractWriteClient.waitToCondition(() -> true, 30000);
-        AbstractWriteClient.waitToCondition(() -> false, 1);
+    @Override
+    public void publish(final LogRecord record) {
+        List<LogRecord> records = levels.computeIfAbsent(record.getLevel(), level -> new ArrayList<>());
+        records.add(record);
+    }
 
-        List<String> records = handler.getRecords(Level.SEVERE)
-                .stream()
-                .map(LogRecord::getMessage)
-                .collect(Collectors.toList());
-        
-        Assertions.assertThat(records).contains("The WriteApi can't be gracefully dispose! - 1ms elapsed.");
-        Assertions.assertThat(records).doesNotContain("The WriteApi can't be gracefully dispose! - 30000ms elapsed.");
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() throws SecurityException {
+
+    }
+
+    public List<LogRecord> getRecords(Level level) {
+        return levels.get(level);
     }
 }

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import retrofit2.HttpException;
 
 /**
  * @author Jakub Bednar (bednar@github) (21/09/2018 11:36)
@@ -649,8 +648,8 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         retriableListener.awaitCount(1);
         Assertions.assertThat(retriableListener.getValue().getThrowable())
-                .isInstanceOf(HttpException.class)
-                .hasMessage("HTTP 429 Client Error");
+                .isInstanceOf(InfluxException.class)
+                .hasMessage("token is temporarily over quota");
         
         Assertions.assertThat(retriableListener.getValue().getRetryInterval()).isEqualTo(5000);
 

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -778,10 +778,10 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         Assertions.assertThat(records).hasSize(1);
         Assertions.assertThat(records.get(0).getMessage())
-                .isEqualTo("The retriable error occurred during writing of data. Reason: '{0}'. Retry in: {1}ms.");
+                .isEqualTo("The retriable error occurred during writing of data. Reason: ''{0}''. Retry in: {1}s.");
         Assertions.assertThat(records.get(0).getParameters()).hasSize(2);
         Assertions.assertThat(records.get(0).getParameters()[0]).isEqualTo("org 04014de4ed590000 has exceeded limited_write plan limit");
-        Assertions.assertThat(records.get(0).getParameters()[1]).isEqualTo(5000L);
+        Assertions.assertThat(records.get(0).getParameters()[1]).isEqualTo(5.0);
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

The message looks like:

 _The retriable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in 5000ms._

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
