### PR TITLE
fix: query response parser should use UTF-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#161](https://github.com/influxdata/influxdb-client-java/pull/161): Offset param could be 0 - FluxDSL
+1. [#164](https://github.com/influxdata/influxdb-client-java/pull/164): Query response parser uses UTF-8 encoding
 
 ## 1.12.0 [2020-10-02]
 

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -24,6 +24,7 @@ package com.influxdb.query.internal;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ public class FluxCsvParser {
 
         Arguments.checkNotNull(bufferedSource, "bufferedSource");
 
-        Reader reader = new InputStreamReader(bufferedSource.inputStream());
+        Reader reader = new InputStreamReader(bufferedSource.inputStream(), StandardCharsets.UTF_8);
 
         ParsingState parsingState = ParsingState.NORMAL;
 


### PR DESCRIPTION
Closes #162 

## Proposed Changes

The response from InfluxDB server is encoded in UTF-8 => `InputStreamReader` should use UTF-8 as en encoding. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
