### PR TITLE
fix: downgrade gson to 2.8.5 to support Java 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 1. [#161](https://github.com/influxdata/influxdb-client-java/pull/161): Offset param could be 0 - FluxDSL
 1. [#164](https://github.com/influxdata/influxdb-client-java/pull/164): Query response parser uses UTF-8 encoding
+1. [#169](https://github.com/influxdata/influxdb-client-java/pull/169): Downgrade gson to 2.8.5 to support Java 8
 
 ## 1.12.0 [2020-10-02]
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
 
         <dependency.retrofit.version>2.9.0</dependency.retrofit.version>
         <dependency.okhttp3.version>4.7.2</dependency.okhttp3.version>
+        <dependency.gson.version>2.8.5</dependency.gson.version>
 
         <plugin.surefire.version>2.22.2</plugin.surefire.version>
         <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
@@ -511,7 +512,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.6</version>
+                <version>${dependency.gson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Downgrade gson version from 2.8.6 to 2.8.5 in order to support Java 8.

Related gson issue: https://github.com/google/gson/issues/1608

gson 2.8.7 should fix this once it is released

Closes #

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
