### PR TITLE
feat: added `to` function without `org` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.14.0 [unreleased]
 
+### Features
+1. [#172](https://github.com/influxdata/influxdb-client-java/pull/172): flux-dsl: added `to` function without `org` parameter
+
 ## 1.13.0 [2020-10-30]
 
 ### Features

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
@@ -1748,6 +1748,19 @@ public abstract class Flux {
      * To operation takes data from a stream and writes it to a bucket.
      *
      * @param bucket The bucket to which data will be written.
+     * @return {@link ToFlux}
+     */
+    @Nonnull
+    public final ToFlux to(@Nonnull final String bucket) {
+
+        return new ToFlux(this)
+                .withBucket(bucket);
+    }
+
+    /**
+     * To operation takes data from a stream and writes it to a bucket.
+     *
+     * @param bucket The bucket to which data will be written.
      * @param org    The organization name of the above bucket.
      * @return {@link ToFlux}
      */

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
@@ -44,7 +44,12 @@ import com.influxdb.query.dsl.Flux;
  *     <li><b>fieldFn</b> - Function that takes a record from the input table and returns an object.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <h3>Examples</h3>
+ * <pre>
+ * Flux flux = Flux
+ *     .from("telegraf")
+ *     .to("my-bucket");
+ * </pre>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFluxTest.java
@@ -57,6 +57,17 @@ class ToFluxTest {
     }
 
     @Test
+    void toBucket() {
+
+        Flux flux = Flux
+                .from("telegraf")
+                .to("my-bucket");
+
+        Assertions.assertThat(flux.toString())
+                .isEqualToIgnoringWhitespace("from(bucket:\"telegraf\") |> to(bucket: \"my-bucket\")");
+    }
+
+    @Test
     void toBucketOrg() {
 
         Flux flux = Flux


### PR DESCRIPTION
Closes #170

## Proposed Changes

Add `to` function without `org`.

> Similarly org and orgID are mutually exclusive and only required when writing to a remote host. 

https://github.com/influxdata/flux/blob/master/docs/SPEC.md#to

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
