### PR TITLE
fix: query error could be after "success" table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.14.0 [unreleased]
 
+### Bug Fixes
+1. [#173](https://github.com/influxdata/influxdb-client-java/pull/173): Query error could be after _success_ table
+
 ## 1.13.0 [2020-10-30]
 
 ### Features

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -53,8 +53,6 @@ import org.apache.commons.csv.CSVRecord;
  */
 public class FluxCsvParser {
 
-    private static final int ERROR_RECORD_INDEX = 4;
-
     private enum ParsingState {
         NORMAL,
 
@@ -111,6 +109,7 @@ public class FluxCsvParser {
      * @param consumer       to accept {@link FluxTable}s and {@link FluxRecord}s
      * @throws IOException If there is a problem with reading CSV
      */
+    @SuppressWarnings("MagicNumber")
     public void parseFluxResponse(@Nonnull final BufferedSource bufferedSource,
                                   @Nonnull final Cancellable cancellable,
                                   @Nonnull final FluxResponseConsumer consumer) throws IOException {
@@ -132,13 +131,10 @@ public class FluxCsvParser {
                     return;
                 }
 
-                long recordNumber = csvRecord.getRecordNumber();
-
                 //
                 // Response has HTTP status ok, but response is error.
                 //
-                if (ERROR_RECORD_INDEX == recordNumber && csvRecord.get(1).equals("error")
-                        && csvRecord.get(2).equals("reference")) {
+                if (csvRecord.size() >= 3 && csvRecord.get(1).equals("error") && csvRecord.get(2).equals("reference")) {
 
                     parsingState = ParsingState.IN_ERROR;
                     continue;
@@ -153,7 +149,7 @@ public class FluxCsvParser {
 
                     int reference = 0;
                     if (referenceValue != null && !referenceValue.isEmpty()) {
-                        reference = Integer.valueOf(referenceValue);
+                        reference = Integer.parseInt(referenceValue);
                     }
 
                     throw new FluxQueryException(error, reference);

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -573,7 +573,7 @@ class FluxCsvParserTest {
     }
 
     @Test
-    public void responseWitError() {
+    public void responseWithError() {
         String data = "#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string\n"
                 + "#group,false,false,true,true,true,true,false,false,true\n"
                 + "#default,t1,,,,,,,,\n"

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -572,6 +572,29 @@ class FluxCsvParserTest {
         }
     }
 
+    @Test
+    public void responseWitError() {
+        String data = "#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string\n"
+                + "#group,false,false,true,true,true,true,false,false,true\n"
+                + "#default,t1,,,,,,,,\n"
+                + ",result,table,_field,_measurement,_start,_stop,_time,_value,tag\n"
+                + ",,0,value,python_client_test,2010-02-27T04:48:32.752600083Z,2020-02-27T16:48:32.752600083Z,2020-02-27T16:20:00Z,2,test1\n"
+                + ",,0,value,python_client_test,2010-02-27T04:48:32.752600083Z,2020-02-27T16:48:32.752600083Z,2020-02-27T16:21:40Z,2,test1\n"
+                + ",,0,value,python_client_test,2010-02-27T04:48:32.752600083Z,2020-02-27T16:48:32.752600083Z,2020-02-27T16:23:20Z,2,test1\n"
+                + ",,0,value,python_client_test,2010-02-27T04:48:32.752600083Z,2020-02-27T16:48:32.752600083Z,2020-02-27T16:25:00Z,2,test1\n"
+                + "\n"
+                + "#datatype,string,string\n"
+                + "#group,true,true\n"
+                + "#default,,\n"
+                + ",error,reference\n"
+                + ",\"engine: unknown field type for value: xyz\",";
+
+        Assertions.assertThatThrownBy(() -> parseFluxResponse(data))
+                .isInstanceOf(FluxQueryException.class)
+                .hasMessage("engine: unknown field type for value: xyz")
+                .matches((Predicate<Throwable>) throwable -> ((FluxQueryException) throwable).reference() == 0);
+    }
+
     @Nonnull
     private List<FluxTable> parseFluxResponse(@Nonnull final String data) throws IOException {
 
@@ -591,6 +614,7 @@ class FluxCsvParserTest {
         charset.setAccessible(true);
         charset.set(null, Charset.forName(name));
     }
+
     private static class DefaultCancellable implements Cancellable {
 
 


### PR DESCRIPTION
Closes #171

## Proposed Changes

According to specification of Flux, the error could be propagated after "success" table:

> When an error occurs after some results have already been sent to the client the error will be encoded as the next table and the rest of the results will be discarded. In such a case the HTTP status code cannot be changed and will remain as 200 OK. 

https://github.com/influxdata/flux/blob/master/docs/SPEC.md#errors

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
