### PR TITLE
fix: concatenation of url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 1. [#173](https://github.com/influxdata/influxdb-client-java/pull/173): Query error could be after _success_ table
 1. [#176](https://github.com/influxdata/influxdb-client-java/pull/176): Blocking API batches Point by precision
+1. [#180](https://github.com/influxdata/influxdb-client-java/pull/180): Fixed concatenation of url
 
 ## 1.13.0 [2020-10-30]
 

--- a/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
@@ -118,7 +118,7 @@ class AuthenticateInterceptor implements Interceptor {
                     .basic(influxDBClientOptions.getUsername(), string(influxDBClientOptions.getPassword()));
 
             Request authRequest = new Request.Builder()
-                    .url(buildPath("/api/v2/signin"))
+                    .url(buildPath("api/v2/signin"))
                     .addHeader("Authorization", credentials)
                     .post(RequestBody.create(null, ""))
                     .build();
@@ -156,7 +156,7 @@ class AuthenticateInterceptor implements Interceptor {
         this.sessionToken = null;
 
         Request authRequest = new Request.Builder()
-                .url(buildPath("/api/v2/signout"))
+                .url(buildPath("api/v2/signout"))
                 .post(RequestBody.create(null, ""))
                 .build();
 
@@ -172,7 +172,7 @@ class AuthenticateInterceptor implements Interceptor {
         return HttpUrl
                 .parse(influxDBClientOptions.getUrl())
                 .newBuilder()
-                .encodedPath(buildPath)
+                .addEncodedPathSegments(buildPath)
                 .build()
                 .toString();
     }

--- a/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
@@ -35,6 +35,7 @@ import com.influxdb.client.InfluxDBClientOptions;
 import okhttp3.Call;
 import okhttp3.Cookie;
 import okhttp3.Credentials;
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -117,7 +118,7 @@ class AuthenticateInterceptor implements Interceptor {
                     .basic(influxDBClientOptions.getUsername(), string(influxDBClientOptions.getPassword()));
 
             Request authRequest = new Request.Builder()
-                    .url(influxDBClientOptions.getUrl() + "/api/v2/signin")
+                    .url(buildPath("/api/v2/signin"))
                     .addHeader("Authorization", credentials)
                     .post(RequestBody.create(null, ""))
                     .build();
@@ -155,12 +156,25 @@ class AuthenticateInterceptor implements Interceptor {
         this.sessionToken = null;
 
         Request authRequest = new Request.Builder()
-                .url(influxDBClientOptions.getUrl() + "/api/v2/signout")
+                .url(buildPath("/api/v2/signout"))
                 .post(RequestBody.create(null, ""))
                 .build();
 
         Response response = this.okHttpClient.newCall(authRequest).execute();
         response.close();
+    }
+
+    @Nonnull
+    String buildPath(final String buildPath) {
+
+        Arguments.checkNotNull(buildPath, "buildPath");
+
+        return HttpUrl
+                .parse(influxDBClientOptions.getUrl())
+                .newBuilder()
+                .encodedPath(buildPath)
+                .build()
+                .toString();
     }
 
     @Nonnull

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -179,7 +179,7 @@ public final class Point {
     }
 
     /**
-     * Add {@link Boolean} field.
+     * Add {@link String} field.
      *
      * @param field the field name
      * @param value the field value

--- a/client/src/test/java/com/influxdb/client/ITTemplatesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTemplatesApi.java
@@ -51,6 +51,7 @@ import org.junit.runner.RunWith;
  * @author Jakub Bednar (bednar@github) (25/03/2019 09:52)
  */
 @RunWith(JUnitPlatform.class)
+@Disabled("https://github.com/influxdata/influxdb/issues/20163")
 class ITTemplatesApi extends AbstractITClientTest {
 
     private TemplatesApi templatesApi;

--- a/client/src/test/java/com/influxdb/client/QueryApiTest.java
+++ b/client/src/test/java/com/influxdb/client/QueryApiTest.java
@@ -22,7 +22,6 @@
 package com.influxdb.client;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import com.influxdb.client.domain.Dialect;
 import com.influxdb.client.domain.Query;
@@ -405,7 +404,5 @@ class QueryApiTest extends AbstractInfluxDBClientTest {
         request = takeRequest();
 
         Assertions.assertThat(request.getRequestUrl().queryParameter("org")).isEqualTo("123456");
-
-
     }
 }

--- a/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
@@ -121,6 +121,29 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
     }
 
     @Test
+    void connectionStringSigInSignOutURL() {
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .connectionString("http://localhost:8086?writeTimeout=1000&connectTimeout=1000&logLevel=BODY")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        AuthenticateInterceptor interceptor = new AuthenticateInterceptor(options);
+
+        Assertions
+                .assertThat("http://localhost:8086/api/v2/signin")
+                .isEqualTo(interceptor.buildPath("/api/v2/signin"));
+
+        Assertions
+                .assertThat("http://localhost:8086/api/v2/signout")
+                .isEqualTo(interceptor.buildPath("/api/v2/signout"));
+
+        Assertions
+                .assertThat("http://localhost:8086/api/v2/setup")
+                .isEqualTo(interceptor.buildPath("/api/v2/setup"));
+    }
+
+    @Test
     void authorizationSessionWithoutCookie() throws IOException, InterruptedException {
 
         InfluxDBClientOptions options = InfluxDBClientOptions.builder()

--- a/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
@@ -121,6 +121,46 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
     }
 
     @Test
+    public void buildPath() {
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .url("http://localhost:8086")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        Assertions
+                .assertThat("http://localhost:8086/api/v2/signin")
+                .isEqualTo(new AuthenticateInterceptor(options).buildPath("api/v2/signin"));
+
+        options = InfluxDBClientOptions.builder()
+                .url("http://localhost:8086/")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        Assertions
+                .assertThat("http://localhost:8086/api/v2/signin")
+                .isEqualTo(new AuthenticateInterceptor(options).buildPath("api/v2/signin"));
+
+        options = InfluxDBClientOptions.builder()
+                .url("http://localhost:8086/proxy")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        Assertions
+                .assertThat("http://localhost:8086/proxy/api/v2/signin")
+                .isEqualTo(new AuthenticateInterceptor(options).buildPath("api/v2/signin"));
+
+        options = InfluxDBClientOptions.builder()
+                .url("http://localhost:8086/proxy/")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        Assertions
+                .assertThat("http://localhost:8086/proxy/api/v2/signin")
+                .isEqualTo(new AuthenticateInterceptor(options).buildPath("api/v2/signin"));
+    }
+
+    @Test
     void connectionStringSigInSignOutURL() {
 
         InfluxDBClientOptions options = InfluxDBClientOptions.builder()
@@ -132,15 +172,39 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
 
         Assertions
                 .assertThat("http://localhost:8086/api/v2/signin")
-                .isEqualTo(interceptor.buildPath("/api/v2/signin"));
+                .isEqualTo(interceptor.buildPath("api/v2/signin"));
 
         Assertions
                 .assertThat("http://localhost:8086/api/v2/signout")
-                .isEqualTo(interceptor.buildPath("/api/v2/signout"));
+                .isEqualTo(interceptor.buildPath("api/v2/signout"));
 
         Assertions
                 .assertThat("http://localhost:8086/api/v2/setup")
-                .isEqualTo(interceptor.buildPath("/api/v2/setup"));
+                .isEqualTo(interceptor.buildPath("api/v2/setup"));
+    }
+
+
+    @Test
+    void connectionStringSigInSignOutURLProxy() {
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .connectionString("http://localhost:8086/proxy?writeTimeout=1000&connectTimeout=1000&logLevel=BODY")
+                .authenticate("user", "secret".toCharArray())
+                .build();
+
+        AuthenticateInterceptor interceptor = new AuthenticateInterceptor(options);
+
+        Assertions
+                .assertThat("http://localhost:8086/proxy/api/v2/signin")
+                .isEqualTo(interceptor.buildPath("api/v2/signin"));
+
+        Assertions
+                .assertThat("http://localhost:8086/proxy/api/v2/signout")
+                .isEqualTo(interceptor.buildPath("api/v2/signout"));
+
+        Assertions
+                .assertThat("http://localhost:8086/proxy/api/v2/setup")
+                .isEqualTo(interceptor.buildPath("api/v2/setup"));
     }
 
     @Test


### PR DESCRIPTION
Closes #178 

## Proposed Changes

Fixed concatenation of url - avoid double backslash

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
