### PR TITLE
fix: use Source.unfoldResource of source for Querying [scala]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tree.txt
 **/.openapi-generator*
 **/swagger2.yml
 **/response.json
+**/test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#196](https://github.com/influxdata/influxdb-client-java/issues/196): Removed badly licenced JSON-Java library
+1. [#199](https://github.com/influxdata/influxdb-client-java/pull/199): Correct implementation of Backpressure for Scala Querying
 
 ### CI
 1. [#203](https://github.com/influxdata/influxdb-client-java/pull/203): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`

--- a/client-scala/README.md
+++ b/client-scala/README.md
@@ -12,14 +12,6 @@ The reference Scala client that allows query and write for the InfluxDB 2.0 by [
 ## Queries
 
 The [QueryScalaApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-scala/scaladocs/org/influxdata/client/scala/QueryScalaApi.html) is based on the [Akka Streams](https://doc.akka.io/docs/akka/2.6/stream/). 
-The streaming can be configured by:
-
-- `bufferSize` - Size of a buffer for incoming responses. Default 10000. 
-- `overflowStrategy` - Strategy that is used when incoming response cannot fit inside the buffer. Default `akka.stream.OverflowStrategies.Backpressure`.
-
-```scala
-val fluxClient = InfluxDBClientScalaFactory.create(options, 5000, OverflowStrategy.dropTail)
-```
 
 The following example demonstrates querying using the Flux language:
 

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
@@ -21,10 +21,10 @@
  */
 package com.influxdb.client.scala
 
-import akka.stream.OverflowStrategy
 import com.influxdb.Arguments
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.scala.internal.InfluxDBClientScalaImpl
+
 import javax.annotation.Nonnull
 
 /**
@@ -143,19 +143,13 @@ object InfluxDBClientScalaFactory {
   /**
    * Create an instance of the InfluxDB 2.0 reactive client.
    *
-   * @param options          the connection configuration
-   * @param bufferSize       size of a buffer for incoming responses. Default 10000.
-   * @param overflowStrategy Strategy that is used when incoming response cannot fit inside the buffer.
-   *                         Default [[akka.stream.OverflowStrategies.Backpressure]].
-   * @see [[akka.stream.scaladsl.Source#queue(int, akka.stream.OverflowStrategy)]]
+   * @param options the connection configuration
    * @return client
    */
-  @Nonnull def create(@Nonnull options: InfluxDBClientOptions,
-                      @Nonnull bufferSize: Int = 10000,
-                      @Nonnull overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure): InfluxDBClientScala = {
+  @Nonnull def create(@Nonnull options: InfluxDBClientOptions): InfluxDBClientScala = {
 
     Arguments.checkNotNull(options, "InfluxDBClientOptions")
 
-    new InfluxDBClientScalaImpl(options, bufferSize, overflowStrategy)
+    new InfluxDBClientScalaImpl(options)
   }
 }

--- a/client-scala/src/main/scala/com/influxdb/client/scala/internal/InfluxDBClientScalaImpl.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/internal/InfluxDBClientScalaImpl.scala
@@ -21,27 +21,25 @@
  */
 package com.influxdb.client.scala.internal
 
-import akka.stream.OverflowStrategy
 import com.influxdb.LogLevel
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.domain.HealthCheck
 import com.influxdb.client.internal.AbstractInfluxDBClient
 import com.influxdb.client.scala.{InfluxDBClientScala, QueryScalaApi}
 import com.influxdb.client.service.QueryService
+
 import javax.annotation.Nonnull
 
 /**
  * @author Jakub Bednar (bednar@github) (08/02/2019 09:26)
  */
-class InfluxDBClientScalaImpl(@Nonnull options: InfluxDBClientOptions,
-                              @Nonnull val bufferSize: Int,
-                              @Nonnull val overflowStrategy: OverflowStrategy) extends AbstractInfluxDBClient(options, "scala") with InfluxDBClientScala {
+class InfluxDBClientScalaImpl(@Nonnull options: InfluxDBClientOptions) extends AbstractInfluxDBClient(options, "scala") with InfluxDBClientScala {
   /**
    * Get the Query client.
    *
    * @return the new client instance for the Query API
    */
-  override def getQueryScalaApi(): QueryScalaApi = new QueryScalaApiImpl(retrofit.create(classOf[QueryService]), options, bufferSize, overflowStrategy)
+  override def getQueryScalaApi(): QueryScalaApi = new QueryScalaApiImpl(retrofit.create(classOf[QueryService]), options)
 
   /**
    * Get the health of an instance.

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
                     <excludes>**/target/**, **/*.jar, **/.git/**, **/.*, **/*.png, **/*.iml, **/*.bolt, .idea/**,
                         **/*nightly*/**, **/.m2/**, LICENSE, **/*.md, **/PLACEHOLDER, **/.influxdb/**, **/generated/**,
                         **/openapi-generator/**, **/swagger.yml, **/*.json, **/spring.factories, **/PULL_REQUEST_TEMPLATE,
-                        release.properties/, **/pom.xml.releaseBackup, **/pom.xml.tag, **/semantic.yml
+                        release.properties/, **/pom.xml.releaseBackup, **/pom.xml.tag, **/semantic.yml, **/test.txt
                     </excludes>
                     <properties>
                         <organizationName>${project.organization.name}</organizationName>


### PR DESCRIPTION
Closes #198 

## Proposed Changes

The `Backpressure` with previous implementation didn't works. The our API didn't supports a `QueueOfferResult` that is result of [offer()](https://doc.akka.io/api/akka/2.6/akka/stream/javadsl/SourceQueue.html#offer(elem:T):java.util.concurrent.CompletionStage[akka.stream.QueueOfferResult]) so the API wasn't be able to slowdown producing of results.

Instead of complicated implementation of `QueueOfferResult` ([see example](https://doc.akka.io/docs/akka/current/stream/operators/Source/queue.html#example-boundedsourcequeue-)) we just switch to `Source.unfoldResource`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
