### PR TITLE
fix: :bug: replace accept-encoding application/json to null for all clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.1.0 [unreleased]
 
+### Bug Fixes
+1. [#205](https://github.com/influxdata/influxdb-client-java/pull/205): Fix GZIP issue for query executed from all clients [see issue comments](https://github.com/influxdata/influxdb-client-java/issues/50#issuecomment-796896401)
+
 ## 2.0.0 [2021-03-05]
 
 ### API

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
@@ -167,7 +167,7 @@ internal class QueryKotlinApiImpl(private val service: QueryService, private val
 
         val channel = Channel<String>()
 
-        val queryCall = service.postQueryResponseBody(null,  "application/json",
+        val queryCall = service.postQueryResponseBody(null,  null,
                 null, org, null, query)
 
         val consumer = BiConsumer { cancellable: Cancellable, line: String ->
@@ -194,7 +194,7 @@ internal class QueryKotlinApiImpl(private val service: QueryService, private val
 
         val channel = Channel<T>()
 
-        val queryCall = service.postQueryResponseBody(null, "application/json",
+        val queryCall = service.postQueryResponseBody(null, null,
                 null, org, null, query)
 
         val responseConsumer = object : FluxResponseConsumer {

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
@@ -118,7 +118,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
         return Flowable
                 .fromPublisher(queryStream)
-                .map(it -> service.postQueryResponseBody(null, "application/json",
+                .map(it -> service.postQueryResponseBody(null, null,
                         null, org, null, new Query().query(it).dialect(AbstractInfluxDBClient.DEFAULT_DIALECT)))
                 .flatMap(queryCall -> {
 
@@ -256,7 +256,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
         return Flowable
                 .fromPublisher(queryStream)
-                .map(it -> service.postQueryResponseBody(null, "application/json",
+                .map(it -> service.postQueryResponseBody(null, null,
                         null, org, null, new Query().query(it).dialect(dialect)))
                 .flatMap(queryCall -> {
 

--- a/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
@@ -102,7 +102,7 @@ class QueryScalaApiImpl(@Nonnull service: QueryService, @Nonnull options: Influx
 
     Source.unfoldResource[FluxRecord, AbstractQueryApi#FluxRecordIterator](
       () => {
-        val call = service.postQueryResponseBody(null, "application/json", null, org, null, query)
+        val call = service.postQueryResponseBody(null, null, null, org, null, query)
 
         queryIterator(call)
 
@@ -277,7 +277,7 @@ class QueryScalaApiImpl(@Nonnull service: QueryService, @Nonnull options: Influx
 
     Source.unfoldResource[String, AbstractQueryApi#RawIterator](
       () => {
-        val call = service.postQueryResponseBody(null, "application/json", null, org, null, query)
+        val call = service.postQueryResponseBody(null, null, null, org, null, query)
 
         queryRawIterator(call)
 

--- a/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
@@ -793,8 +793,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
                        @Nonnull final Boolean asynchronously) {
 
         Call<ResponseBody> queryCall = service
-                .postQueryResponseBody(null, "application/json",
-                        null, org, null, query);
+                .postQueryResponseBody(null, null, null, org, null, query);
 
 
         LOG.log(Level.FINEST, "Prepare query \"{0}\" with dialect \"{1}\" on organization \"{2}\".",
@@ -811,7 +810,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
                           @Nonnull final Boolean asynchronously) {
 
         Call<ResponseBody> queryCall = service
-                .postQueryResponseBody(null, "application/json", null, org, null, query);
+                .postQueryResponseBody(null, null, null, org, null, query);
 
         LOG.log(Level.FINEST, "Prepare raw query \"{0}\" with dialect \"{1}\" on organization \"{2}\".",
                 new Object[]{query, query.getDialect(), org});


### PR DESCRIPTION
## Proposed Changes

👋 Hi folks, I try make a humble contribution to fix a gzip compression issue during a query.

- the `Accept-Encoding` header is not used for influx 2.0 server because it always send back CSV data (the server didn't care if you asked for JSON)
- this header blocks the `Accept-Encoding: gzip` header from the `BridgeInterceptor` ([quick look here 👀](https://github.com/square/okhttp/blob/a8b5b5ecb24fa20cfd3b39fd81e7ba96c970d969/okhttp/src/main/kotlin/okhttp3/internal/http/BridgeInterceptor.kt#L69))


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
