### PR TITLE
chore: updated Swagger API to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 1. [#205](https://github.com/influxdata/influxdb-client-java/pull/205): Fix GZIP issue for query executed from all clients [see issue comments](https://github.com/influxdata/influxdb-client-java/issues/50#issuecomment-796896401)
 
+### API
+1. [#206](https://github.com/influxdata/influxdb-client-java/pull/206): Updated swagger to the latest version
+
 ## 2.0.0 [2021-03-05]
 
 ### API

--- a/client/src/generated/java/com/influxdb/client/domain/BucketRetentionRules.java
+++ b/client/src/generated/java/com/influxdb/client/domain/BucketRetentionRules.java
@@ -13,16 +13,15 @@
 
 package com.influxdb.client.domain;
 
+import java.io.IOException;
 import java.util.Objects;
-import java.util.Arrays;
+
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.IOException;
 
 /**
  * BucketRetentionRules
@@ -82,6 +81,10 @@ public class BucketRetentionRules {
   @SerializedName(SERIALIZED_NAME_EVERY_SECONDS)
   private Integer everySeconds;
 
+  public static final String SERIALIZED_NAME_SHARD_GROUP_DURATION_SECONDS = "shardGroupDurationSeconds";
+  @SerializedName(SERIALIZED_NAME_SHARD_GROUP_DURATION_SECONDS)
+  private Long shardGroupDurationSeconds;
+
    /**
    * Get type
    * @return type
@@ -97,17 +100,35 @@ public class BucketRetentionRules {
   }
 
    /**
-   * Duration in seconds for how long data will be kept in the database.
-   * minimum: 1
+   * Duration in seconds for how long data will be kept in the database. 0 means infinite.
+   * minimum: 0
    * @return everySeconds
   **/
-  @ApiModelProperty(example = "86400", required = true, value = "Duration in seconds for how long data will be kept in the database.")
+  @ApiModelProperty(example = "86400", required = true, value = "Duration in seconds for how long data will be kept in the database. 0 means infinite.")
   public Integer getEverySeconds() {
     return everySeconds;
   }
 
   public void setEverySeconds(Integer everySeconds) {
     this.everySeconds = everySeconds;
+  }
+
+  public BucketRetentionRules shardGroupDurationSeconds(Long shardGroupDurationSeconds) {
+    this.shardGroupDurationSeconds = shardGroupDurationSeconds;
+    return this;
+  }
+
+   /**
+   * Shard duration measured in seconds.
+   * @return shardGroupDurationSeconds
+  **/
+  @ApiModelProperty(value = "Shard duration measured in seconds.")
+  public Long getShardGroupDurationSeconds() {
+    return shardGroupDurationSeconds;
+  }
+
+  public void setShardGroupDurationSeconds(Long shardGroupDurationSeconds) {
+    this.shardGroupDurationSeconds = shardGroupDurationSeconds;
   }
 
 
@@ -121,12 +142,13 @@ public class BucketRetentionRules {
     }
     BucketRetentionRules postBucketRequestRetentionRules = (BucketRetentionRules) o;
     return Objects.equals(this.type, postBucketRequestRetentionRules.type) &&
-        Objects.equals(this.everySeconds, postBucketRequestRetentionRules.everySeconds);
+        Objects.equals(this.everySeconds, postBucketRequestRetentionRules.everySeconds) &&
+        Objects.equals(this.shardGroupDurationSeconds, postBucketRequestRetentionRules.shardGroupDurationSeconds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, everySeconds);
+    return Objects.hash(type, everySeconds, shardGroupDurationSeconds);
   }
 
 
@@ -136,6 +158,7 @@ public class BucketRetentionRules {
     sb.append("class BucketRetentionRules {\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    everySeconds: ").append(toIndentedString(everySeconds)).append("\n");
+    sb.append("    shardGroupDurationSeconds: ").append(toIndentedString(shardGroupDurationSeconds)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/client/src/generated/java/com/influxdb/client/domain/DateTimeLiteral.java
+++ b/client/src/generated/java/com/influxdb/client/domain/DateTimeLiteral.java
@@ -13,16 +13,12 @@
 
 package com.influxdb.client.domain;
 
+import java.time.OffsetDateTime;
 import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
+
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.IOException;
 
 /**
  * Represents an instant in time with nanosecond precision using the syntax of golang&#39;s RFC3339 Nanosecond variant
@@ -36,7 +32,7 @@ public class DateTimeLiteral extends Expression {
 
   public static final String SERIALIZED_NAME_VALUE = "value";
   @SerializedName(SERIALIZED_NAME_VALUE)
-  private String value;
+  private OffsetDateTime value;
 
   public DateTimeLiteral type(String type) {
     this.type = type;
@@ -56,7 +52,7 @@ public class DateTimeLiteral extends Expression {
     this.type = type;
   }
 
-  public DateTimeLiteral value(String value) {
+  public DateTimeLiteral value(OffsetDateTime value) {
     this.value = value;
     return this;
   }
@@ -66,11 +62,11 @@ public class DateTimeLiteral extends Expression {
    * @return value
   **/
   @ApiModelProperty(value = "")
-  public String getValue() {
+  public OffsetDateTime getValue() {
     return value;
   }
 
-  public void setValue(String value) {
+  public void setValue(OffsetDateTime value) {
     this.value = value;
   }
 


### PR DESCRIPTION
## Proposed Changes

Allow setting shard-group durations for buckets via API

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
