### PR TITLE
feat(flux-dsl): supports empty logic operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You have to replace your dependency from: `influxdb-client-scala` to:
 
 ### Features
 1. [#211](https://github.com/influxdata/influxdb-client-java/pull/211): Add supports for Scala cross versioning [`2.12`, `2.13`]
+1. [#213](https://github.com/influxdata/influxdb-client-java/pull/213): Supports empty logic operator [FluxDSL]
 
 ## 2.1.0 [2021-04-01]
 

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/Restrictions.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/Restrictions.java
@@ -21,7 +21,7 @@
  */
 package com.influxdb.query.dsl.functions.restriction;
 
-import java.util.stream.Collectors;
+import java.util.StringJoiner;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -141,7 +141,12 @@ public abstract class Restrictions {
 
             return Stream.of(restrictions)
                     .map(Object::toString)
-                    .collect(Collectors.joining(" " + operator + " ", "(", ")"));
+                    .filter(it -> it != null && !it.isEmpty())
+                    .collect(() -> new StringJoiner(" " + operator + " ", "(", ")")
+                                    .setEmptyValue(""),
+                            StringJoiner::add,
+                            StringJoiner::merge)
+                    .toString();
         }
     }
 }

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
@@ -63,4 +63,21 @@ class RestrictionsTest {
 
         Assertions.assertThat(restrictions.toString()).isEqualTo("exists r[\"_value\"]");
     }
+
+    @Test
+    void emptyLogical() {
+
+        Restrictions restrictions = Restrictions.and(
+                Restrictions.tag("tag").equal("production"),
+                Restrictions.or(),
+                Restrictions.measurement().equal("data")
+        );
+        Assertions.assertThat(restrictions.toString()).isEqualTo("(r[\"tag\"] == \"production\" and r[\"_measurement\"] == \"data\")");
+
+        restrictions = Restrictions.and(Restrictions.or());
+        Assertions.assertThat(restrictions.toString()).isEqualTo("");
+
+        restrictions = Restrictions.or(Restrictions.or());
+        Assertions.assertThat(restrictions.toString()).isEqualTo("");
+    }
 }


### PR DESCRIPTION
Closes #212

## Proposed Changes

The FluxDSL supports empty logic operator. It is useful for something like:

```java
String classCode = search.getClassCode();
restriction = Restrictions.and(
        Restrictions.tag("containerId").equal(search.getContainerId()),
        classCode != null ? Restrictions.tag("classCode").equal(classCode) : Restrictions.or(),
        Restrictions.measurement().equal("data")
);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
