### PR TITLE
feat(flux-dsl): allow to specify  name of `column` in `last` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You have to replace your dependency from: `influxdb-client-scala` to:
 ### Features
 1. [#211](https://github.com/influxdata/influxdb-client-java/pull/211): Add supports for Scala cross versioning [`2.12`, `2.13`]
 1. [#213](https://github.com/influxdata/influxdb-client-java/pull/213): Supports empty logic operator [FluxDSL]
+1. [#216](https://github.com/influxdata/influxdb-client-java/pull/216): Allow to specify a name of `column` in `last` function [FluxDSL]
 
 ## 2.1.0 [2021-04-01]
 

--- a/flux-dsl/README.md
+++ b/flux-dsl/README.md
@@ -363,7 +363,7 @@ Flux flux = Flux
 
 ### last
 Returns the last result of the query [[doc](http://bit.ly/flux-spec#last)].
-- `useStartTime` - Use the start time as the timestamp of the resulting aggregate. [boolean]
+- `column` - The column used to verify the existence of a value. Defaults to `_value`. [string]
 
 ```java
 Flux flux = Flux

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
@@ -947,6 +947,18 @@ public abstract class Flux {
     }
 
     /**
+     * Returns the last result of the query.
+     *
+     * @param column The column used to verify the existence of a value.
+     * @return {@link LastFlux}
+     */
+    @Nonnull
+    public final LastFlux last(@Nonnull final String column) {
+        return new LastFlux(this)
+                .withColumn(column);
+    }
+
+    /**
      * Restricts the number of rows returned in the results.
      *
      * <h3>The parameters had to be defined by:</h3>

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
@@ -23,11 +23,17 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
+import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
 
 /**
  * Returns the last result of the query.
  * <a href="http://bit.ly/flux-spec#last">See SPEC</a>.
+ *
+ * <h3>Options</h3>
+ * <ul>
+ * <li><b>column</b> - The column used to verify the existence of a value [string]. Default to <i>_value</i>.</li>
+ * </ul>
  *
  * <h3>Example</h3>
  * <pre>
@@ -48,5 +54,19 @@ public final class LastFlux extends AbstractParametrizedFlux {
     @Override
     protected String operatorName() {
         return "last";
+    }
+
+    /**
+     * @param column The column used to verify the existence of a value.
+     * @return this
+     */
+    @Nonnull
+    public LastFlux withColumn(@Nonnull final String column) {
+
+        Arguments.checkNonEmpty(column, "Column");
+
+        this.withPropertyValueEscaped("column", column);
+
+        return this;
     }
 }

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LastFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LastFluxTest.java
@@ -47,6 +47,17 @@ class LastFluxTest {
     }
 
     @Test
+    void column() {
+
+        Flux flux = Flux
+                .from("telegraf")
+                .last("_time");
+
+        Assertions.assertThat(flux.toString())
+                .isEqualToIgnoringWhitespace("from(bucket:\"telegraf\") |> last(column: \"_time\")");
+    }
+
+    @Test
     void lastByParameter() {
 
         Flux flux = Flux

--- a/scripts/checkstyle.xml
+++ b/scripts/checkstyle.xml
@@ -29,7 +29,7 @@
 <module name="Checker">
     <module name="SuppressWarningsFilter"/>
     <module name="FileLength">
-        <property name="max" value="2500"/>
+        <property name="max" value="3500"/>
     </module>
     <module name="FileTabCharacter"/>
 


### PR DESCRIPTION
Closes #215

## Proposed Changes

Allow queries like:

```java
Flux flux = Flux
    .from("telegraf")
    .last("_time");
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
