### PR TITLE
feat(query): supports enum types in mapping into POJO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You have to replace your dependency from: `influxdb-client-scala` to:
 1. [#211](https://github.com/influxdata/influxdb-client-java/pull/211): Add supports for Scala cross versioning [`2.12`, `2.13`]
 1. [#213](https://github.com/influxdata/influxdb-client-java/pull/213): Supports empty logic operator [FluxDSL]
 1. [#216](https://github.com/influxdata/influxdb-client-java/pull/216): Allow to specify a name of `column` in `last` function [FluxDSL]
+1. [#218](https://github.com/influxdata/influxdb-client-java/pull/218): Supports enum types in mapping into POJO
 
 ## 2.1.0 [2021-04-01]
 

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
@@ -130,7 +130,13 @@ public class FluxResultMapper {
             }
             if (BigDecimal.class.isAssignableFrom(fieldType)) {
                 field.set(object, toBigDecimalValue(value));
+                return;
+            }
 
+            //enum
+            if (fieldType.isEnum()) {
+                //noinspection unchecked, rawtypes
+                field.set(object, Enum.valueOf((Class<Enum>) fieldType, String.valueOf(value)));
                 return;
             }
 

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -84,6 +84,17 @@ class FluxResultMapperTest {
         Assertions.assertThat(bean.superValue).isEqualByComparingTo(new BigDecimal(20));
     }
 
+    @Test
+    public void enumTag() {
+        FluxRecord record = new FluxRecord(0);
+        record.getValues().put("tag", "tagB");
+        record.getValues().put("num", 20);
+
+        TagEnumBean bean = mapper.toPOJO(record, TagEnumBean.class);
+        Assertions.assertThat(bean.tag).isEqualTo(TagEnum.tagB);
+        Assertions.assertThat(bean.value).isEqualTo(20);
+    }
+
     public static class BigDecimalBean
     {
         @Column(name = "value1")
@@ -107,5 +118,19 @@ class FluxResultMapperTest {
     public static class BaseBean extends SuperBean {
         @Column(name = "baseValue")
         BigDecimal baseValue;
+    }
+
+    public static class TagEnumBean {
+
+        @Column(name = "tag", tag = true)
+        private TagEnum tag;
+
+        @Column(name = "num")
+        private Integer value;
+    }
+
+    public enum TagEnum {
+        tagA,
+        tagB
     }
 }

--- a/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
@@ -102,7 +102,7 @@ class MeasurementMapperTest {
     }
 
     @Test
-    public void escapingTags() {
+    void escapingTags() {
 
         Pojo pojo = new Pojo();
         pojo.tag = "mad\nrid";
@@ -110,6 +110,16 @@ class MeasurementMapperTest {
 
         String lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
         Assertions.assertThat(lineProtocol).isEqualTo("pojo,tag=mad\\nrid value=\"5\"");
+    }
+
+    @Test
+    void enumTag() {
+        PojoTagEnum pojo = new PojoTagEnum();
+        pojo.tag = TagEnum.tagA;
+        pojo.value = 5;
+
+        String lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("pojo,tag=tagA num=5i");
     }
 
     @Measurement(name = "pojo")
@@ -129,5 +139,20 @@ class MeasurementMapperTest {
 
         @Column(timestamp = true)
         private Instant timestamp;
+    }
+
+    @Measurement(name = "pojo")
+    private static class PojoTagEnum {
+
+        @Column(name = "tag", tag = true)
+        private TagEnum tag;
+
+        @Column(name = "num")
+        private Integer value;
+    }
+
+    private enum TagEnum {
+        tagA,
+        tagB
     }
 }


### PR DESCRIPTION
Closes #217

## Proposed Changes

Supports enum types in mapping into POJO.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
