### PR TITLE
Openjdk 16 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,9 @@ workflows:
           name: jdk-11
           maven-image: "circleci/openjdk:11"
       - tests-java:
+          name: jdk-16
+          maven-image: "circleci/openjdk:16-buster"
+      - tests-java:
           name: jdk-8-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - deploy-snapshot:

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -555,7 +555,7 @@ class FluxCsvParserTest {
     public void responseIsInUTF8() throws IOException, IllegalAccessException, NoSuchFieldException {
 
         String oldCharset = Charset.defaultCharset().toString();
-        setDefaultCharset("GBK");
+        System.setProperty("file.encoding", "GBK");
 
         try {
             String data = "#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string\n"
@@ -569,7 +569,7 @@ class FluxCsvParserTest {
             Assertions.assertThat(tables.get(0).getRecords()).hasSize(1);
             Assertions.assertThat(tables.get(0).getRecords().get(0).getValueByKey("tag")).isEqualTo("ěščřĚŠČŘ Přerov 🍺");
         } finally {
-            setDefaultCharset(oldCharset);
+            System.setProperty("file.encoding", oldCharset);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <plugin.surefire.version>2.22.2</plugin.surefire.version>
         <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
         <plugin.checkstyle.version>3.1.1</plugin.checkstyle.version>
-        <plugin.jacoco.version>0.8.5</plugin.jacoco.version>
+        <plugin.jacoco.version>0.8.7</plugin.jacoco.version>
         <plugin.site.version>3.9.0</plugin.site.version>
         <plugin.scala.version>3.4.4</plugin.scala.version>
 


### PR DESCRIPTION
## Proposed Changes

add support for building with openjdk-16

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
