### PR TITLE
fix: connection URL with custom base path, update Kotlin to 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Now you are able to use `micrometer-registry-influx`, for more info [see our doc
 ### Bug Fixes
 1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Connection URL with custom base path
 
+### Dependencies
+1. [#227](https://github.com/influxdata/influxdb-client-csharp/pull/227): Update dependencies:
+   - Kotlin to 1.5.10
+   
 ## 2.3.0 [2021-06-04]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Now you are able to use `micrometer-registry-influx`, for more info [see our doc
 ### Features
 1. [#231](https://github.com/influxdata/influxdb-client-java/pull/231): Add support for Spring Boot 2.4 [spring]
 
+### Bug Fixes
+1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Connection URL with custom base path
+
 ## 2.3.0 [2021-06-04]
 
 ### Features
 1. [#223](https://github.com/influxdata/influxdb-client-java/pull/223): Exponential random backoff retry strategy
-
-### Bug Fixes
-1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Connection URL with custom base path
 
 ## 2.2.0 [2021-04-30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Now you are able to use `micrometer-registry-influx`, for more info [see our doc
 ### Features
 1. [#223](https://github.com/influxdata/influxdb-client-java/pull/223): Exponential random backoff retry strategy
 
+### Bug Fixes
+1. [#???](https://github.com/influxdata/influxdb-client-java/pull/???): Connection URL with custom base path
+
 ## 2.2.0 [2021-04-30]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Now you are able to use `micrometer-registry-influx`, for more info [see our doc
 1. [#223](https://github.com/influxdata/influxdb-client-java/pull/223): Exponential random backoff retry strategy
 
 ### Bug Fixes
-1. [#???](https://github.com/influxdata/influxdb-client-java/pull/???): Connection URL with custom base path
+1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Connection URL with custom base path
 
 ## 2.2.0 [2021-04-30]
 

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
@@ -54,7 +54,7 @@ class InfluxDBClientKotlinFactoryTest : AbstractTest() {
 
         val options = getDeclaredField<InfluxDBClientOptions>(influxDBClient, "options", AbstractInfluxDBClient::class.java)
 
-        Assertions.assertThat(options.url).isEqualTo("http://localhost:9999")
+        Assertions.assertThat(options.url).isEqualTo("http://localhost:9999/")
         Assertions.assertThat(options.org).isEqualTo("my-org")
         Assertions.assertThat(options.bucket).isEqualTo("my-bucket")
         Assertions.assertThat(options.token).isEqualTo("my-token".toCharArray())

--- a/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
@@ -69,11 +69,12 @@ public final class FluxConnectionOptions {
 
     public static Builder builder(final String connectionString) {
         Builder builder = new Builder();
-        HttpUrl parse = HttpUrl.parse(connectionString);
 
+        HttpUrl parse = HttpUrl.parse(connectionString);
         if (parse == null) {
             throw new InfluxException("Unable to parse connection string " + connectionString);
         }
+
         HttpUrl url = parse.newBuilder().build();
 
         String urlWithoutParams = url.scheme() + "://" + url.host() + ":" + url.port() + url.encodedPath();

--- a/client-legacy/src/main/java/com/influxdb/client/flux/internal/FluxService.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/internal/FluxService.java
@@ -38,11 +38,11 @@ import retrofit2.http.Streaming;
 public interface FluxService {
 
     @Streaming
-    @POST("/api/v2/query")
+    @POST("api/v2/query")
     @Nonnull
     @Headers("Content-Type: application/json")
     Call<ResponseBody> query(@Nonnull @Body final RequestBody query);
 
-    @GET("/ping")
+    @GET("ping")
     Call<ResponseBody> ping();
 }

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
@@ -70,7 +70,7 @@ class InfluxDBClientReactiveFactoryTest extends AbstractTest {
 
         InfluxDBClientOptions options = getDeclaredField(influxDBClient, "options", AbstractInfluxDBClient.class);
 
-        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999");
+        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
         Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
         Assertions.assertThat(options.getToken()).isEqualTo("my-token".toCharArray());

--- a/client-scala/src/test/scala/com/influxdb/client/scala/InfluxDBClientScalaFactoryTest.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/InfluxDBClientScalaFactoryTest.scala
@@ -48,7 +48,7 @@ class InfluxDBClientScalaFactoryTest extends AnyFunSuite with Matchers {
     val client = InfluxDBClientScalaFactory.create()
     val options = utils.getDeclaredField(client, "options", classOf[AbstractInfluxDBClient]).asInstanceOf[InfluxDBClientOptions]
 
-    options.getUrl should be("http://localhost:9999")
+    options.getUrl should be("http://localhost:9999/")
     options.getOrg should be("my-org")
     options.getBucket should be("my-bucket")
     options.getToken should be("my-token".toCharArray)

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
@@ -137,7 +137,7 @@ class InfluxDBClientFactoryTest extends AbstractTest {
 
         InfluxDBClientOptions options = getDeclaredField(influxDBClient, "options", AbstractInfluxDBClient.class);
 
-        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999");
+        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
         Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
         Assertions.assertThat(options.getToken()).isEqualTo("my-token".toCharArray());
@@ -166,7 +166,7 @@ class InfluxDBClientFactoryTest extends AbstractTest {
 
         InfluxDBClientOptions options = getDeclaredField(client, "options", AbstractInfluxDBClient.class);
 
-        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:8086");
+        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:8086/");
         Assertions.assertThat(options.getOrg()).isEqualTo("-");
         Assertions.assertThat(options.getBucket()).isEqualTo("database/week");
         Assertions.assertThat(options.getToken()).isEqualTo("my-username:my-password".toCharArray());
@@ -174,7 +174,7 @@ class InfluxDBClientFactoryTest extends AbstractTest {
         client = InfluxDBClientFactory.createV1("http://localhost:8086", null, null, "database", null);
 
         options = getDeclaredField(client, "options", AbstractInfluxDBClient.class);
-        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:8086");
+        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:8086/");
         Assertions.assertThat(options.getOrg()).isEqualTo("-");
         Assertions.assertThat(options.getBucket()).isEqualTo("database/");
         Assertions.assertThat(options.getToken()).isEqualTo(":".toCharArray());

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -40,7 +40,7 @@ class InfluxDBClientOptionsTest {
                 .authenticateToken("xyz".toCharArray())
                 .build();
 
-        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999");
+        Assertions.assertThat(options.getUrl()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(options.getAuthScheme()).isEqualTo(InfluxDBClientOptions.AuthScheme.TOKEN);
         Assertions.assertThat(options.getOkHttpClient()).isNotNull();
     }

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
@@ -254,6 +254,21 @@ class InfluxDBClientTest extends AbstractInfluxDBClientTest {
             clientURL.close();
             clientConnectionString.close();
         }
+
+        // verify Cloud URL
+        {
+            InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                    .connectionString("https://us-west-2-1.aws.cloud2.influxdata.com/")
+                    .build();
+            Assertions.assertThat(options.getUrl()).isEqualTo("https://us-west-2-1.aws.cloud2.influxdata.com:443/");
+
+            options = InfluxDBClientOptions.builder()
+                    .url("https://us-west-2-1.aws.cloud2.influxdata.com/")
+                    .authenticateToken("my-token".toCharArray())
+                    .org("my-org")
+                    .build();
+            Assertions.assertThat(options.getUrl()).isEqualTo("https://us-west-2-1.aws.cloud2.influxdata.com:443/");
+        }
     }
 
     private void queryAndTest(final String expected) throws InterruptedException {

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <plugin.site.version>3.9.0</plugin.site.version>
         <plugin.scala.version>3.4.4</plugin.scala.version>
 
-        <kotlin.version>1.4.32</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
         <karaf.version>4.2.11</karaf.version>
         <junit-jupiter.version>5.6.2</junit-jupiter.version>
     </properties>


### PR DESCRIPTION
Closes #226

## Proposed Changes

Supports URL specified like:
- http://localhost:64348/influxDB/
- http://localhost:64348/influxDB
- http://localhost:64348/
- http://localhost:64348
- http://localhost:64348?readTimeout=1000&writeTimeout=3000&connectTimeout=2000&logLevel=HEADERS
- http://localhost:64348/influx?readTimeout=1000&writeTimeout=3000&connectTimeout=2000&logLevel=HEADERS

Updated Kotlin due the compatibility with JDK 16:
- ![image](https://user-images.githubusercontent.com/455137/121856041-554b0b00-ccf4-11eb-9a5d-e9de921d7b98.png)
- https://youtrack.jetbrains.com/issue/KT-44624
- https://app.circleci.com/pipelines/github/influxdata/influxdb-client-java/1045/workflows/4237df2a-3849-4f0c-a97a-133854ab36fd/jobs/3179

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
