### PR TITLE
fix: set default HTTP protocol to HTTP 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The `shift()` function renamed to `timeShift()`.
 ### Bug Fixes
 1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Connection URL with custom base path
 1. [#236](https://github.com/influxdata/influxdb-client-java/pull/236): Rename `shift()` to `timeShift()` [FluxDSL]
+1. [#241](https://github.com/influxdata/influxdb-client-java/pull/241): Set default HTTP protocol to HTTP 1.1
 
 ### Dependencies
 1. [#227](https://github.com/influxdata/influxdb-client-java/pull/227): Update dependencies:

--- a/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client.flux;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +36,7 @@ import com.influxdb.exceptions.InfluxException;
 
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 
 /**
  * FluxConnectionOptions are used to configure queries to the Flux.
@@ -121,7 +123,8 @@ public final class FluxConnectionOptions {
     public static class Builder {
 
         private String url;
-        private OkHttpClient.Builder okHttpClient = new OkHttpClient.Builder();
+        private OkHttpClient.Builder okHttpClient = new OkHttpClient.Builder()
+                .protocols(Collections.singletonList(Protocol.HTTP_1_1));
         private Map<String, String> parameters = new HashMap<>();
 
         /**

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxConnectionOptionsTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxConnectionOptionsTest.java
@@ -21,7 +21,10 @@
  */
 package com.influxdb.client.flux;
 
+import java.util.List;
+
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -64,5 +67,17 @@ class FluxConnectionOptionsTest {
                 .build();
 
         Assertions.assertThat(fluxConnectionOptions.getOkHttpClient()).isEqualTo(okHttpClient);
+    }
+
+    @Test
+    void protocolVersion() {
+
+        FluxConnectionOptions options = FluxConnectionOptions.builder()
+                .url("http://localhost:8093")
+                .build();
+
+        List<Protocol> protocols = options.getOkHttpClient().build().protocols();
+        Assertions.assertThat(protocols).hasSize(1);
+        Assertions.assertThat(protocols).contains(Protocol.HTTP_1_1);
     }
 }

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,6 +40,7 @@ import com.influxdb.exceptions.InfluxException;
 
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 
 /**
  * InfluxDBClientOptions are used to configure theInfluxDB 2.0 connections.
@@ -445,7 +447,8 @@ public final class InfluxDBClientOptions {
             }
 
             if (okHttpClient == null) {
-                okHttpClient = new OkHttpClient.Builder();
+                okHttpClient = new OkHttpClient.Builder()
+                        .protocols(Collections.singletonList(Protocol.HTTP_1_1));
             }
 
             if (logLevel == null) {
@@ -477,7 +480,8 @@ public final class InfluxDBClientOptions {
                 logLevel(Enum.valueOf(LogLevel.class, logLevel));
             }
 
-            okHttpClient = new OkHttpClient.Builder();
+            okHttpClient = new OkHttpClient.Builder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1));
             if (readTimeout != null) {
                 okHttpClient.readTimeout(toDuration(readTimeout));
             }

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -21,7 +21,10 @@
  */
 package com.influxdb.client;
 
+import java.util.List;
+
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -86,5 +89,18 @@ class InfluxDBClientOptionsTest {
                 .build();
 
         Assertions.assertThat(options.getAuthScheme()).isEqualTo(InfluxDBClientOptions.AuthScheme.SESSION);
+    }
+
+    @Test
+    void protocolVersion() {
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .url("http://localhost:9999")
+                .authenticateToken("xyz".toCharArray())
+                .build();
+
+        List<Protocol> protocols = options.getOkHttpClient().build().protocols();
+        Assertions.assertThat(protocols).hasSize(1);
+        Assertions.assertThat(protocols).contains(Protocol.HTTP_1_1);
     }
 }

--- a/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfiguration.java
+++ b/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfiguration.java
@@ -21,11 +21,14 @@
  */
 package com.influxdb.spring.influx;
 
+import java.util.Collections;
+
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
 
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -64,6 +67,7 @@ public class InfluxDB2AutoConfiguration {
         OkHttpClient.Builder okHttpBuilder;
         if (builderProvider == null) {
             okHttpBuilder = new OkHttpClient.Builder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
                     .readTimeout(properties.getReadTimeout())
                     .writeTimeout(properties.getWriteTimeout())
                     .connectTimeout(properties.getConnectTimeout());


### PR DESCRIPTION
Closes #240
Related to https://github.com/influxdata/EAR/issues/2223

## Proposed Changes

Set default http protocol to `HTTP 1.1`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
