### PR TITLE
feat: add support for auto-configure of reactive API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 3.1.0 [unreleased]
 
+### Breaking Changes
+
+#### `influxdb-spring`:
+
+Change configuration prefix from `spring.influx2` to `influx` according to [Spring Docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.developing-auto-configuration.custom-starter.configuration-keys) - for more info see [README.md](./spring).
+
+### Features
+1. [#244](https://github.com/influxdata/influxdb-client-java/pull/244): Add support for auto-configure the reactive client - `InfluxDBClientReactive` [spring]
+
 ### Bug Fixes
 1. [#246](https://github.com/influxdata/influxdb-client-java/pull/246): Parsing infinite numbers
 1. [#241](https://github.com/influxdata/influxdb-client-java/pull/241): Set default HTTP protocol to HTTP 1.1

--- a/spring/README.md
+++ b/spring/README.md
@@ -10,14 +10,14 @@
 
 ## InfluxDB2 auto-configuration
 
-To enable `InfluxDBClient` support you need to set a `spring.influx2.url` property, and include `influxdb-client-java` on your classpath. 
+To enable `InfluxDBClient` support you need to set a `influx.url` property, and include `influxdb-client-java` on your classpath. 
 
 `InfluxDBClient` relies on OkHttp. If you need to tune the http client, you can register an `InfluxDB2OkHttpClientBuilderProvider` bean.
 
 The default configuration can be override via properties:
 
 ```yaml
-spring.influx2:
+influx:
     url: http://localhost:8086/api/v2 # URL to connect to InfluxDB.
     username: my-user # Username to use in the basic auth.
     password: my-password # Password to use in the basic auth.
@@ -29,6 +29,8 @@ spring.influx2:
     writeTimeout: 5s # Write timeout for OkHttpClient. (Default: 10s)
     connectTimeout: 5s # Connection timeout for OkHttpClient. (Default: 10s)
 ```
+
+If you want to configure the `InfluxDBClientReactive` client, you need to include `influxdb-client-reactive` on your classpath instead of `influxdb-client-java`.
 
 ## Actuator for InfluxDB2 micrometer registry
 
@@ -74,7 +76,7 @@ The `/health` endpoint can monitor an **InfluxDB 2.0** server.
 InfluxDB 2.0 health check relies on `InfluxDBClient` and can be configured via:
 
 ```yaml
-management.health.influxdb2.enabled=true # Whether to enable InfluxDB 2.0 health check.
+management.health.influx.enabled=true # Whether to enable InfluxDB 2.0 health check.
 ```
 
 ## Version

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -109,6 +109,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.influxdb</groupId>
+            <artifactId>influxdb-client-reactive</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-influx</artifactId>
             <version>${micrometer.version}</version>

--- a/spring/src/main/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfiguration.java
+++ b/spring/src/main/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(InfluxDBClient.class)
 @ConditionalOnBean(InfluxDBClient.class)
-@ConditionalOnEnabledHealthIndicator("influxdb")
+@ConditionalOnEnabledHealthIndicator("influx")
 @AutoConfigureAfter(InfluxDB2AutoConfiguration.class)
 public class InfluxDB2HealthIndicatorAutoConfiguration
         extends CompositeHealthContributorConfiguration<InfluxDB2HealthIndicator, InfluxDBClient> {

--- a/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfiguration.java
+++ b/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfiguration.java
@@ -22,10 +22,13 @@
 package com.influxdb.spring.influx;
 
 import java.util.Collections;
+import javax.annotation.Nonnull;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.client.reactive.InfluxDBClientReactive;
+import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -33,6 +36,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -60,10 +64,28 @@ public class InfluxDB2AutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty("influx.url")
     @ConditionalOnMissingBean
-    @ConditionalOnProperty("spring.influx2.url")
+    @ConditionalOnMissingClass("com.influxdb.client.reactive.InfluxDBClientReactive")
     public InfluxDBClient influxDBClient() {
 
+        InfluxDBClientOptions.Builder influxBuilder = makeBuilder();
+
+        return InfluxDBClientFactory.create(influxBuilder.build()).setLogLevel(properties.getLogLevel());
+    }
+
+    @Bean
+    @ConditionalOnProperty("influx.url")
+    @ConditionalOnMissingBean
+    @ConditionalOnClass(InfluxDBClientReactive.class)
+    public InfluxDBClientReactive influxDBClientReactive() {
+        InfluxDBClientOptions.Builder influxBuilder = makeBuilder();
+
+        return InfluxDBClientReactiveFactory.create(influxBuilder.build()).setLogLevel(properties.getLogLevel());
+    }
+
+    @Nonnull
+    private InfluxDBClientOptions.Builder makeBuilder() {
         OkHttpClient.Builder okHttpBuilder;
         if (builderProvider == null) {
             okHttpBuilder = new OkHttpClient.Builder()
@@ -86,8 +108,6 @@ public class InfluxDB2AutoConfiguration {
         } else if (StringUtils.hasLength(properties.getUsername()) && StringUtils.hasLength(properties.getPassword())) {
             influxBuilder.authenticate(properties.getUsername(), properties.getPassword().toCharArray());
         }
-
-        return InfluxDBClientFactory.create(influxBuilder.build()).setLogLevel(properties.getLogLevel());
+        return influxBuilder;
     }
-
 }

--- a/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2Properties.java
+++ b/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2Properties.java
@@ -32,7 +32,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jakub Bednar (bednar@github) (06/05/2019 12:54)
  */
-@ConfigurationProperties(prefix = "spring.influx2")
+@ConfigurationProperties(prefix = "influx")
 public class InfluxDB2Properties {
 
     private static final int DEFAULT_TIMEOUT = 10_000;

--- a/spring/src/test/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfigurationTest.java
+++ b/spring/src/test/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfigurationTest.java
@@ -23,7 +23,7 @@ package com.influxdb.spring.health;
 
 import com.influxdb.client.InfluxDBClient;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(JUnitPlatform.class)
 class InfluxDB2HealthIndicatorAutoConfigurationTest {
 
-    private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withUserConfiguration(InfluxDBClientConfiguration.class).withConfiguration(
                     AutoConfigurations.of(InfluxDB2HealthIndicatorAutoConfiguration.class,
                             HealthContributorAutoConfiguration.class));
@@ -56,7 +56,7 @@ class InfluxDB2HealthIndicatorAutoConfigurationTest {
 
     @Test
     public void runWhenDisabledShouldNotCreateIndicator() {
-        this.contextRunner.withPropertyValues("management.health.influxdb2.enabled:false")
+        this.contextRunner.withPropertyValues("management.health.influx.enabled:false")
                 .run((context) -> assertThat(context)
                         .doesNotHaveBean(InfluxDB2HealthIndicator.class));
     }


### PR DESCRIPTION
Closes #243
Closes #237

## Proposed Changes

This PR adds support for auto-configure `InfluxDBClientReactive` for `SpringBoot` and also change configuration prefix from `spring.influx2` to `influx` according to [Spring Docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.developing-auto-configuration.custom-starter.configuration-keys): 

![image](https://user-images.githubusercontent.com/455137/125416910-83a56ef5-5824-449a-95e5-e63552fadcb3.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
