### PR TITLE
fix: remove unsupported Influx2MetricsExportAutoConfiguration

### DIFF
--- a/spring/src/main/resources/META-INF/spring.factories
+++ b/spring/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.influxdb.spring.health.InfluxDB2HealthIndicatorAutoConfiguration,\
-com.influxdb.spring.influx.InfluxDB2AutoConfiguration,\
-com.influxdb.spring.metrics.Influx2MetricsExportAutoConfiguration
+com.influxdb.spring.influx.InfluxDB2AutoConfiguration


### PR DESCRIPTION
Closes #247
Related to https://github.com/influxdata/influxdb-client-java/pull/231

## Proposed Changes

Remove `Influx2MetricsExportAutoConfiguration` auto configuration candidates which was removed in `3.0.0`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
