### PR TITLE
feat: write reactive client uses direct flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ This release uses the latest InfluxDB OSS API definitions - [oss.yml](https://ra
 1. [#272](https://github.com/influxdata/influxdb-client-java/pull/272): Add `PingService` to check status of OSS and Cloud instance
 1. [#278](https://github.com/influxdata/influxdb-client-java/pull/278): Add query method with all params for BucketsApi, OrganizationApi and TasksApi
 1. [#280](https://github.com/influxdata/influxdb-client-java/pull/280): Use async HTTP calls in the Batching writer
+1. [#251](https://github.com/influxdata/influxdb-client-java/pull/251): Client uses `Reactive Streams` in public API, `WriteReactiveApi` is cold `Publisher` [influxdb-client-reactive]
 
 ### Bug Fixes
 1. [#279](https://github.com/influxdata/influxdb-client-java/pull/279): Session authentication for InfluxDB `2.1`
+
+### Bug Fixes
 1. [#276](https://github.com/influxdata/influxdb-client-java/pull/276): `influxdb-client-utils` uses different package then `influxdb-client-core`[java module system]
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ This release uses the latest InfluxDB OSS API definitions - [oss.yml](https://ra
 
 ### Bug Fixes
 1. [#279](https://github.com/influxdata/influxdb-client-java/pull/279): Session authentication for InfluxDB `2.1`
-
-### Bug Fixes
 1. [#276](https://github.com/influxdata/influxdb-client-java/pull/276): `influxdb-client-utils` uses different package then `influxdb-client-core`[java module system]
 
 ### API

--- a/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
+++ b/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
@@ -52,6 +52,7 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Call;
+import retrofit2.HttpException;
 import retrofit2.Response;
 
 /**
@@ -84,6 +85,20 @@ public abstract class AbstractRestClient {
         } catch (IOException e) {
             throw new InfluxException(e);
         }
+    }
+
+    @Nonnull
+    protected InfluxException toInfluxException(@Nonnull final Throwable throwable) {
+
+        if (throwable instanceof InfluxException) {
+            return (InfluxException) throwable;
+        }
+
+        if (throwable instanceof HttpException) {
+            return responseToError(((HttpException) throwable).response());
+        }
+
+        return new InfluxException(throwable);
     }
 
     @Nonnull

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -4,12 +4,10 @@
 
 The reference reactive Java client for InfluxDB 2.0. The client provide supports for asynchronous stream processing with backpressure as is defined by the [Reactive Streams specification](http://www.reactive-streams.org/).
 
----
-**Importatnt**
+## Important
 
-The `Publishers` returned from [Query](src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java) and [Write](src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java) API are cold.
+> :warning: The `Publishers` returned from [Query](src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java) and [Write](src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java) API are cold.
 That means no request to InfluxDB is trigger until register a subscription to `Publisher`.  
----
 
 ## Documentation
 

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -2,7 +2,14 @@
 
 [![javadoc](https://img.shields.io/badge/javadoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/index.html)
 
-The reference Java client that allows query and write for the InfluxDB 2.0 by a reactive way.
+The reference reactive Java client for InfluxDB 2.0. The client provide supports for asynchronous stream processing with backpressure as is defined by the [Reactive Streams specification](http://www.reactive-streams.org/).
+
+---
+**Importatnt**
+
+The `Publishers` returned from [Query](src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java) and [Write](src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java) API are cold.
+That means no request to InfluxDB is trigger until register a subscription to `Publisher`.  
+---
 
 ## Documentation
 
@@ -35,6 +42,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
+import io.reactivex.Flowable;
+
 public class InfluxDB2ReactiveExample {
 
     private static char[] token = "my-token".toCharArray();
@@ -51,8 +60,7 @@ public class InfluxDB2ReactiveExample {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux)
+        Flowable.fromPublisher(queryApi.query(flux))
                 //
                 // Filter records by measurement name
                 //
@@ -82,6 +90,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
+import io.reactivex.Flowable;
+
 public class InfluxDB2ReactiveExampleRaw {
 
     private static char[] token = "my-token".toCharArray();
@@ -98,8 +108,7 @@ public class InfluxDB2ReactiveExampleRaw {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .queryRaw(flux)
+        Flowable.fromPublisher(queryApi.queryRaw(flux))
                 //
                 // Take first 10 records
                 //
@@ -116,7 +125,7 @@ public class InfluxDB2ReactiveExampleRaw {
 }
 ```
 
-The mapping result to POJO is also supported:
+The mapping result to POJO is also support:
 
 ```java
 package example;
@@ -128,6 +137,9 @@ import com.influxdb.annotations.Measurement;
 import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
+
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
 
 public class InfluxDB2ReactiveExamplePojo {
 
@@ -144,8 +156,8 @@ public class InfluxDB2ReactiveExamplePojo {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux, Temperature.class)
+        Publisher<Temperature> query = queryApi.query(flux, Temperature.class);
+        Flowable.fromPublisher(query)
                 //
                 // Take first 10 records
                 //

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -187,17 +187,23 @@ public class InfluxDB2ReactiveExamplePojo {
 
 ## Writes
 
-For writing data we use [WriteReactiveApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/com/influxdb/client/reactive/WriteReactiveApi.html) that supports same configuration as [non reactive client](../client#writes):
+For writing data we use [WriteReactiveApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/com/influxdb/client/reactive/WriteReactiveApi.html) 
+that supports writing data using Line Protocol, Data Point or POJO. The [GZIP compression](#gzip-support) is also supported.
 
-1. writing data using Line Protocol, Data Point, POJO
-2. use batching for writes
-3. use client backpressure strategy
-4. produces events that allow user to be notified and react to this events
-    - `WriteSuccessEvent` - published when arrived the success response from Platform server
-    - `BackpressureEvent` - published when is **client** backpressure applied
-    - `WriteErrorEvent` - published when occurs a unhandled exception
-    - `WriteRetriableErrorEvent` - published when occurs a retriable error
-5. use GZIP compression for data
+The writes are processed in batches which are configurable by [`WriteOptionsReactive`](src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java):
+
+| Property | Description | Default Value |
+| --- | --- | --- |
+| **batchSize** | the number of data point to collect in batch. The `0` disable batching - whole upstream is written in one batch. | 1000 |
+| **flushInterval** | the number of milliseconds before the batch is written | 1000 |
+| **jitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
+| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.| 5000 |
+| **maxRetries** | the number of max retries when write fails. The `0` disable retry strategy - the error is immediately propagate to upstream. | 5 |
+| **maxRetryDelay** | the maximum delay between each retry attempt in milliseconds | 125_000 |
+| **maxRetryTime** | maximum total retry timeout in milliseconds | 180_000 |
+| **exponentialBase** | the base for the exponential retry delay, the next delay is computed using random exponential backoff as a random value within the interval  ``retryInterval * exponentialBase^(attempts-1)`` and ``retryInterval * exponentialBase^(attempts)``. Example for ``retryInterval=5_000, exponentialBase=2, maxRetryDelay=125_000, total=5`` Retry delays are random distributed values within the ranges of ``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``
+
+> Backpressure: is defined by the backpressure behavior of the upstream publisher.
 
 ### Writing data
 
@@ -218,6 +224,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.WriteReactiveApi;
 
 import io.reactivex.Flowable;
+import io.reactivex.disposables.Disposable;
+import org.reactivestreams.Publisher;
 
 public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
 
@@ -227,7 +235,7 @@ public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
 
     public static void main(final String[] args) throws InterruptedException {
 
-        InfluxDBClientReactive influxDBClient = InfluxDBClientReactiveFactory.create("http://localhost:8086", token, org, bucket);
+        InfluxDBClientReactive influxDBClient = InfluxDBClientReactiveFactory.create("http://localhost:9999", token, org, bucket);
 
         //
         // Write data
@@ -244,9 +252,20 @@ public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
                     return temperature;
                 });
 
-        writeApi.writeMeasurements(WritePrecision.NS, measurements);
+        //
+        // ReactiveStreams publisher
+        //
+        Publisher<WriteReactiveApi.Success> publisher = writeApi.writeMeasurements(WritePrecision.NS, measurements);
 
-        Thread.sleep(30_000);
+        //
+        // Subscribe to Publisher
+        //
+        Disposable subscriber = Flowable.fromPublisher(publisher)
+                .subscribe(success -> System.out.println("Successfully written temperature"));
+
+        Thread.sleep(35_000);
+
+        subscriber.dispose();
 
         influxDBClient.close();
     }

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -187,7 +187,7 @@ public class InfluxDB2ReactiveExamplePojo {
 
 ## Writes
 
-For writing data we use [WriteReactiveApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/com/influxdb/client/reactive/WriteReactiveApi.html) 
+For writing data we use [`WriteReactiveApi`](src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java) 
 that supports writing data using Line Protocol, Data Point or POJO. The [GZIP compression](#gzip-support) is also supported.
 
 The writes are configurable by [`WriteOptionsReactive`](src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java):

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -190,7 +190,7 @@ public class InfluxDB2ReactiveExamplePojo {
 For writing data we use [WriteReactiveApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/com/influxdb/client/reactive/WriteReactiveApi.html) 
 that supports writing data using Line Protocol, Data Point or POJO. The [GZIP compression](#gzip-support) is also supported.
 
-The writes are processed in batches which are configurable by [`WriteOptionsReactive`](src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java):
+The writes are configurable by [`WriteOptionsReactive`](src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java):
 
 | Property | Description | Default Value |
 | --- | --- | --- |

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -98,6 +98,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>adapter-rxjava2</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.influxdb</groupId>
             <artifactId>influxdb-client-test</artifactId>
             <scope>test</scope>

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -35,7 +35,8 @@
 
     <name>The RxJava InfluxDB 2.0 Client</name>
     <description>
-        The reference Java client that allows query and write for the InfluxDB 2.0 by a reactive way.
+        The reference reactive Java client for InfluxDB 2.0. The client provide supports for asynchronous stream
+        processing with backpressure as is defined by the Reactive Streams.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java/tree/master/client-reactive</url>

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 
 import com.influxdb.LogLevel;
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.HealthCheck;
 
 import io.reactivex.Single;
@@ -60,7 +59,7 @@ public interface InfluxDBClientReactive extends AutoCloseable {
      * @return the new client instance for the Write API
      */
     @Nonnull
-    WriteReactiveApi getWriteReactiveApi(@Nonnull final WriteOptions writeOptions);
+    WriteReactiveApi getWriteReactiveApi(@Nonnull final WriteOptionsReactive writeOptions);
 
     /**
      * Get the health of an instance.

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
@@ -56,6 +56,7 @@ public interface InfluxDBClientReactive extends AutoCloseable {
     /**
      * Create a new Write client.
      *
+     * @param writeOptions the writes configuration
      * @return the new client instance for the Write API
      */
     @Nonnull

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
@@ -29,7 +29,6 @@ import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.domain.Dialect;
 import com.influxdb.query.FluxRecord;
 
-import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 
 /**
@@ -41,206 +40,206 @@ import org.reactivestreams.Publisher;
 public interface QueryReactiveApi {
 
     /**
-     * Returns {@link Flowable} emitting {@link FluxRecord}s which are matched the query.
-     * If none found than return {@link Flowable#empty()}.
+     * Returns {@link Publisher} emitting {@link FluxRecord}s which are matched the query.
+     * If none found than return empty sequence.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
      * @param query the Flux query to execute
-     * @return {@link Flowable} of {@link FluxRecord}s
+     * @return {@link Publisher} of {@link FluxRecord}s
      */
     @Nonnull
-    Flowable<FluxRecord> query(@Nonnull final String query);
+    Publisher<FluxRecord> query(@Nonnull final String query);
 
     /**
-     * Returns {@link Flowable} emitting {@link FluxRecord}s which are matched the query.
-     * If none found than return {@link Flowable#empty()}.
+     * Returns {@link Publisher} emitting {@link FluxRecord}s which are matched the query.
+     * If none found than return empty sequence.
      *
      * @param query the Flux query to execute
-     * @param org specifies the source organization
-     * @return {@link Flowable} of {@link FluxRecord}s
-     */
-    @Nonnull
-    Flowable<FluxRecord> query(@Nonnull final String query, @Nonnull final String org);
-
-    /**
-     * Execute a Flux against the Flux service.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param query           the flux query to execute
-     * @param measurementType the class type used to which will be result mapped
-     * @param <M>             the type of the measurement (POJO)
-     * @return {@link Flowable} emitting a POJO mapped to {@code measurementType} which are matched
-     * the query or {@link Flowable#empty()} if none found.
-     */
-    <M> Flowable<M> query(@Nonnull final String query,
-                          @Nonnull final Class<M> measurementType);
-
-    /**
-     * Execute a Flux against the Flux service.
-     *
-     * @param query           the flux query to execute
-     * @param org           specifies the source organization
-     * @param measurementType the class type used to which will be result mapped
-     * @param <M>             the type of the measurement (POJO)
-     * @return {@link Flowable} emitting a POJO mapped to {@code measurementType} which are matched
-     * the query or {@link Flowable#empty()} if none found.
-     */
-    <M> Flowable<M> query(@Nonnull final String query,
-                          @Nonnull final String org,
-                          @Nonnull final Class<M> measurementType);
-
-    /**
-     * Returns {@link Flowable} emitting {@link FluxRecord}s which are matched the query.
-     * If none found than return {@link Flowable#empty()}.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param queryStream the Flux query publisher
-     * @return {@link Flowable} of {@link FluxRecord}s
-     */
-    @Nonnull
-    Flowable<FluxRecord> query(@Nonnull final Publisher<String> queryStream);
-
-    /**
-     * Returns {@link Flowable} emitting {@link FluxRecord}s which are matched the query.
-     * If none found than return {@link Flowable#empty()}.
-     *
-     * @param queryStream the Flux query publisher
-     * @param org       specifies the source organization
-     * @return {@link Flowable} of {@link FluxRecord}s
-     */
-    @Nonnull
-    Flowable<FluxRecord> query(@Nonnull final Publisher<String> queryStream, @Nonnull final String org);
-
-    /**
-     * Returns the {@link Flowable} emitting POJO stream.
-     * <p>
-     * If none found than return {@link Flowable#empty()}.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param measurementType the measurement class (POJO)
-     * @param <M>             the type of the measurement (POJO)
-     * @param queryStream     the Flux query publisher
-     * @return {@link Flowable} of {@link FluxRecord}s
-     */
-    @Nonnull
-    <M> Flowable<M> query(@Nonnull final Publisher<String> queryStream,
-                          @Nonnull final Class<M> measurementType);
-
-    /**
-     * Returns the {@link Flowable} emitting POJO stream.
-     * <p>
-     * If none found than return {@link Flowable#empty()}.
-     *
-     * @param measurementType the measurement class (POJO)
-     * @param org           specifies the source organization
-     * @param <M>             the type of the measurement (POJO)
-     * @param queryStream     the Flux query publisher
-     * @return {@link Flowable} of {@link FluxRecord}s
-     */
-    @Nonnull
-    <M> Flowable<M> query(@Nonnull final Publisher<String> queryStream,
-                          @Nonnull final String org,
-                          @Nonnull final Class<M> measurementType);
-
-    /**
-     * Returns {@link Flowable} emitting raw response fromInfluxDB 2.0server line by line.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param query the Flux query to execute
-     * @return {@link Flowable} of response lines
-     */
-    @Nonnull
-    Flowable<String> queryRaw(@Nonnull final String query);
-
-    /**
-     * Returns {@link Flowable} emitting raw response fromInfluxDB 2.0server line by line.
-     *
-     * @param query the Flux query to execute
-     * @param org specifies the source organization
-     * @return {@link Flowable} of response lines
-     */
-    @Nonnull
-    Flowable<String> queryRaw(@Nonnull final String query, @Nonnull final String org);
-
-    /**
-     * Returns {@link Flowable} emitting queryRaw response from InfluxDB server line by line.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param queryStream the Flux query publisher
-     * @return {@link Flowable} of response lines
-     */
-    @Nonnull
-    Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream);
-
-    /**
-     * Returns {@link Flowable} emitting queryRaw response from InfluxDB server line by line.
-     *
-     * @param queryStream the Flux query publisher
-     * @param org       specifies the source organization
-     * @return {@link Flowable} of response lines
-     */
-    @Nonnull
-    Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream, @Nonnull final String org);
-
-    /**
-     * Returns {@link Flowable} emitting queryRaw response fromInfluxDB 2.0server line by line.
-     *
-     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
-     *
-     * @param dialect Dialect is an object defining the options to use when encoding the response.
-     *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
-     * @param query   the Flux query to execute
-     * @return {@link Flowable} of response lines
-     */
-    @Nonnull
-    Flowable<String> queryRaw(@Nonnull final String query,
-                              @Nullable final Dialect dialect);
-
-    /**
-     * Returns {@link Flowable} emitting queryRaw response fromInfluxDB 2.0server line by line.
-     *
-     * @param dialect Dialect is an object defining the options to use when encoding the response.
-     *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
-     * @param query   the Flux query to execute
      * @param org   specifies the source organization
-     * @return {@link Flowable} of response lines
+     * @return {@link Publisher} of {@link FluxRecord}s
      */
     @Nonnull
-    Flowable<String> queryRaw(@Nonnull final String query,
-                              @Nullable final Dialect dialect,
-                              @Nonnull final String org);
+    Publisher<FluxRecord> query(@Nonnull final String query, @Nonnull final String org);
 
     /**
-     * Returns {@link Flowable} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Execute a Flux against the Flux service.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param query           the flux query to execute
+     * @param measurementType the class type used to which will be result mapped
+     * @param <M>             the type of the measurement (POJO)
+     * @return {@link Publisher} emitting a POJO mapped to {@code measurementType} which are matched
+     * the query or empty sequence if none found.
+     */
+    <M> Publisher<M> query(@Nonnull final String query,
+                           @Nonnull final Class<M> measurementType);
+
+    /**
+     * Execute a Flux against the Flux service.
+     *
+     * @param query           the flux query to execute
+     * @param org             specifies the source organization
+     * @param measurementType the class type used to which will be result mapped
+     * @param <M>             the type of the measurement (POJO)
+     * @return {@link Publisher} emitting a POJO mapped to {@code measurementType} which are matched
+     * the query or empty sequence if none found.
+     */
+    <M> Publisher<M> query(@Nonnull final String query,
+                           @Nonnull final String org,
+                           @Nonnull final Class<M> measurementType);
+
+    /**
+     * Returns {@link Publisher} emitting {@link FluxRecord}s which are matched the query.
+     * If none found than return empty sequence.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param queryStream the Flux query publisher
+     * @return {@link Publisher} of {@link FluxRecord}s
+     */
+    @Nonnull
+    Publisher<FluxRecord> query(@Nonnull final Publisher<String> queryStream);
+
+    /**
+     * Returns {@link Publisher} emitting {@link FluxRecord}s which are matched the query.
+     * If none found than return empty sequence.
+     *
+     * @param queryStream the Flux query publisher
+     * @param org         specifies the source organization
+     * @return {@link Publisher} of {@link FluxRecord}s
+     */
+    @Nonnull
+    Publisher<FluxRecord> query(@Nonnull final Publisher<String> queryStream, @Nonnull final String org);
+
+    /**
+     * Returns the {@link Publisher} emitting POJO stream.
+     * <p>
+     * If none found than return empty sequence.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param measurementType the measurement class (POJO)
+     * @param <M>             the type of the measurement (POJO)
+     * @param queryStream     the Flux query publisher
+     * @return {@link Publisher} of {@link FluxRecord}s
+     */
+    @Nonnull
+    <M> Publisher<M> query(@Nonnull final Publisher<String> queryStream,
+                           @Nonnull final Class<M> measurementType);
+
+    /**
+     * Returns the {@link Publisher} emitting POJO stream.
+     * <p>
+     * If none found than return empty sequence.
+     *
+     * @param measurementType the measurement class (POJO)
+     * @param org             specifies the source organization
+     * @param <M>             the type of the measurement (POJO)
+     * @param queryStream     the Flux query publisher
+     * @return {@link Publisher} of {@link FluxRecord}s
+     */
+    @Nonnull
+    <M> Publisher<M> query(@Nonnull final Publisher<String> queryStream,
+                           @Nonnull final String org,
+                           @Nonnull final Class<M> measurementType);
+
+    /**
+     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.0server line by line.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param query the Flux query to execute
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final String query);
+
+    /**
+     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.0server line by line.
+     *
+     * @param query the Flux query to execute
+     * @param org   specifies the source organization
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final String query, @Nonnull final String org);
+
+    /**
+     * Returns {@link Publisher} emitting queryRaw response from InfluxDB server line by line.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param queryStream the Flux query publisher
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream);
+
+    /**
+     * Returns {@link Publisher} emitting queryRaw response from InfluxDB server line by line.
+     *
+     * @param queryStream the Flux query publisher
+     * @param org         specifies the source organization
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream, @Nonnull final String org);
+
+    /**
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     *
+     * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
+     *
+     * @param dialect Dialect is an object defining the options to use when encoding the response.
+     *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
+     * @param query   the Flux query to execute
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final String query,
+                               @Nullable final Dialect dialect);
+
+    /**
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     *
+     * @param dialect Dialect is an object defining the options to use when encoding the response.
+     *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
+     * @param query   the Flux query to execute
+     * @param org     specifies the source organization
+     * @return {@link Publisher} of response lines
+     */
+    @Nonnull
+    Publisher<String> queryRaw(@Nonnull final String query,
+                               @Nullable final Dialect dialect,
+                               @Nonnull final String org);
+
+    /**
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
      * @param dialect     Dialect is an object defining the options to use when encoding the response.
      *                    <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
      * @param queryStream the Flux query publisher
-     * @return {@link Flowable} of response lines
+     * @return {@link Publisher} of response lines
      */
     @Nonnull
-    Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream,
-                              @Nullable final Dialect dialect);
+    Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream,
+                               @Nullable final Dialect dialect);
 
     /**
-     * Returns {@link Flowable} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
      *
      * @param dialect     Dialect is an object defining the options to use when encoding the response.
      *                    <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
      * @param queryStream the Flux query publisher
-     * @param org       specifies the source organization
-     * @return {@link Flowable} of response lines
+     * @param org         specifies the source organization
+     * @return {@link Publisher} of response lines
      */
     @Nonnull
-    Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream,
-                              @Nullable final Dialect dialect,
-                              @Nonnull final String org);
+    Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream,
+                               @Nullable final Dialect dialect,
+                               @Nonnull final String org);
 }

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
@@ -45,6 +45,7 @@ import static com.influxdb.client.WriteOptions.DEFAULT_RETRY_INTERVAL;
  *
  * <p>
  * <b>Example:</b>
+ * </p>
  * <pre>
  *     WriteOptionsReactive writeOptions = WriteOptionsReactive.builder()
  *                 .batchSize(10_000)
@@ -58,7 +59,6 @@ import static com.influxdb.client.WriteOptions.DEFAULT_RETRY_INTERVAL;
  *                 .computationScheduler(Schedulers.newThread())
  *                 .build();
  * </pre>
- * </p>
  *
  * @author Jakub Bednar (05/08/2021 9:13)
  */

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
@@ -133,8 +133,9 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
 
     /**
      * The base for the exponential retry delay.
-     *
+     * <p>
      * The next delay is computed as: retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)
+     * </p>
      *
      * @return exponential base
      * @see WriteOptionsReactive.Builder#exponentialBase(int)
@@ -197,7 +198,10 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
         /**
          * Set the number of data point to collect in batch.
          *
-         * <p>It you set the bath-size to 0 the batching is disabled - whole </p>
+         * <p>
+         * If you set the {@code batchSize} to '0'
+         * the batching is disabled - whole upstream is written in one batch.
+         * </p>
          *
          * @param batchSize the number of data point to collect in batch
          * @return {@code this}
@@ -257,12 +261,17 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
         /**
          * The number of max retries when write fails.
          *
+         * <p>
+         * If you set the {@code maxRetries} to '0'
+         * the retry strategy is disabled - the error is immediately propagate to upstream.
+         * </p>
+         *
          * @param maxRetries number of max retries
          * @return {@code this}
          */
         @Nonnull
         public WriteOptionsReactive.Builder maxRetries(final int maxRetries) {
-            Arguments.checkPositiveNumber(maxRetries, "maxRetries");
+            Arguments.checkNotNegativeNumber(maxRetries, "maxRetries");
             this.maxRetries = maxRetries;
             return this;
         }
@@ -270,7 +279,7 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
         /**
          * The maximum delay between each retry attempt in milliseconds.
          *
-         * @param maxRetryDelay  maximum delay
+         * @param maxRetryDelay maximum delay
          * @return {@code this}
          */
         @Nonnull
@@ -283,7 +292,7 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
         /**
          * The maximum total retry timeout in milliseconds.
          *
-         * @param maxRetryTime  maximum timout
+         * @param maxRetryTime maximum timout
          * @return {@code this}
          */
         @Nonnull

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
@@ -41,6 +41,25 @@ import static com.influxdb.client.WriteOptions.DEFAULT_MAX_RETRY_TIME;
 import static com.influxdb.client.WriteOptions.DEFAULT_RETRY_INTERVAL;
 
 /**
+ * The configuration for {@link WriteReactiveApi}.
+ *
+ * <p>
+ * <b>Example:</b>
+ * <pre>
+ *     WriteOptionsReactive writeOptions = WriteOptionsReactive.builder()
+ *                 .batchSize(10_000)
+ *                 .flushInterval(500)
+ *                 .jitterInterval(1_000)
+ *                 .retryInterval(2_000)
+ *                 .maxRetries(5)
+ *                 .maxRetryDelay(250_123)
+ *                 .maxRetryTime(500_000)
+ *                 .exponentialBase(2)
+ *                 .computationScheduler(Schedulers.newThread())
+ *                 .build();
+ * </pre>
+ * </p>
+ *
  * @author Jakub Bednar (05/08/2021 9:13)
  */
 @ThreadSafe

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
@@ -197,12 +197,14 @@ public final class WriteOptionsReactive implements WriteApi.RetryOptions {
         /**
          * Set the number of data point to collect in batch.
          *
+         * <p>It you set the bath-size to 0 the batching is disabled - whole </p>
+         *
          * @param batchSize the number of data point to collect in batch
          * @return {@code this}
          */
         @Nonnull
         public WriteOptionsReactive.Builder batchSize(final int batchSize) {
-            Arguments.checkPositiveNumber(batchSize, "batchSize");
+            Arguments.checkNotNegativeNumber(batchSize, "batchSize");
             this.batchSize = batchSize;
             return this;
         }

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteOptionsReactive.java
@@ -25,8 +25,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.WriteApi;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
@@ -43,13 +43,9 @@ import org.reactivestreams.Subscriber;
 public interface WriteReactiveApi {
 
     /**
-     * The enum represents a successful written operation.
+     * The class represents a successful written operation.
      */
-    enum Success {
-        /**
-         * Success write.
-         */
-        OK
+    class Success {
     }
 
     /**

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
@@ -33,7 +33,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 /**
- * Write time-series data into InfluxDB 2.0.
+ * Write time-series data into by reactive way InfluxDB 2.0.
  * <p>
  * The data are formatted in <a href="https://bit.ly/line-protocol">Line Protocol</a>.
  *

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client.reactive.internal;
 
+import java.util.Collections;
 import javax.annotation.Nonnull;
 
 import com.influxdb.LogLevel;
@@ -36,6 +37,7 @@ import com.influxdb.client.service.WriteService;
 import com.influxdb.utils.Arguments;
 
 import io.reactivex.Single;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 
 /**
  * @author Jakub Bednar (bednar@github) (20/11/2018 07:12)
@@ -44,7 +46,7 @@ public class InfluxDBClientReactiveImpl extends AbstractInfluxDBClient
         implements InfluxDBClientReactive {
 
     public InfluxDBClientReactiveImpl(@Nonnull final InfluxDBClientOptions options) {
-        super(options, "java");
+        super(options, "java", Collections.singletonList(RxJava2CallAdapterFactory.create()));
     }
 
     @Nonnull
@@ -65,7 +67,7 @@ public class InfluxDBClientReactiveImpl extends AbstractInfluxDBClient
 
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 
-        return new WriteReactiveApiImpl(writeOptions, retrofit.create(WriteService.class), options, autoCloseables);
+        return new WriteReactiveApiImpl(writeOptions, retrofit.create(WriteService.class), options);
     }
 
     @Nonnull

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
@@ -26,11 +26,11 @@ import javax.annotation.Nonnull;
 
 import com.influxdb.LogLevel;
 import com.influxdb.client.InfluxDBClientOptions;
-import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.HealthCheck;
 import com.influxdb.client.internal.AbstractInfluxDBClient;
 import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.QueryReactiveApi;
+import com.influxdb.client.reactive.WriteOptionsReactive;
 import com.influxdb.client.reactive.WriteReactiveApi;
 import com.influxdb.client.service.QueryService;
 import com.influxdb.client.service.WriteService;
@@ -58,12 +58,12 @@ public class InfluxDBClientReactiveImpl extends AbstractInfluxDBClient
     @Nonnull
     @Override
     public WriteReactiveApi getWriteReactiveApi() {
-        return getWriteReactiveApi(WriteOptions.DEFAULTS);
+        return getWriteReactiveApi(WriteOptionsReactive.DEFAULTS);
     }
 
     @Nonnull
     @Override
-    public WriteReactiveApi getWriteReactiveApi(@Nonnull final WriteOptions writeOptions) {
+    public WriteReactiveApi getWriteReactiveApi(@Nonnull final WriteOptionsReactive writeOptions) {
 
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
@@ -62,7 +62,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<FluxRecord> query(@Nonnull final String query) {
+    public Publisher<FluxRecord> query(@Nonnull final String query) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -71,7 +71,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<FluxRecord> query(@Nonnull final String query, @Nonnull final String org) {
+    public Publisher<FluxRecord> query(@Nonnull final String query, @Nonnull final String org) {
 
         Arguments.checkNonEmpty(query, "Flux query");
         Arguments.checkNonEmpty(org, "org");
@@ -80,7 +80,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
     }
 
     @Override
-    public <M> Flowable<M> query(@Nonnull final String query, @Nonnull final Class<M> measurementType) {
+    public <M> Publisher<M> query(@Nonnull final String query, @Nonnull final Class<M> measurementType) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -88,9 +88,9 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
     }
 
     @Override
-    public <M> Flowable<M> query(@Nonnull final String query,
-                                 @Nonnull final String org,
-                                 @Nonnull final Class<M> measurementType) {
+    public <M> Publisher<M> query(@Nonnull final String query,
+                                  @Nonnull final String org,
+                                  @Nonnull final Class<M> measurementType) {
 
         Arguments.checkNonEmpty(query, "Flux query");
         Arguments.checkNotNull(measurementType, "Measurement type");
@@ -101,7 +101,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<FluxRecord> query(@Nonnull final Publisher<String> queryStream) {
+    public Publisher<FluxRecord> query(@Nonnull final Publisher<String> queryStream) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -110,8 +110,8 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<FluxRecord> query(@Nonnull final Publisher<String> queryStream,
-                                      @Nonnull final String org) {
+    public Publisher<FluxRecord> query(@Nonnull final Publisher<String> queryStream,
+                                       @Nonnull final String org) {
 
         Arguments.checkNotNull(queryStream, "queryStream");
         Arguments.checkNonEmpty(org, "org");
@@ -155,8 +155,8 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public <M> Flowable<M> query(@Nonnull final Publisher<String> queryStream,
-                                 @Nonnull final Class<M> measurementType) {
+    public <M> Publisher<M> query(@Nonnull final Publisher<String> queryStream,
+                                  @Nonnull final Class<M> measurementType) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -165,20 +165,22 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public <M> Flowable<M> query(@Nonnull final Publisher<String> queryStream,
-                                 @Nonnull final String org,
-                                 @Nonnull final Class<M> measurementType) {
+    public <M> Publisher<M> query(@Nonnull final Publisher<String> queryStream,
+                                  @Nonnull final String org,
+                                  @Nonnull final Class<M> measurementType) {
 
         Arguments.checkNotNull(queryStream, "queryStream");
         Arguments.checkNotNull(measurementType, "Measurement type");
         Arguments.checkNonEmpty(org, "org");
 
-        return query(queryStream, org).map(fluxRecord -> resultMapper.toPOJO(fluxRecord, measurementType));
+        return Flowable
+                .fromPublisher(query(queryStream, org))
+                .map(fluxRecord -> resultMapper.toPOJO(fluxRecord, measurementType));
     }
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final String query) {
+    public Publisher<String> queryRaw(@Nonnull final String query) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -187,7 +189,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final String query, @Nonnull final String org) {
+    public Publisher<String> queryRaw(@Nonnull final String query, @Nonnull final String org) {
 
         Arguments.checkNonEmpty(query, "Flux query");
         Arguments.checkNonEmpty(org, "org");
@@ -197,7 +199,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream) {
+    public Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -206,8 +208,8 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream,
-                                     @Nonnull final String org) {
+    public Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream,
+                                      @Nonnull final String org) {
 
         Arguments.checkNotNull(queryStream, "queryStream");
         Arguments.checkNonEmpty(org, "org");
@@ -217,7 +219,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final String query, @Nullable final Dialect dialect) {
+    public Publisher<String> queryRaw(@Nonnull final String query, @Nullable final Dialect dialect) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -226,9 +228,9 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final String query,
-                                     @Nullable final Dialect dialect,
-                                     @Nonnull final String org) {
+    public Publisher<String> queryRaw(@Nonnull final String query,
+                                      @Nullable final Dialect dialect,
+                                      @Nonnull final String org) {
 
         Arguments.checkNonEmpty(query, "Flux query");
         Arguments.checkNonEmpty(org, "org");
@@ -238,7 +240,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream, @Nullable final Dialect dialect) {
+    public Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream, @Nullable final Dialect dialect) {
 
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -247,9 +249,9 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
 
     @Nonnull
     @Override
-    public Flowable<String> queryRaw(@Nonnull final Publisher<String> queryStream,
-                                     @Nullable final Dialect dialect,
-                                     @Nonnull final String org) {
+    public Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream,
+                                      @Nullable final Dialect dialect,
+                                      @Nonnull final String org) {
 
         Arguments.checkNotNull(queryStream, "queryStream");
         Arguments.checkNonEmpty(org, "org");

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -24,6 +24,7 @@ package com.influxdb.client.reactive.internal;
 import java.text.MessageFormat;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -312,6 +313,13 @@ public class WriteReactiveApiImpl extends AbstractRestClient implements WriteRea
                             (double) retryInterval / 1000);
                     LOG.log(Level.WARNING, msg, throwable);
                 }))
+                //
+                // maxRetryTime timeout
+                //
+                .timeout(writeOptions.getMaxRetryTime(),
+                        TimeUnit.MILLISECONDS,
+                        scheduler,
+                        Flowable.error(new TimeoutException("Max retry time exceeded.")))
                 //
                 // Map to Influx Error
                 //

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -82,7 +82,8 @@ public class WriteReactiveApiImpl extends AbstractRestClient implements WriteRea
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(precision, "precision");
         if (record == null) {
-            return Flowable.just(Success.OK);
+            //TODO add logging
+            return Flowable.just(new Success());
         }
 
         return writeRecords(bucket, org, precision, Flowable.just(record));
@@ -269,7 +270,7 @@ public class WriteReactiveApiImpl extends AbstractRestClient implements WriteRea
                         return Flowable.error(responseToError(response));
                     }
 
-                    return Flowable.just(Success.OK);
+                    return Flowable.just(new Success());
                 })
                 .onErrorResumeNext(throwable -> {
                     return Flowable.error(toInfluxException(throwable));

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -21,256 +21,258 @@
  */
 package com.influxdb.client.reactive.internal;
 
-import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.WritePrecision;
-import com.influxdb.client.internal.AbstractWriteClient;
+import com.influxdb.client.internal.AbstractWriteClient.BatchWriteData;
+import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataMeasurement;
+import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataPoint;
+import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataRecord;
+import com.influxdb.client.internal.MeasurementMapper;
 import com.influxdb.client.reactive.WriteReactiveApi;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.client.write.Point;
 import com.influxdb.client.write.events.AbstractWriteEvent;
+import com.influxdb.internal.AbstractRestClient;
 import com.influxdb.utils.Arguments;
 
 import io.reactivex.Flowable;
-import io.reactivex.Maybe;
-import io.reactivex.Observable;
 import org.reactivestreams.Publisher;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/11/2018 06:50)
  */
-public class WriteReactiveApiImpl extends AbstractWriteClient implements WriteReactiveApi {
+public class WriteReactiveApiImpl extends AbstractRestClient implements WriteReactiveApi {
+
+    private final WriteOptions writeOptions;
+    private final InfluxDBClientOptions options;
+    private final WriteService service;
+    private final MeasurementMapper measurementMapper = new MeasurementMapper();
 
     WriteReactiveApiImpl(@Nonnull final WriteOptions writeOptions,
                          @Nonnull final WriteService service,
-                         @Nonnull final InfluxDBClientOptions options, final Collection<AutoCloseable> autoCloseables) {
+                         @Nonnull final InfluxDBClientOptions options) {
 
-        super(writeOptions, options, writeOptions.getWriteScheduler(), service, autoCloseables);
+        this.writeOptions = writeOptions;
+        this.options = options;
+        this.service = service;
     }
 
     @Override
-    public void writeRecord(@Nonnull final WritePrecision precision, @Nonnull final Maybe<String> record) {
+    public Publisher<Success> writeRecord(@Nonnull final WritePrecision precision, @Nullable final String record) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writeRecord(options.getBucket(), options.getOrg(), precision, record);
+        return writeRecord(options.getBucket(), options.getOrg(), precision, record);
     }
 
     @Override
-    public void writeRecord(@Nonnull final String bucket,
-                            @Nonnull final String org,
-                            @Nonnull final WritePrecision precision,
-                            @Nonnull final Maybe<String> record) {
+    public Publisher<Success> writeRecord(@Nonnull final String bucket,
+                                          @Nonnull final String org,
+                                          @Nonnull final WritePrecision precision,
+                                          @Nullable final String record) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(precision, "precision");
-        Arguments.checkNotNull(record, "record");
+        if (record == null) {
+            return Flowable.just(Success.OK);
+        }
 
-        writeRecords(bucket, org, precision, record.toFlowable());
+        return writeRecords(bucket, org, precision, Flowable.just(record));
     }
 
     @Override
-    public void writeRecords(@Nonnull final WritePrecision precision, @Nonnull final Flowable<String> records) {
+    public Publisher<Success> writeRecords(@Nonnull final WritePrecision precision,
+                                           @Nonnull final Publisher<String> records) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writeRecords(options.getBucket(), options.getOrg(), precision, records);
+        return writeRecords(options.getBucket(), options.getOrg(), precision, records);
     }
 
     @Override
-    public void writeRecords(@Nonnull final String bucket,
-                             @Nonnull final String org,
-                             @Nonnull final WritePrecision precision,
-                             @Nonnull final Flowable<String> records) {
-
-        Arguments.checkNonEmpty(bucket, "bucket");
-        Arguments.checkNonEmpty(org, "organization");
-        Arguments.checkNotNull(precision, "precision");
-        Arguments.checkNotNull(records, "records");
-
-        Flowable<BatchWriteData> stream = records.map(BatchWriteDataRecord::new);
-
-        write(bucket, org, precision, stream);
-    }
-
-    @Override
-    public void writeRecords(@Nonnull final WritePrecision precision, @Nonnull final Publisher<String> records) {
-
-        Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
-        Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
-
-        writeRecords(options.getBucket(), options.getOrg(), precision, records);
-    }
-
-    @Override
-    public void writeRecords(@Nonnull final String bucket,
-                             @Nonnull final String org,
-                             @Nonnull final WritePrecision precision,
-                             @Nonnull final Publisher<String> records) {
+    public Publisher<Success> writeRecords(@Nonnull final String bucket,
+                                           @Nonnull final String org,
+                                           @Nonnull final WritePrecision precision,
+                                           @Nonnull final Publisher<String> records) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(records, "records");
 
-        writeRecords(bucket, org, precision, Flowable.fromPublisher(records));
+        Flowable<BatchWriteData> stream = Flowable.fromPublisher(records).map(BatchWriteDataRecord::new);
+
+        return write(bucket, org, precision, stream);
     }
 
     @Override
-    public void writePoint(@Nonnull final Maybe<Point> point) {
+    public Publisher<Success> writePoint(@Nonnull final WritePrecision precision, @Nonnull final Point point) {
 
+        Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writePoint(options.getBucket(), options.getOrg(), point);
+        return writePoint(options.getBucket(), options.getOrg(), precision, point);
     }
 
     @Override
-    public void writePoint(@Nonnull final String bucket,
-                           @Nonnull final String org,
-                           @Nonnull final Maybe<Point> point) {
+    public Publisher<Success> writePoint(@Nonnull final String bucket,
+                                         @Nonnull final String org,
+                                         @Nonnull final WritePrecision precision,
+                                         @Nonnull final Point point) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
+        Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(point, "point");
 
-        writePoints(bucket, org, point.toFlowable());
+        return writePoints(bucket, org, precision, Flowable.just(point));
     }
 
     @Override
-    public void writePoints(@Nonnull final Flowable<Point> points) {
+    public Publisher<Success> writePoints(@Nonnull final WritePrecision precision,
+                                          @Nonnull final Publisher<Point> points) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writePoints(options.getBucket(), options.getOrg(), points);
+        return writePoints(options.getBucket(), options.getOrg(), precision, points);
     }
 
     @Override
-    public void writePoints(@Nonnull final String bucket,
-                            @Nonnull final String org,
-                            @Nonnull final Flowable<Point> points) {
+    public Publisher<Success> writePoints(@Nonnull final String bucket,
+                                          @Nonnull final String org,
+                                          @Nonnull final WritePrecision precision,
+                                          @Nonnull final Publisher<Point> points) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(points, "points");
 
-        Flowable<BatchWriteDataPoint> stream = points.filter(Objects::nonNull)
+        Flowable<BatchWriteData> stream = Flowable.fromPublisher(points).filter(Objects::nonNull)
+                //
+                //
+                //!!!! TODO add precision !!!!
+                //
+                //
                 .map(point -> new BatchWriteDataPoint(point, options));
 
-        write(bucket, org, stream);
+        return write(bucket, org, precision, stream);
     }
 
     @Override
-    public void writePoints(@Nonnull final Publisher<Point> points) {
+    public <M> Publisher<Success> writeMeasurement(@Nonnull final WritePrecision precision,
+                                                   @Nonnull final M measurement) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writePoints(options.getBucket(), options.getOrg(), points);
+        return writeMeasurement(options.getBucket(), options.getOrg(), precision, measurement);
     }
 
     @Override
-    public void writePoints(@Nonnull final String bucket,
-                            @Nonnull final String org,
-                            @Nonnull final Publisher<Point> points) {
-
-        Arguments.checkNonEmpty(bucket, "bucket");
-        Arguments.checkNonEmpty(org, "organization");
-        Arguments.checkNotNull(points, "points");
-
-        writePoints(bucket, org, Flowable.fromPublisher(points));
-    }
-
-    @Override
-    public <M> void writeMeasurement(@Nonnull final WritePrecision precision, @Nonnull final Maybe<M> measurement) {
-
-        Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
-        Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
-
-        writeMeasurement(options.getBucket(), options.getOrg(), precision, measurement);
-    }
-
-    @Override
-    public <M> void writeMeasurement(@Nonnull final String bucket,
-                                     @Nonnull final String org,
-                                     @Nonnull final WritePrecision precision,
-                                     @Nonnull final Maybe<M> measurement) {
+    public <M> Publisher<Success> writeMeasurement(@Nonnull final String bucket,
+                                                   @Nonnull final String org,
+                                                   @Nonnull final WritePrecision precision,
+                                                   @Nonnull final M measurement) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(measurement, "measurement");
 
-        writeMeasurements(bucket, org, precision, measurement.toFlowable());
+        return writeMeasurements(bucket, org, precision, Flowable.just(measurement));
     }
 
     @Override
-    public <M> void writeMeasurements(@Nonnull final WritePrecision precision,
-                                      @Nonnull final Flowable<M> measurements) {
+    public <M> Publisher<Success> writeMeasurements(@Nonnull final WritePrecision precision,
+                                                    @Nonnull final Publisher<M> measurements) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
-        writeMeasurements(options.getBucket(), options.getOrg(), precision, measurements);
+        return writeMeasurements(options.getBucket(), options.getOrg(), precision, measurements);
     }
 
     @Override
-    public <M> void writeMeasurements(@Nonnull final String bucket,
-                                      @Nonnull final String org,
-                                      @Nonnull final WritePrecision precision,
-                                      @Nonnull final Flowable<M> measurements) {
+    public <M> Publisher<Success> writeMeasurements(@Nonnull final String bucket,
+                                                    @Nonnull final String org,
+                                                    @Nonnull final WritePrecision precision,
+                                                    @Nonnull final Publisher<M> measurements) {
 
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(measurements, "measurements");
 
-        Flowable<BatchWriteData> stream = measurements
+        Flowable<BatchWriteData> stream = Flowable.fromPublisher(measurements)
                 .map(it -> new BatchWriteDataMeasurement(it, precision, options, measurementMapper));
 
-        write(bucket, org, precision, stream);
-    }
-
-    @Override
-    public <M> void writeMeasurements(@Nonnull final WritePrecision precision,
-                                      @Nonnull final Publisher<M> measurements) {
-
-        Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
-        Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
-
-        writeMeasurements(options.getBucket(), options.getOrg(), precision, measurements);
-    }
-
-    @Override
-    public <M> void writeMeasurements(@Nonnull final String bucket,
-                                      @Nonnull final String org,
-                                      @Nonnull final WritePrecision precision,
-                                      @Nonnull final Publisher<M> measurements) {
-
-        Arguments.checkNonEmpty(bucket, "bucket");
-        Arguments.checkNonEmpty(org, "organization");
-        Arguments.checkNotNull(precision, "precision");
-        Arguments.checkNotNull(measurements, "measurements");
-
-        writeMeasurements(bucket, org, precision, Flowable.fromPublisher(measurements));
+        return write(bucket, org, precision, stream);
     }
 
     @Nonnull
-    @Override
-    public <T extends AbstractWriteEvent> Observable<T> listenEvents(@Nonnull final Class<T> eventType) {
-        return super.addEventListener(eventType);
-    }
+    private Publisher<Success> write(@Nonnull final String bucket,
+                                     @Nonnull final String organization,
+                                     @Nonnull final WritePrecision precision,
+                                     @Nonnull final Flowable<BatchWriteData> stream) {
 
-    @Override
-    public void close() {
-        super.close();
+        Arguments.checkNonEmpty(bucket, "bucket");
+        Arguments.checkNonEmpty(organization, "organization");
+        Arguments.checkNotNull(precision, "precision");
+        Arguments.checkNotNull(stream, "stream");
+
+        Flowable<String> batches = stream
+                // Create batches
+                //
+                // TODO scheduler
+                //
+                .window(writeOptions.getFlushInterval(), TimeUnit.MILLISECONDS, writeOptions.getBatchSize(), true)
+                // Collect batch to LineProtocol concatenated by '\n'
+                .concatMapSingle(batch -> batch
+                        .map(item -> {
+                            String lineProtocol = item.toLineProtocol();
+                            if (lineProtocol == null) {
+                                return "";
+                            }
+                            return lineProtocol;
+                        })
+                        .filter(it -> !it.isEmpty())
+                        .collect(StringBuilder::new, (sb, x) -> {
+                            if (sb.length() > 0) {
+                                sb.append("\n");
+                            }
+                            sb.append(x);
+                        })
+                        .map(StringBuilder::toString))
+                // Filter empty batches
+                .filter(it -> !it.isEmpty());
+
+        return batches
+                // HTTP post
+                .flatMapSingle(it -> service.postWriteRx(organization, bucket, it, null,
+                        "identity", "text/plain; charset=utf-8", null,
+                        "application/json", null, precision)
+                )
+                // Map to Success
+                .flatMap(response -> {
+                    if (!response.isSuccessful()) {
+                        return Flowable.error(responseToError(response));
+                    }
+
+                    return Flowable.just(Success.OK);
+                })
+                .onErrorResumeNext(throwable -> {
+                    return Flowable.error(toInfluxException(throwable));
+                });
     }
 }

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -248,11 +248,23 @@ public class WriteReactiveApiImpl extends AbstractRestClient implements WriteRea
                 //
                 // Create batches
                 //
-                .window(writeOptions.getFlushInterval(),
-                        TimeUnit.MILLISECONDS,
-                        writeOptions.getComputationScheduler(),
-                        writeOptions.getBatchSize(),
-                        true)
+                .compose(source -> {
+                    //
+                    // disabled batches
+                    //
+                    if (writeOptions.getBatchSize() == 0) {
+                        return Flowable.just(Flowable.fromPublisher(stream));
+                    }
+
+                    //
+                    // batching
+                    //
+                    return source.window(writeOptions.getFlushInterval(),
+                            TimeUnit.MILLISECONDS,
+                            writeOptions.getComputationScheduler(),
+                            writeOptions.getBatchSize(),
+                            true);
+                })
                 //
                 // Collect batch to LineProtocol concatenated by '\n'
                 //

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -42,7 +42,6 @@ import com.influxdb.client.reactive.WriteOptionsReactive;
 import com.influxdb.client.reactive.WriteReactiveApi;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.client.write.Point;
-import com.influxdb.client.write.events.AbstractWriteEvent;
 import com.influxdb.internal.AbstractRestClient;
 import com.influxdb.utils.Arguments;
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -170,13 +170,10 @@ public class WriteReactiveApiImpl extends AbstractRestClient implements WriteRea
         Arguments.checkNonEmpty(org, "organization");
         Arguments.checkNotNull(points, "points");
 
-        Flowable<BatchWriteData> stream = Flowable.fromPublisher(points).filter(Objects::nonNull)
-                //
-                //
-                //!!!! TODO add precision !!!!
-                //
-                //
-                .map(point -> new BatchWriteDataPoint(point, options));
+        Flowable<BatchWriteData> stream = Flowable
+                .fromPublisher(points)
+                .filter(Objects::nonNull)
+                .map(point -> new BatchWriteDataPoint(point, precision, options));
 
         return write(bucket, org, precision, stream);
     }

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/AbstractITInfluxDBClientTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/AbstractITInfluxDBClientTest.java
@@ -29,7 +29,6 @@ import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.test.AbstractTest;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -123,17 +123,20 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<FluxRecord> result = queryClient.query("from(bucket:\"" + bucketName + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", organization.getId());
+        Publisher<FluxRecord> result = queryClient.query("from(bucket:\"" + bucketName + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", organization.getId());
 
-        result.test().assertValueCount(1).assertValue(fluxRecord -> {
+        Flowable.fromPublisher(result)
+                .test()
+                .assertValueCount(1)
+                .assertValue(fluxRecord -> {
 
-            Assertions.assertThat(fluxRecord.getMeasurement()).isEqualTo("h2o_feet");
-            Assertions.assertThat(fluxRecord.getValue()).isEqualTo(1.0D);
-            Assertions.assertThat(fluxRecord.getField()).isEqualTo("level water_level");
-            Assertions.assertThat(fluxRecord.getTime()).isEqualTo(Instant.ofEpochSecond(0, 1));
+                    Assertions.assertThat(fluxRecord.getMeasurement()).isEqualTo("h2o_feet");
+                    Assertions.assertThat(fluxRecord.getValue()).isEqualTo(1.0D);
+                    Assertions.assertThat(fluxRecord.getField()).isEqualTo("level water_level");
+                    Assertions.assertThat(fluxRecord.getTime()).isEqualTo(Instant.ofEpochSecond(0, 1));
 
-            return true;
-        });
+                    return true;
+                });
     }
 
     @Test
@@ -159,9 +162,10 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(2);
 
-        Flowable<FluxRecord> results = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
+        Publisher<FluxRecord> results = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
 
-        results.test()
+        Flowable.fromPublisher(results)
+                .test()
                 .assertValueCount(2)
                 .assertValueAt(0, fluxRecord -> {
 
@@ -194,18 +198,21 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<FluxRecord> result = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last()");
+        Publisher<FluxRecord> result = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last()");
 
-        result.test().assertValueCount(1).assertValue(fluxRecord -> {
+        Flowable.fromPublisher(result)
+                .test()
+                .assertValueCount(1)
+                .assertValue(fluxRecord -> {
 
-            Assertions.assertThat(fluxRecord.getMeasurement()).isEqualTo("h2o_feet");
-            Assertions.assertThat(fluxRecord.getValue()).isEqualTo(1L);
-            Assertions.assertThat(fluxRecord.getField()).isEqualTo("water_level");
-            Assertions.assertThat(fluxRecord.getValueByKey("location")).isEqualTo("south");
-            Assertions.assertThat(fluxRecord.getTime()).isEqualTo(time);
+                    Assertions.assertThat(fluxRecord.getMeasurement()).isEqualTo("h2o_feet");
+                    Assertions.assertThat(fluxRecord.getValue()).isEqualTo(1L);
+                    Assertions.assertThat(fluxRecord.getField()).isEqualTo("water_level");
+                    Assertions.assertThat(fluxRecord.getValueByKey("location")).isEqualTo("south");
+                    Assertions.assertThat(fluxRecord.getTime()).isEqualTo(time);
 
-            return true;
-        });
+                    return true;
+                });
     }
 
     @Test
@@ -221,9 +228,9 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<FluxRecord> result = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
+        Publisher<FluxRecord> result = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
 
-        result
+        Flowable.fromPublisher(result)
                 .test()
                 .assertValueCount(2);
         //
@@ -251,17 +258,20 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<H2O> measurements = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last() |> rename(columns:{_value: \"water_level\"})", H2O.class);
+        Publisher<H2O> measurements = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last() |> rename(columns:{_value: \"water_level\"})", H2O.class);
 
-        measurements.test().assertValueCount(1).assertValueAt(0, h2O -> {
+        Flowable.fromPublisher(measurements)
+                .test()
+                .assertValueCount(1)
+                .assertValueAt(0, h2O -> {
 
-            Assertions.assertThat(h2O.location).isEqualTo("coyote_creek");
-            Assertions.assertThat(h2O.description).isNull();
-            Assertions.assertThat(h2O.level).isEqualTo(2.927);
-            Assertions.assertThat(h2O.time).isEqualTo(measurement.time);
+                    Assertions.assertThat(h2O.location).isEqualTo("coyote_creek");
+                    Assertions.assertThat(h2O.description).isNull();
+                    Assertions.assertThat(h2O.level).isEqualTo(2.927);
+                    Assertions.assertThat(h2O.time).isEqualTo(measurement.time);
 
-            return true;
-        });
+                    return true;
+                });
     }
 
     @Test
@@ -284,9 +294,9 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<H2O> measurements = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> sort(desc: false, columns:[\"_time\"]) |>rename(columns:{_value: \"water_level\"})", H2O.class);
+        Publisher<H2O> measurements = queryClient.query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> sort(desc: false, columns:[\"_time\"]) |>rename(columns:{_value: \"water_level\"})", H2O.class);
 
-        measurements
+        Flowable.fromPublisher(measurements)
                 .test()
                 .assertValueCount(2)
                 .assertValueAt(1, h2O -> {
@@ -317,9 +327,10 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<String> result = queryClient.queryRaw("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
+        Publisher<String> result = queryClient.queryRaw("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)");
 
-        result.test()
+        Flowable.fromPublisher(result)
+                .test()
                 .assertValueCount(6)
                 .assertValueAt(0, "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string")
                 .assertValueAt(1, "#group,false,false,true,true,false,false,true,true,true")
@@ -342,9 +353,10 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
                 .test()
                 .assertValueCount(1);
 
-        Flowable<String> result = queryClient.queryRaw("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", (Dialect) null);
+        Publisher<String> result = queryClient.queryRaw("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", (Dialect) null);
 
-        result.test()
+        Flowable.fromPublisher(result)
+                .test()
                 .assertValueCount(3)
                 .assertValueAt(0, ",result,table,_start,_stop,_time,_value,_field,_measurement,location")
                 .assertValueAt(1, value -> {
@@ -387,48 +399,54 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
         String query = "from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)";
         // String
         {
-            Flowable<FluxRecord> result = queryApi.query(query);
+            Publisher<FluxRecord> result = queryApi.query(query);
 
-            result.test().assertValueCount(1).assertValue(fluxRecord -> {
+            Flowable.fromPublisher(result)
+                    .test()
+                    .assertValueCount(1)
+                    .assertValue(fluxRecord -> {
 
-                Assertions.assertThat(fluxRecord.getValue()).isEqualTo(60.0);
+                        Assertions.assertThat(fluxRecord.getValue()).isEqualTo(60.0);
 
-                return true;
-            });
+                        return true;
+                    });
         }
 
         // Publisher
         {
-            Flowable<FluxRecord> result = queryApi.query(Flowable.just(query));
+            Publisher<FluxRecord> result = queryApi.query(Flowable.just(query));
 
-            result.test().assertValueCount(1).assertValue(fluxRecord -> {
+            Flowable.fromPublisher(result)
+                    .test()
+                    .assertValueCount(1)
+                    .assertValue(fluxRecord -> {
 
-                Assertions.assertThat(fluxRecord.getValue()).isEqualTo(60.0);
+                        Assertions.assertThat(fluxRecord.getValue()).isEqualTo(60.0);
 
-                return true;
-            });
+                        return true;
+                    });
         }
 
         // Measurement
         {
-            Flowable<H2O> result = queryApi.query(query, H2O.class);
+            Publisher<H2O> result = queryApi.query(query, H2O.class);
 
-            result.test().assertValueCount(1);
+            Flowable.fromPublisher(result).test().assertValueCount(1);
         }
 
         // Raw
         {
-            Flowable<String> result = queryApi.queryRaw(query);
-            result.test().assertValueCount(6);
+            Publisher<String> result = queryApi.queryRaw(query);
+            Flowable.fromPublisher(result).test().assertValueCount(6);
 
             result = queryApi.queryRaw(Flowable.just(query));
-            result.test().assertValueCount(6);
+            Flowable.fromPublisher(result).test().assertValueCount(6);
 
             result = queryApi.queryRaw(query, AbstractInfluxDBClient.DEFAULT_DIALECT);
-            result.test().assertValueCount(6);
+            Flowable.fromPublisher(result).test().assertValueCount(6);
 
             result = queryApi.queryRaw(Flowable.just(query), AbstractInfluxDBClient.DEFAULT_DIALECT);
-            result.test().assertValueCount(6);
+            Flowable.fromPublisher(result).test().assertValueCount(6);
         }
 
         client.close();

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -151,7 +151,7 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
     @Test
     void writeRecords() {
 
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).build());
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).build());
 
         Publisher<String> records = Flowable.just(
                 "h2o_feet,location=coyote_creek level\\ water_level=1.0 1",

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -28,7 +28,6 @@ import com.influxdb.annotations.Column;
 import com.influxdb.annotations.Measurement;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
-import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.Authorization;
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.Dialect;

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -233,16 +233,6 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
         Flowable.fromPublisher(result)
                 .test()
                 .assertValueCount(2);
-        //
-        //
-        //
-        //
-        //TODO test correct time of points
-        //
-        //
-        //
-        //
-        //
     }
 
     @Test

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.reactive;
+
+import io.reactivex.schedulers.Schedulers;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jakub Bednar (05/08/2021 9:23)
+ */
+@RunWith(JUnitPlatform.class)
+class WriteOptionsReactiveTest {
+    @Test
+    void configure() {
+
+        WriteOptionsReactive writeOptions = WriteOptionsReactive.builder()
+                .batchSize(10_000)
+                .flushInterval(500)
+                .jitterInterval(1_000)
+                .retryInterval(2_000)
+                .maxRetries(5)
+                .maxRetryDelay(250_123)
+                .maxRetryTime(500_000)
+                .exponentialBase(2)
+                .computationScheduler(Schedulers.newThread())
+                .build();
+
+        Assertions.assertThat(writeOptions.getBatchSize()).isEqualTo(10_000);
+        Assertions.assertThat(writeOptions.getFlushInterval()).isEqualTo(500);
+        Assertions.assertThat(writeOptions.getJitterInterval()).isEqualTo(1_000);
+        Assertions.assertThat(writeOptions.getRetryInterval()).isEqualTo(2_000);
+        Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(5);
+        Assertions.assertThat(writeOptions.getMaxRetryDelay()).isEqualTo(250_123);
+        Assertions.assertThat(writeOptions.getMaxRetryTime()).isEqualTo(500_000);
+        Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(2);
+        Assertions.assertThat(writeOptions.getComputationScheduler()).isEqualTo(Schedulers.newThread());
+    }
+}

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
@@ -67,4 +67,14 @@ class WriteOptionsReactiveTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageEndingWith("Expecting a positive or zero number for batchSize");
     }
+
+    @Test
+    void disableRetryConfiguration() {
+        WriteOptionsReactive writeOptions = WriteOptionsReactive.builder().maxRetries(0).build();
+        Assertions.assertThat(writeOptions.getMaxRetries()).isEqualTo(0);
+
+        Assertions.assertThatThrownBy(() -> WriteOptionsReactive.builder().maxRetries(-1).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageEndingWith("Expecting a positive or zero number for maxRetries");
+    }
 }

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
@@ -57,4 +57,14 @@ class WriteOptionsReactiveTest {
         Assertions.assertThat(writeOptions.getExponentialBase()).isEqualTo(2);
         Assertions.assertThat(writeOptions.getComputationScheduler()).isEqualTo(Schedulers.newThread());
     }
+
+    @Test
+    void disableBatchingConfiguration() {
+        WriteOptionsReactive writeOptions = WriteOptionsReactive.builder().batchSize(0).build();
+        Assertions.assertThat(writeOptions.getBatchSize()).isEqualTo(0);
+
+        Assertions.assertThatThrownBy(() -> WriteOptionsReactive.builder().batchSize(-1).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageEndingWith("Expecting a positive or zero number for batchSize");
+    }
 }

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.internal.RetryAttempt;
 import com.influxdb.client.write.Point;
@@ -80,7 +79,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
 
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).build());
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).build());
 
         Publisher<String> records = Flowable.just(
                 "h2o_feet,location=coyote_creek level=1.0 1",
@@ -106,7 +105,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
 
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(100_000)
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(100_000)
                 .flushInterval(100).build());
 
         Flowable<String> records = Flowable.interval(500, TimeUnit.MILLISECONDS)
@@ -145,7 +144,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
 
         // Without jitter
         {
-            writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).build());
+            writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).build());
 
             Publisher<WriteReactiveApi.Success> success = writeClient
                     .writeRecord("my-bucket", "my-org", WritePrecision.S, "mem,tag=a field=1 1");
@@ -159,7 +158,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
 
         // With jitter
         {
-            writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).jitterInterval(2_000).build());
+            writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).jitterInterval(2_000).build());
 
             Publisher<WriteReactiveApi.Success> success = writeClient
                     .writeRecord("my-bucket", "my-org", WritePrecision.S, "mem,tag=a field=1 1");
@@ -180,7 +179,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
         mockServer.enqueue(createErrorResponse("token is temporarily over quota", true, 429));
         mockServer.enqueue(createResponse("{}"));
 
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).build());
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).build());
 
         Point point = Point.measurement("h2o").addTag("location", "europe").addField("level", 2);
         Publisher<WriteReactiveApi.Success> success = writeClient.writePoint("b1", "org1", WritePrecision.NS, point);
@@ -209,7 +208,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
         errorResponse.addHeader("Retry-After", 1);
         mockServer.enqueue(errorResponse);
 
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).maxRetryTime(500).build());
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).maxRetryTime(500).build());
 
         Point point = Point.measurement("h2o").addTag("location", "europe").addField("level", 2);
         Publisher<WriteReactiveApi.Success> success = writeClient.writePoint("b1", "org1", WritePrecision.NS, point);
@@ -236,7 +235,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
     void networkError() throws IOException {
         mockServer.shutdown();
 
-        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).maxRetries(1).build());
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptionsReactive.builder().batchSize(1).maxRetries(1).build());
 
         Publisher<WriteReactiveApi.Success> success = writeClient.writeRecord("my-bucket", "my-org", WritePrecision.S, "mem,tag=a field=10");
         TestSubscriber<WriteReactiveApi.Success> test = Flowable.fromPublisher(success)

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
@@ -1,0 +1,150 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.reactive;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.influxdb.client.WriteOptions;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.exceptions.InfluxException;
+import com.influxdb.test.AbstractMockServerTest;
+
+import io.reactivex.Flowable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.reactivestreams.Publisher;
+
+/**
+ * @author Jakub Bednar (02/08/2021 12:28)
+ */
+@RunWith(JUnitPlatform.class)
+class WriteReactiveApiTest extends AbstractMockServerTest {
+
+    private TestScheduler testScheduler;
+    private WriteReactiveApi writeClient;
+    private InfluxDBClientReactive influxDBClient;
+
+    @BeforeEach
+    void setUp() {
+
+        influxDBClient = InfluxDBClientReactiveFactory.create(startMockServer());
+
+        testScheduler = new TestScheduler();
+        RxJavaPlugins.setComputationSchedulerHandler(scheduler -> testScheduler);
+
+    }
+
+    @AfterEach
+    void tearDown() {
+
+        influxDBClient.close();
+
+        testScheduler.shutdown();
+        RxJavaPlugins.setComputationSchedulerHandler(null);
+    }
+
+    @Test
+    void batches() {
+
+        mockServer.enqueue(createResponse("{}"));
+        mockServer.enqueue(createResponse("{}"));
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(1).build());
+
+        Publisher<String> records = Flowable.just(
+                "h2o_feet,location=coyote_creek level=1.0 1",
+                "h2o_feet,location=coyote_creek level=2.0 2");
+
+        Publisher<WriteReactiveApi.Success> success = writeClient.writeRecords("my-bucket", "my-org", WritePrecision.S, records);
+        Flowable.fromPublisher(success)
+                .test()
+                .assertValueCount(2);
+
+        Assertions.assertThat(getRequestBody(mockServer)).isEqualTo("h2o_feet,location=coyote_creek level=1.0 1");
+        Assertions.assertThat(getRequestBody(mockServer)).isEqualTo("h2o_feet,location=coyote_creek level=2.0 2");
+
+        Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    void flushByTime() {
+
+        mockServer.enqueue(createResponse("{}"));
+        mockServer.enqueue(createResponse("{}"));
+        mockServer.enqueue(createResponse("{}"));
+        mockServer.enqueue(createResponse("{}"));
+        mockServer.enqueue(createResponse("{}"));
+
+        writeClient = influxDBClient.getWriteReactiveApi(WriteOptions.builder().batchSize(100_000)
+                .flushInterval(100).build());
+
+        Flowable<String> records = Flowable.interval(500, TimeUnit.MILLISECONDS)
+                .take(5)
+                .map(it -> String.format("mem,tag=a field=%d %d", it, it));
+
+        Publisher<WriteReactiveApi.Success> success = writeClient
+                .writeRecords("my-bucket", "my-org", WritePrecision.S, records);
+
+        TestSubscriber<WriteReactiveApi.Success> test = Flowable.fromPublisher(success)
+                .test();
+
+        testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        test.awaitCount(1);
+
+        testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        test.awaitCount(2).assertNotComplete();
+
+        testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        test.awaitCount(3).assertNotComplete();
+
+        testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        test.awaitCount(4).assertNotComplete();
+
+        testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+        test.awaitCount(5).assertComplete();
+
+        Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(5);
+    }
+
+    @Test
+    public void networkError() throws IOException {
+        mockServer.shutdown();
+
+        writeClient = influxDBClient.getWriteReactiveApi();
+
+        Publisher<WriteReactiveApi.Success> success = writeClient.writeRecord("my-bucket", "my-org", WritePrecision.S, "mem,tag=a field=10");
+        Flowable.fromPublisher(success)
+                .test()
+                .assertError(throwable -> {
+                    Assertions.assertThat(throwable).isInstanceOf(InfluxException.class);
+                    Assertions.assertThat(throwable).hasCauseInstanceOf(IOException.class);
+                    return true;
+                });
+    }
+}

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
@@ -30,7 +30,6 @@ import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.internal.RetryAttempt;
 import com.influxdb.client.write.Point;
 import com.influxdb.exceptions.InfluxException;
-import com.influxdb.query.FluxRecord;
 import com.influxdb.test.AbstractMockServerTest;
 
 import io.reactivex.Flowable;

--- a/client-test/src/main/java/com/influxdb/test/AbstractMockServerTest.java
+++ b/client-test/src/main/java/com/influxdb/test/AbstractMockServerTest.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 
 /**
@@ -139,5 +140,21 @@ public abstract class AbstractMockServerTest extends AbstractTest {
 
     protected RecordedRequest takeRequest() throws InterruptedException {
         return mockServer.takeRequest(10L, TimeUnit.SECONDS);
+    }
+
+    @Nonnull
+    protected String getRequestBody(@Nonnull final MockWebServer server) {
+
+        Assertions.assertThat(server).isNotNull();
+
+        RecordedRequest recordedRequest = null;
+        try {
+            recordedRequest = server.takeRequest(10L, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Assertions.fail("Unexpected exception", e);
+        }
+        Assertions.assertThat(recordedRequest).isNotNull();
+
+        return recordedRequest.getBody().readUtf8();
     }
 }

--- a/client/src/main/java/com/influxdb/client/WriteApi.java
+++ b/client/src/main/java/com/influxdb/client/WriteApi.java
@@ -236,4 +236,51 @@ public interface WriteApi extends AutoCloseable {
      * Close threads for asynchronous batch writing.
      */
     void close();
+
+    /**
+     * Retry configuration.
+     */
+    interface RetryOptions {
+
+        /**
+         * Jitters the batch flush interval by a random amount. This is primarily to avoid
+         * large write spikes for users running a large number of client instances.
+         * ie, a jitter of 5s and flush duration 10s means flushes will happen every 10-15s.
+         *
+         * @return milliseconds
+         */
+        int getJitterInterval();
+
+        /**
+         * The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
+         * <br>
+         * Retry-After: A non-negative decimal integer indicating the seconds to delay after the response is received.
+         *
+         * @return the time to wait before retry unsuccessful write (milliseconds)
+         */
+        int getRetryInterval();
+
+        /**
+         * The number of max retries when write fails.
+         *
+         * @return number of max retries
+         */
+        int getMaxRetries();
+
+        /**
+         * The maximum delay between each retry attempt in milliseconds.
+         *
+         * @return maximum delay
+         */
+        int getMaxRetryDelay();
+
+        /**
+         * The base for the exponential retry delay.
+         *
+         * The next delay is computed as: retryInterval * exponentialBase^(attempts-1) + random(jitterInterval)
+         *
+         * @return exponential base
+         */
+        int getExponentialBase();
+    }
 }

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -548,20 +548,6 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
                 });
     }
 
-    @Nonnull
-    private InfluxException toInfluxException(@Nonnull final Throwable throwable) {
-
-        if (throwable instanceof InfluxException) {
-            return (InfluxException) throwable;
-        }
-
-        if (throwable instanceof HttpException) {
-            return responseToError(((HttpException) throwable).response());
-        }
-
-        return new InfluxException(throwable);
-    }
-
     static void waitToCondition(final Supplier<Boolean> condition, final int millis) {
         long start = System.currentTimeMillis();
         while (!condition.get()) {

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -280,12 +280,21 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
         private static final Logger LOG = Logger.getLogger(BatchWriteDataPoint.class.getName());
 
         private final Point point;
+        private final WritePrecision precision;
         private final InfluxDBClientOptions options;
 
         public BatchWriteDataPoint(@Nonnull final Point point,
                                    @Nonnull final InfluxDBClientOptions options) {
 
+            this(point, point.getPrecision(), options);
+        }
+
+        public BatchWriteDataPoint(@Nonnull final Point point,
+                                   @Nonnull final WritePrecision precision,
+                                   @Nonnull final InfluxDBClientOptions options) {
+
             this.point = point;
+            this.precision = precision;
             this.options = options;
         }
 
@@ -300,7 +309,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
                 return null;
             }
 
-            return point.toLineProtocol(options.getPointSettings());
+            return point.toLineProtocol(options.getPointSettings(), precision);
         }
     }
 

--- a/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
+++ b/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
@@ -40,7 +40,7 @@ import com.influxdb.utils.Arguments;
 /**
  * @author Jakub Bednar (bednar@github) (15/10/2018 13:04)
  */
-class MeasurementMapper {
+public final class MeasurementMapper {
 
     private static final Logger LOG = Logger.getLogger(MeasurementMapper.class.getName());
 

--- a/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
+++ b/client/src/main/java/com/influxdb/client/internal/RetryAttempt.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
-import com.influxdb.client.WriteOptions;
+import com.influxdb.client.WriteApi.RetryOptions;
 
 import org.jetbrains.annotations.Nullable;
 import retrofit2.HttpException;
@@ -51,12 +51,12 @@ public final class RetryAttempt {
 
     private final Throwable throwable;
     private final int count;
-    private final WriteOptions writeOptions;
+    private final RetryOptions writeOptions;
 
-    RetryAttempt(final Throwable throwable, final int count, final WriteOptions writeOptions) {
+    RetryAttempt(final Throwable throwable, final int count, final RetryOptions retryOptions) {
         this.throwable = throwable;
         this.count = count;
-        this.writeOptions = writeOptions;
+        this.writeOptions = retryOptions;
     }
 
     /**

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -406,18 +406,24 @@ public final class Point {
 
         sb.append(" ");
 
-        BigInteger time;
-        if (this.time instanceof BigDecimal) {
-            time = ((BigDecimal) this.time).toBigInteger();
-        } else if (this.time instanceof BigInteger) {
-            time = (BigInteger) this.time;
+        if (this.precision == precision) {
+            if (this.time instanceof BigDecimal) {
+                sb.append(((BigDecimal) this.time).toBigInteger());
+            } else if (this.time instanceof BigInteger) {
+                sb.append(this.time);
+            } else {
+                sb.append(this.time.longValue());
+            }
         } else {
-            time = BigInteger.valueOf(this.time.longValue());
-        }
-        if (this.precision != precision) {
-            sb.append(toTimeUnit(precision).convert(time.longValueExact(), toTimeUnit(this.precision)));
-        } else {
-            sb.append(time);
+            long time;
+            if (this.time instanceof BigDecimal) {
+                time = ((BigDecimal) this.time).longValueExact();
+            } else if (this.time instanceof BigInteger) {
+                time = ((BigInteger) this.time).longValueExact();
+            } else {
+                time = this.time.longValue();
+            }
+            sb.append(toTimeUnit(precision).convert(time, toTimeUnit(this.precision)));
         }
     }
 

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -1018,22 +1018,6 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         Assertions.assertThat(userAgent).startsWith("influxdb-client-java/4.");
     }
 
-    @Nonnull
-    private String getRequestBody(@Nonnull final MockWebServer server) {
-
-        Assertions.assertThat(server).isNotNull();
-
-        RecordedRequest recordedRequest = null;
-        try {
-            recordedRequest = server.takeRequest(10L, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Assertions.fail("Unexpected exception", e);
-        }
-        Assertions.assertThat(recordedRequest).isNotNull();
-
-        return recordedRequest.getBody().readUtf8();
-    }
-
     public abstract class Metric {
         @Column(name = "source", tag = true)
         private String source;

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -44,6 +44,8 @@ import com.influxdb.exceptions.ForbiddenException;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.RequestEntityTooLargeException;
 import com.influxdb.exceptions.UnauthorizedException;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
 
 import io.reactivex.schedulers.TestScheduler;
 import okhttp3.mockwebserver.MockResponse;

--- a/examples/src/main/java/example/InfluxDB2ReactiveExample.java
+++ b/examples/src/main/java/example/InfluxDB2ReactiveExample.java
@@ -25,6 +25,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
+import io.reactivex.Flowable;
+
 public class InfluxDB2ReactiveExample {
 
     private static char[] token = "my-token".toCharArray();
@@ -41,8 +43,7 @@ public class InfluxDB2ReactiveExample {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux)
+        Flowable.fromPublisher(queryApi.query(flux))
                 //
                 // Filter records by measurement name
                 //

--- a/examples/src/main/java/example/InfluxDB2ReactiveExampleDSL.java
+++ b/examples/src/main/java/example/InfluxDB2ReactiveExampleDSL.java
@@ -29,6 +29,8 @@ import com.influxdb.client.reactive.QueryReactiveApi;
 import com.influxdb.query.dsl.Flux;
 import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
+import io.reactivex.Flowable;
+
 public class InfluxDB2ReactiveExampleDSL {
 
     private static char[] token = "my-token".toCharArray();
@@ -47,8 +49,7 @@ public class InfluxDB2ReactiveExampleDSL {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux.toString())
+        Flowable.fromPublisher(queryApi.query(flux.toString()))
                 .subscribe(fluxRecord -> {
                     //
                     // The callback to consume a FluxRecord.

--- a/examples/src/main/java/example/InfluxDB2ReactiveExamplePojo.java
+++ b/examples/src/main/java/example/InfluxDB2ReactiveExamplePojo.java
@@ -29,6 +29,9 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+
 public class InfluxDB2ReactiveExamplePojo {
 
     private static char[] token = "my-token".toCharArray();
@@ -44,8 +47,8 @@ public class InfluxDB2ReactiveExamplePojo {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux, Temperature.class)
+        Publisher<Temperature> query = queryApi.query(flux, Temperature.class);
+        Flowable.fromPublisher(query)
                 //
                 // Take first 10 records
                 //

--- a/examples/src/main/java/example/InfluxDB2ReactiveExampleRaw.java
+++ b/examples/src/main/java/example/InfluxDB2ReactiveExampleRaw.java
@@ -25,6 +25,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
+import io.reactivex.Flowable;
+
 public class InfluxDB2ReactiveExampleRaw {
 
     private static char[] token = "my-token".toCharArray();
@@ -41,8 +43,7 @@ public class InfluxDB2ReactiveExampleRaw {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .queryRaw(flux)
+        Flowable.fromPublisher(queryApi.queryRaw(flux))
                 //
                 // Take first 10 records
                 //

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>adapter-rxjava2</artifactId>
+                <version>${dependency.retrofit.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
                 <version>2.6.0</version>


### PR DESCRIPTION
Related to https://github.com/influxdata/EAR/issues/2287

## Proposed Changes

Improvements of Reactive client:
- [x] `WriteApi` uses generic [Reactive Streams](https://www.reactive-streams.org)
    - [x] jittering
    - [x] retry 
    - [x] possibility to disable:
        - [x] batching
        - [x] retry
- [x] `QueryApi` uses generic [Reactive Streams](https://www.reactive-streams.org)
- [x] Update `README.md` and JavaDoc
- [x] Update [SpringBoot demo](https://github.com/bednar/influxdb-reactor-rest-write-example)
- [x] TODOs in `client-reactive`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
