### PR TITLE
fix: Spring auto-configuration works even without `influxdb-client-reactive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.2.0 [unreleased]
 
+### Bug Fixes
+1. [#252](https://github.com/influxdata/influxdb-client-java/pull/252): Spring auto-configuration works even without `influxdb-client-reactive` [spring]
+
+
 ## 3.1.0 [2021-07-27]
 
 ### Breaking Changes

--- a/spring/README.md
+++ b/spring/README.md
@@ -18,7 +18,7 @@ The default configuration can be override via properties:
 
 ```yaml
 influx:
-    url: http://localhost:8086/api/v2 # URL to connect to InfluxDB.
+    url: http://localhost:8086/ # URL to connect to InfluxDB.
     username: my-user # Username to use in the basic auth.
     password: my-password # Password to use in the basic auth.
     token: my-token # Token to use for the authorization.

--- a/spring/src/main/java/com/influxdb/spring/influx/AbstractInfluxDB2AutoConfiguration.java
+++ b/spring/src/main/java/com/influxdb/spring/influx/AbstractInfluxDB2AutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.spring.influx;
+
+import java.util.Collections;
+import javax.annotation.Nonnull;
+
+import com.influxdb.client.InfluxDBClientOptions;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Jakub Bednar (04/08/2021 11:41)
+ */
+abstract class AbstractInfluxDB2AutoConfiguration {
+    protected final InfluxDB2Properties properties;
+    protected final InfluxDB2OkHttpClientBuilderProvider builderProvider;
+
+    protected AbstractInfluxDB2AutoConfiguration(final InfluxDB2Properties properties,
+                                                 final InfluxDB2OkHttpClientBuilderProvider builderProvider) {
+        this.properties = properties;
+        this.builderProvider = builderProvider;
+    }
+
+    @Nonnull
+    protected InfluxDBClientOptions.Builder makeBuilder() {
+        OkHttpClient.Builder okHttpBuilder;
+        if (builderProvider == null) {
+            okHttpBuilder = new OkHttpClient.Builder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
+                    .readTimeout(properties.getReadTimeout())
+                    .writeTimeout(properties.getWriteTimeout())
+                    .connectTimeout(properties.getConnectTimeout());
+        } else {
+            okHttpBuilder = builderProvider.get();
+        }
+
+        InfluxDBClientOptions.Builder influxBuilder = InfluxDBClientOptions.builder()
+                .url(properties.getUrl())
+                .bucket(properties.getBucket())
+                .org(properties.getOrg())
+                .okHttpClient(okHttpBuilder);
+
+        if (StringUtils.hasLength(properties.getToken())) {
+            influxBuilder.authenticateToken(properties.getToken().toCharArray());
+        } else if (StringUtils.hasLength(properties.getUsername()) && StringUtils.hasLength(properties.getPassword())) {
+            influxBuilder.authenticate(properties.getUsername(), properties.getPassword().toCharArray());
+        }
+        return influxBuilder;
+    }
+}

--- a/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactive.java
+++ b/spring/src/main/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactive.java
@@ -21,9 +21,9 @@
  */
 package com.influxdb.spring.influx;
 
-import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.client.reactive.InfluxDBClientReactive;
+import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -40,22 +40,22 @@ import org.springframework.context.annotation.Configuration;
  * @author Jakub Bednar (bednar@github) (06/05/2019 13:09)
  */
 @Configuration
-@ConditionalOnClass(InfluxDBClient.class)
+@ConditionalOnClass(name = "com.influxdb.client.reactive.InfluxDBClientReactive")
 @EnableConfigurationProperties(InfluxDB2Properties.class)
-public class InfluxDB2AutoConfiguration extends AbstractInfluxDB2AutoConfiguration {
+public class InfluxDB2AutoConfigurationReactive extends AbstractInfluxDB2AutoConfiguration {
 
-    public InfluxDB2AutoConfiguration(final InfluxDB2Properties properties,
-                                      final ObjectProvider<InfluxDB2OkHttpClientBuilderProvider> builderProvider) {
+    public InfluxDB2AutoConfigurationReactive(final InfluxDB2Properties properties,
+                                              final ObjectProvider<InfluxDB2OkHttpClientBuilderProvider>
+                                                      builderProvider) {
         super(properties, builderProvider.getIfAvailable());
     }
 
     @Bean
     @ConditionalOnProperty("influx.url")
-    @ConditionalOnMissingBean(InfluxDBClient.class)
-    public InfluxDBClient influxDBClient() {
-
+    @ConditionalOnMissingBean(InfluxDBClientReactive.class)
+    public InfluxDBClientReactive influxDBClientReactive() {
         InfluxDBClientOptions.Builder influxBuilder = makeBuilder();
 
-        return InfluxDBClientFactory.create(influxBuilder.build()).setLogLevel(properties.getLogLevel());
+        return InfluxDBClientReactiveFactory.create(influxBuilder.build()).setLogLevel(properties.getLogLevel());
     }
 }

--- a/spring/src/main/resources/META-INF/spring.factories
+++ b/spring/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.influxdb.spring.health.InfluxDB2HealthIndicatorAutoConfiguration,\
-com.influxdb.spring.influx.InfluxDB2AutoConfiguration
+com.influxdb.spring.influx.InfluxDB2AutoConfiguration,\
+com.influxdb.spring.influx.InfluxDB2AutoConfigurationReactive

--- a/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactiveTest.java
+++ b/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactiveTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.spring.influx;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.reactive.InfluxDBClientReactive;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests for {@link InfluxDB2AutoConfiguration}.
+ *
+ * @author Jakub Bednar (bednar@github) (07/05/2019 12:59)
+ */
+@RunWith(JUnitPlatform.class)
+class InfluxDB2AutoConfigurationReactiveTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(InfluxDB2AutoConfigurationReactive.class));
+
+
+    @Test
+    public void influxDBClientReactive() {
+        this.contextRunner.withPropertyValues("influx.url=http://localhost:8086/")
+                .run(((context) -> Assertions.assertThat(context.getBeansOfType(InfluxDBClientReactive.class))
+                        .hasSize(1)))
+                .run(((context) -> Assertions.assertThat(context.getBeansOfType(InfluxDBClient.class))
+                        .hasSize(0)));
+    }
+}

--- a/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationTest.java
+++ b/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.reactive.InfluxDBClientReactive;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -52,7 +50,6 @@ import retrofit2.Retrofit;
 class InfluxDB2AutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withClassLoader(new FilteredClassLoader(InfluxDBClientReactive.class))
             .withConfiguration(AutoConfigurations.of(InfluxDB2AutoConfiguration.class));
 
     @Test
@@ -100,21 +97,6 @@ class InfluxDB2AutoConfigurationTest {
                     int readTimeout = getReadTimeoutProperty(context);
                     Assertions.assertThat(readTimeout).isEqualTo(13_000);
                 });
-    }
-
-    @Test
-    public void influxDBClientReactive() {
-        ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-                .withPropertyValues("influx.url=http://localhost:8086/")
-                .withConfiguration(AutoConfigurations.of(InfluxDB2AutoConfiguration.class));
-
-        contextRunner
-                .run(((context) -> Assertions.assertThat(context.getBeansOfType(InfluxDBClientReactive.class))
-                .hasSize(1)));
-
-        contextRunner
-                .run(((context) -> Assertions.assertThat(context.getBeansOfType(InfluxDBClient.class))
-                .hasSize(0)));
     }
 
     @Test


### PR DESCRIPTION
Closes #250

## Proposed Changes

The SpringBoot auto-configuration works even without `influxdb-client-reactive`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
