### PR TITLE
fix: read entire query response into bytes array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 1. [#252](https://github.com/influxdata/influxdb-client-java/pull/252): Spring auto-configuration works even without `influxdb-client-reactive` [spring]
-
+1. [#254](https://github.com/influxdata/influxdb-client-java/pull/254): Avoid reading entire query response into bytes array
 
 ## 3.1.0 [2021-07-27]
 

--- a/client/src/generated/java/com/influxdb/client/service/QueryService.java
+++ b/client/src/generated/java/com/influxdb/client/service/QueryService.java
@@ -75,6 +75,7 @@ public interface QueryService {
    * @return Call&lt;ResponseBody&gt;
    */
   @POST("api/v2/query")
+  @Streaming
   Call<ResponseBody> postQueryResponseBody(
     @retrofit2.http.Header("Zap-Trace-Span") String zapTraceSpan, @retrofit2.http.Header("Accept-Encoding") String acceptEncoding, @retrofit2.http.Header("Content-Type") String contentType, @retrofit2.http.Query("org") String org, @retrofit2.http.Query("orgID") String orgID, @retrofit2.http.Body Query query
   );


### PR DESCRIPTION
Closes #253

## Proposed Changes

Avoid to read entire query response into byte arrays - https://square.github.io/retrofit/2.x/retrofit/retrofit2/http/Streaming.html

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
