### PR TITLE
docs: clarify how to use asynchronous non-blocking Write API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 1. [#252](https://github.com/influxdata/influxdb-client-java/pull/252): Spring auto-configuration works even without `influxdb-client-reactive` [spring]
 1. [#254](https://github.com/influxdata/influxdb-client-java/pull/254): Avoid reading entire query response into bytes array
 
+### Deprecates
+1. [#255](https://github.com/influxdata/influxdb-client-java/pull/255): `InfluxDBClient#getWriteApi()` instead use `InfluxDBClient#makeWriteApi()`
+
 ## 3.1.0 [2021-07-27]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import com.influxdb.annotations.Measurement;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.QueryApi;
-import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import com.influxdb.query.FluxRecord;
@@ -143,33 +143,32 @@ public class InfluxDB2Example {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
 
-            //
-            // Write by Data Point
-            //
-            Point point = Point.measurement("temperature")
-                    .addTag("location", "west")
-                    .addField("value", 55D)
-                    .time(Instant.now().toEpochMilli(), WritePrecision.MS);
+        //
+        // Write by Data Point
+        //
+        Point point = Point.measurement("temperature")
+                .addTag("location", "west")
+                .addField("value", 55D)
+                .time(Instant.now().toEpochMilli(), WritePrecision.MS);
 
-            writeApi.writePoint(point);
+        writeApi.writePoint(point);
 
-            //
-            // Write by LineProtocol
-            //
-            writeApi.writeRecord(WritePrecision.MS, "temperature,location=north value=60.0");
+        //
+        // Write by LineProtocol
+        //
+        writeApi.writeRecord(WritePrecision.NS, "temperature,location=north value=60.0");
 
-            //
-            // Write by POJO
-            //
-            Temperature temperature = new Temperature();
-            temperature.location = "south";
-            temperature.value = 62D;
-            temperature.time = Instant.now();
+        //
+        // Write by POJO
+        //
+        Temperature temperature = new Temperature();
+        temperature.location = "south";
+        temperature.value = 62D;
+        temperature.time = Instant.now();
 
-            writeApi.writeMeasurement(WritePrecision.MS, temperature);
-        }
+        writeApi.writeMeasurement( WritePrecision.NS, temperature);
 
         //
         // Query data

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
@@ -33,14 +33,14 @@ import java.io.Closeable
 interface InfluxDBClientKotlin : Closeable {
 
     /**
-     * Get the Query client.
+     * Create a new Query client.
      *
      * @return the new client instance for the Query API
      */
     fun getQueryKotlinApi() : QueryKotlinApi
 
     /**
-     * Get the Write client.
+     * Create a new Write client.
      *
      * @return the new client instance for the Write API
      */

--- a/client-osgi/src/main/java/com/influxdb/client/osgi/LineProtocolWriter.java
+++ b/client-osgi/src/main/java/com/influxdb/client/osgi/LineProtocolWriter.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.internal.NanosecondConverter;
 
@@ -177,7 +177,7 @@ public class LineProtocolWriter implements EventHandler {
         }
 
         final WritePrecision writePrecision = getPrecision(event);
-        final WriteApi writeApi = client.getWriteApi();
+        final WriteApiBlocking writeApi = client.getWriteApiBlocking();
 
         final String record = (String) event.getProperty(RECORD);
         final List<String> records = (List<String>) event.getProperty(RECORDS);

--- a/client-osgi/src/main/java/com/influxdb/client/osgi/PointWriter.java
+++ b/client-osgi/src/main/java/com/influxdb/client/osgi/PointWriter.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 
@@ -232,7 +232,7 @@ public class PointWriter implements EventHandler {
             bucket = config.bucket();
         }
 
-        final WriteApi writeApi = client.getWriteApi();
+        final WriteApiBlocking writeApi = client.getWriteApiBlocking();
 
         final Object point = event.getProperty(POINT);
         final Collection<Object> points = (Collection<Object>) event.getProperty(POINTS);

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/LineProtocolWriterTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/LineProtocolWriterTest.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +70,7 @@ public class LineProtocolWriterTest {
     private static final String BUCKET_OVERRIDE = "my-bucket";
 
     @Mock
-    private WriteApi writeApi;
+    private WriteApiBlocking writeApi;
 
     @Mock
     private InfluxDBClient client;
@@ -97,7 +98,7 @@ public class LineProtocolWriterTest {
     @BeforeEach
     void setUp() {
         lineProtocolWriter = new LineProtocolWriter();
-        when(client.getWriteApi()).thenReturn(writeApi);
+        when(client.getWriteApiBlocking()).thenReturn(writeApi);
         lineProtocolWriter.client = client;
         payload = new TreeMap<>();
         payload.put(EventConstants.TIMESTAMP, System.currentTimeMillis());

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/PointWriterTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/PointWriterTest.java
@@ -23,6 +23,7 @@ package com.influxdb.client.osgi;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import org.hamcrest.CoreMatchers;
@@ -94,7 +95,7 @@ public class PointWriterTest {
     private static final String BUCKET_OVERRIDE = "my-bucket";
 
     @Mock
-    private WriteApi writeApi;
+    private WriteApiBlocking writeApi;
 
     @Mock
     private InfluxDBClient client;
@@ -119,7 +120,7 @@ public class PointWriterTest {
     @BeforeEach
     void setUp() {
         pointWriter = new PointWriter();
-        when(client.getWriteApi()).thenReturn(writeApi);
+        when(client.getWriteApiBlocking()).thenReturn(writeApi);
         pointWriter.client = client;
         payload = new TreeMap<>();
         payload.put(EventConstants.TIMESTAMP, System.currentTimeMillis());

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
@@ -39,7 +39,7 @@ import io.reactivex.Single;
 public interface InfluxDBClientReactive extends AutoCloseable {
 
     /**
-     * Get the Query client.
+     * Create a new Query client.
      *
      * @return the new client instance for the Query API
      */
@@ -47,7 +47,7 @@ public interface InfluxDBClientReactive extends AutoCloseable {
     QueryReactiveApi getQueryReactiveApi();
 
     /**
-     * Get the Write client.
+     * Create a new Write client.
      *
      * @return the new client instance for the Write API
      */
@@ -55,7 +55,7 @@ public interface InfluxDBClientReactive extends AutoCloseable {
     WriteReactiveApi getWriteReactiveApi();
 
     /**
-     * Get the Write client.
+     * Create a new Write client.
      *
      * @return the new client instance for the Write API
      */

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScala.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScala.scala
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull
 trait InfluxDBClientScala {
 
   /**
-   * Get the Query client.
+   * Create a new Query client.
    *
    * @return the new client instance for the Query API
    */

--- a/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
@@ -98,7 +98,7 @@ class ITQueryScalaApiQuery extends AbstractITQueryScalaApi with Matchers {
       "cpu,host=A,hyper-threading=true,region=west usage_system=55i,user_usage=65i 20000000000")
       .mkString("\n")
 
-    val writeApi = client.getWriteApi
+    val writeApi = client.getWriteApiBlocking
     writeApi.writeRecord(bucket.getName, organization.getId, WritePrecision.NS, records)
 
     client.close()
@@ -388,7 +388,7 @@ class ITQueryScalaApiQuery extends AbstractITQueryScalaApi with Matchers {
     //
     val records = Range(0, 10000).map(n => s"buffer field=$n $n").mkString("\n")
     val client = InfluxDBClientFactory.create(influxDBUtils.getUrl, "my-user", "my-password".toCharArray)
-    client.getWriteApi.writeRecord(bucket.getName, organization.getId, WritePrecision.NS, records)
+    client.getWriteApiBlocking.writeRecord(bucket.getName, organization.getId, WritePrecision.NS, records)
     client.close()
 
     //

--- a/client/README.md
+++ b/client/README.md
@@ -420,7 +420,7 @@ public class WriteDataBlocking {
          
 ### Asynchronous non-blocking API
 
-> :warning: **The `WriteApi` is supposed to be use as a singleton**: Don't create new instance for every write!
+> :warning: **The `WriteApi` is supposed to be use as a singleton**. Don't create a new instance for every write!
 
 For writing data we use [WriteApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApi.html) that is an asynchronous non-blocking API and supports:
 
@@ -510,7 +510,7 @@ public class WritePojo {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        try (WriteApi writeApi = influxDBClient.makeWriteApi()) {
 
             //
             // Write by POJO
@@ -569,7 +569,7 @@ public class WriteDataPoint {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        try (WriteApi writeApi = influxDBClient.makeWriteApi()) {
 
             //
             // Write by Data Point
@@ -612,7 +612,7 @@ public class WriteLineProtocol {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        try (WriteApi writeApi = influxDBClient.makeWriteApi()) {
 
             //
             // Write by LineProtocol
@@ -672,7 +672,7 @@ mine-sensor,id=132-987-655,customer="California Miner",hostname=example.com,sens
 ##### Handle the Success write
 
 ```java
-WriteApi writeApi = influxDBClient.getWriteApi();
+WriteApi writeApi = influxDBClient.makeWriteApi();
 writeApi.listenEvents(WriteSuccessEvent.class, event -> {
 
     String data = event.getLineProtocol();
@@ -686,7 +686,7 @@ writeApi.listenEvents(WriteSuccessEvent.class, event -> {
 ##### Handle the Error Write
 
 ```java
-WriteApi writeApi = influxDBClient.getWriteApi();
+WriteApi writeApi = influxDBClient.makeWriteApi();
 writeApi.listenEvents(WriteErrorEvent.class, event -> {
 
     Throwable exception = event.getThrowable();

--- a/client/README.md
+++ b/client/README.md
@@ -332,6 +332,96 @@ public class RawQueryAsynchronous {
 
 ## Writes
 
+The client offers two types of API to ingesting data:
+1. [Synchronous blocking API](#synchronous-blocking-api)
+1. [Asynchronous non-blocking API](#asynchronous-non-blocking-api) which supports batching, retrying and jittering
+
+### Synchronous blocking API
+
+The [WriteApiBlocking](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApiBlocking.html) provides a synchronous blocking API to writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point and POJO.
+
+_It's up to user to handle a server or a http exception._
+
+```java
+package example;
+
+import java.time.Instant;
+
+import com.influxdb.annotations.Column;
+import com.influxdb.annotations.Measurement;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import com.influxdb.exceptions.InfluxException;
+
+public class WriteDataBlocking {
+
+    private static char[] token = "my-token".toCharArray();
+    private static String org = "my-org";
+    private static String bucket = "my-bucket";
+
+    public static void main(final String[] args) {
+
+        InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:8086", token, org, bucket);
+
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+
+        try {
+            //
+            // Write by LineProtocol
+            //
+            String record = "temperature,location=north value=60.0";
+
+            writeApi.writeRecord(WritePrecision.NS, record);
+
+            //
+            // Write by Data Point
+            //
+            Point point = Point.measurement("temperature")
+                    .addTag("location", "west")
+                    .addField("value", 55D)
+                    .time(Instant.now().toEpochMilli(), WritePrecision.MS);
+
+            writeApi.writePoint(point);
+
+            //
+            // Write by POJO
+            //
+            Temperature temperature = new Temperature();
+            temperature.location = "south";
+            temperature.value = 62D;
+            temperature.time = Instant.now();
+
+            writeApi.writeMeasurement(WritePrecision.NS, temperature);
+
+        } catch (InfluxException ie) {
+            System.out.println("InfluxException: " + ie);
+        }
+
+        influxDBClient.close();
+    }
+
+    @Measurement(name = "temperature")
+    private static class Temperature {
+
+        @Column(tag = true)
+        String location;
+
+        @Column
+        Double value;
+
+        @Column(timestamp = true)
+        Instant time;
+    }
+}
+```
+         
+### Asynchronous non-blocking API
+
+> :warning: **The `WriteApi` is supposed to be use as a singleton**: Don't create new instance for every write!
+
 For writing data we use [WriteApi](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApi.html) that is an asynchronous non-blocking API and supports:
 
 1. writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point, POJO 
@@ -359,7 +449,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **bufferLimit** | the maximum number of unwritten stored points | 10000 |
 | **backpressureStrategy** | the strategy to deal with buffer overflow | DROP_OLDEST |
 
-### Backpressure
+#### Backpressure
 The backpressure presents the problem of what to do with a growing backlog of unconsumed data points. 
 The key feature of backpressure is to provide the capability to avoid consuming the unexpected amount of system resources.  
 This situation is not common and can be caused by several problems: generating too much measurements in short interval,
@@ -368,7 +458,7 @@ long term unavailability of the InfluxDB server, network issues.
 The size of backlog is configured by 
 `WriteOptions.bufferLimit` and backpressure strategy by `WriteOptions.backpressureStrategy`.
 
-#### Strategy how react to backlog overflows
+##### Strategy how react to backlog overflows
 - `DROP_OLDEST` - Drop the oldest data points from the backlog 
 - `DROP_LATEST` - Drop the latest data points from the backlog  
 - `ERROR` - Signal a exception
@@ -389,9 +479,9 @@ writeApi.listenEvents(BackpressureEvent.class, value -> {
 
 There is also a synchronous blocking version of `WriteApi` - [WriteApiBlocking](#writing-data-using-synchronous-blocking-api).
 
-### Writing data
+#### Writing data
 
-#### By POJO
+##### By POJO
 
 Write Measurement into specified bucket:
 
@@ -451,7 +541,7 @@ public class WritePojo {
 }
 ```
 
-#### By Data Point
+##### By Data Point
 
 Write Data point into specified bucket:
 
@@ -497,7 +587,7 @@ public class WriteDataPoint {
 }
 ```
 
-#### By LineProtocol
+##### By LineProtocol
 
 Write Line Protocol record into specified bucket:
 
@@ -537,7 +627,7 @@ public class WriteLineProtocol {
 }
 ```
 
-#### Default Tags
+##### Default Tags
 
 Sometimes is useful to store same information in every measurement e.g. `hostname`, `location`, `customer`. 
 The client is able to use static value, system property or env property as a tag value.
@@ -547,7 +637,7 @@ The expressions:
 - `${version}` -  system property
 - `${env.hostname}` - environment property
 
-##### Via Configuration file
+###### Via Configuration file
 
 In a [configuration file](#client-configuration-file) you are able to specify default tags by `influx2.measurement` prefix.
 
@@ -558,7 +648,7 @@ influx2.tags.hostname = ${env.hostname}
 influx2.tags.sensor-version = ${version}
 ```
 
-##### Via API
+###### Via API
 
 ```java
 InfluxDBClientOptions options = InfluxDBClientOptions.builder()
@@ -577,9 +667,9 @@ Both of configurations will produce the Line protocol:
 mine-sensor,id=132-987-655,customer="California Miner",hostname=example.com,sensor-version=v1.00 altitude=10
 ```
 
-### Handle the Events
+#### Handle the Events
 
-#### Handle the Success write
+##### Handle the Success write
 
 ```java
 WriteApi writeApi = influxDBClient.getWriteApi();
@@ -593,7 +683,7 @@ writeApi.listenEvents(WriteSuccessEvent.class, event -> {
 });
 ```
 
-#### Handle the Error Write
+##### Handle the Error Write
 
 ```java
 WriteApi writeApi = influxDBClient.getWriteApi();

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -57,7 +57,7 @@ import com.influxdb.exceptions.UnprocessableEntityException;
 public interface InfluxDBClient extends AutoCloseable {
 
     /**
-     * Get the Query client.
+     * Create a new Query client.
      *
      * @return the new client instance for the Query API
      */
@@ -65,24 +65,55 @@ public interface InfluxDBClient extends AutoCloseable {
     QueryApi getQueryApi();
 
     /**
-     * Get the asynchronous non-blocking Write client.
+     * Create a new asynchronous non-blocking Write client.
+     *
+     * @deprecated use {@link #makeWriteApi()}, the API is subject to removal in a next major release
+     * @return the new client instance for the Write API
+     */
+    @Nonnull
+    @Deprecated
+    WriteApi getWriteApi();
+
+    /**
+     * Create a new asynchronous non-blocking Write client.
+     *
+     * <p>
+     * The {@link WriteApi} uses background thread to ingesting data into InfluxDB and is suppose to run as a singleton.
+     * <b>Don't create new instance for every write.</b>
+     * </p>
      *
      * @return the new client instance for the Write API
      */
     @Nonnull
-    WriteApi getWriteApi();
+    WriteApi makeWriteApi();
 
     /**
-     * Get the asynchronous non-blocking Write client.
+     * Create a new asynchronous non-blocking Write client.
+     *
+     * @param writeOptions the writes configuration
+     * @deprecated use {@link #makeWriteApi(WriteOptions)}, the API is subject to removal in a next major release
+     * @return the new client instance for the Write API
+     */
+    @Nonnull
+    @Deprecated
+    WriteApi getWriteApi(@Nonnull final WriteOptions writeOptions);
+
+    /**
+     * Create a new asynchronous non-blocking Write client.
+     *
+     * <p>
+     * The {@link WriteApi} uses background thread to ingesting data into InfluxDB and is suppose to run as a singleton.
+     * <b>Don't create new instance for every write.</b>
+     * </p>
      *
      * @param writeOptions the writes configuration
      * @return the new client instance for the Write API
      */
     @Nonnull
-    WriteApi getWriteApi(@Nonnull final WriteOptions writeOptions);
+    WriteApi makeWriteApi(@Nonnull final WriteOptions writeOptions);
 
     /**
-     * Get the synchronous blocking Write client.
+     * Create a new synchronous blocking Write client.
      *
      * @return the new client instance for the Write API
      */
@@ -90,7 +121,7 @@ public interface InfluxDBClient extends AutoCloseable {
     WriteApiBlocking getWriteApiBlocking();
 
     /**
-     * Get the {@link Authorization} client.
+     * Create a new {@link Authorization} client.
      *
      * @return the new client instance for Authorization API
      */
@@ -98,7 +129,7 @@ public interface InfluxDBClient extends AutoCloseable {
     AuthorizationsApi getAuthorizationsApi();
 
     /**
-     * Get the {@link Bucket} client.
+     * Create a new {@link Bucket} client.
      *
      * @return the new client instance for Bucket API
      */
@@ -106,7 +137,7 @@ public interface InfluxDBClient extends AutoCloseable {
     BucketsApi getBucketsApi();
 
     /**
-     * Get the {@link Organization} client.
+     * Create a new {@link Organization} client.
      *
      * @return the new client instance for Organization API
      */
@@ -114,7 +145,7 @@ public interface InfluxDBClient extends AutoCloseable {
     OrganizationsApi getOrganizationsApi();
 
     /**
-     * Get the {@link Source} client.
+     * Create a new {@link Source} client.
      *
      * @return the new client instance for Source API
      */
@@ -122,7 +153,7 @@ public interface InfluxDBClient extends AutoCloseable {
     SourcesApi getSourcesApi();
 
     /**
-     * Get the {@link Task} client.
+     * Create a new {@link Task} client.
      *
      * @return the new client instance for Task API
      */
@@ -130,7 +161,7 @@ public interface InfluxDBClient extends AutoCloseable {
     TasksApi getTasksApi();
 
     /**
-     * Get the {@link User} client.
+     * Create a new {@link User} client.
      *
      * @return the new client instance for User API
      */
@@ -138,7 +169,7 @@ public interface InfluxDBClient extends AutoCloseable {
     UsersApi getUsersApi();
 
     /**
-     * Get the {@link ScraperTargetResponse} client.
+     * Create a new {@link ScraperTargetResponse} client.
      *
      * @return the new client instance for Scraper API
      */
@@ -146,7 +177,7 @@ public interface InfluxDBClient extends AutoCloseable {
     ScraperTargetsApi getScraperTargetsApi();
 
     /**
-     * Get the {@link Telegraf} client.
+     * Create a new {@link Telegraf} client.
      *
      * @return the new client instance for Telegrafs API
      */
@@ -154,7 +185,7 @@ public interface InfluxDBClient extends AutoCloseable {
     TelegrafsApi getTelegrafsApi();
 
     /**
-     * Get the {@link Label} client.
+     * Create a new {@link Label} client.
      *
      * @return the new client instance for Label API
      */
@@ -162,7 +193,7 @@ public interface InfluxDBClient extends AutoCloseable {
     LabelsApi getLabelsApi();
 
     /**
-     * Get the {@link Document} client.
+     * Create a new {@link Document} client.
      *
      * @return the new client instance for Template API
      */
@@ -170,7 +201,7 @@ public interface InfluxDBClient extends AutoCloseable {
     TemplatesApi getTemplatesApi();
 
     /**
-     * Get the {@link Variable} client.
+     * Create a new {@link Variable} client.
      *
      * @return the new client instance for Variable API
      */
@@ -178,7 +209,7 @@ public interface InfluxDBClient extends AutoCloseable {
     VariablesApi getVariablesApi();
 
     /**
-     * Get the {@link Dashboard} client.
+     * Create a new {@link Dashboard} client.
      *
      * @return the new client instance for Dashboard API
      */
@@ -186,7 +217,7 @@ public interface InfluxDBClient extends AutoCloseable {
     DashboardsApi getDashboardsApi();
 
     /**
-     * Get the {@link Check} client.
+     * Create a new {@link Check} client.
      *
      * @return the new client instance for Checks API
      */
@@ -194,7 +225,7 @@ public interface InfluxDBClient extends AutoCloseable {
     ChecksApi getChecksApi();
 
     /**
-     * Get the {@link NotificationEndpoint} client.
+     * Create a new {@link NotificationEndpoint} client.
      *
      * @return the new client instance for NotificationEndpoint API
      */
@@ -202,7 +233,7 @@ public interface InfluxDBClient extends AutoCloseable {
     NotificationEndpointsApi getNotificationEndpointsApi();
 
     /**
-     * Get the {@link NotificationRules} client.
+     * Create a new {@link NotificationRules} client.
      *
      * @return the new client instance for NotificationRules API
      */
@@ -210,7 +241,7 @@ public interface InfluxDBClient extends AutoCloseable {
     NotificationRulesApi getNotificationRulesApi();
 
     /**
-     * Get the Delete client.
+     * Create a new Delete client.
      *
      * @return the new client instance for the Delete API
      */

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -67,6 +67,11 @@ public interface InfluxDBClient extends AutoCloseable {
     /**
      * Create a new asynchronous non-blocking Write client.
      *
+     * <p>
+     * The {@link WriteApi} uses background thread to ingesting data into InfluxDB and is suppose to run as a singleton.
+     * <b>Don't create new instance for every write.</b>
+     * </p>
+     *
      * @deprecated use {@link #makeWriteApi()}, the API is subject to removal in a next major release
      * @return the new client instance for the Write API
      */

--- a/client/src/main/java/com/influxdb/client/WriteApi.java
+++ b/client/src/main/java/com/influxdb/client/WriteApi.java
@@ -42,6 +42,10 @@ import com.influxdb.client.write.events.WriteSuccessEvent;
  * The data are formatted in <a href="https://bit.ly/line-protocol">Line Protocol</a>.
  * <p>
  *
+ * <b>
+ *     The {@link WriteApi} uses background thread to ingesting data into InfluxDB and is suppose to run as a singleton.
+ * </b>
+ *
  * @author Jakub Bednar (bednar@github) (20/09/2018 10:58)
  */
 @ThreadSafe

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -129,8 +129,16 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
 
     @Nonnull
     @Override
+    @SuppressWarnings("MagicNumber")
     public WriteApi makeWriteApi(@Nonnull final WriteOptions writeOptions) {
         Arguments.checkNotNull(writeOptions, "WriteOptions");
+
+        if (autoCloseables.size() >= 10) {
+            String format = "There is already created %d instances of 'WriteApi'. "
+                    + "The 'WriteApi' is suppose to run as a singleton and should be reused across threads. "
+                    + "Use 'WriteApiBlocking` if you would like to use one-time ingesting.";
+            LOG.warning(String.format(format, autoCloseables.size()));
+        }
 
         return new WriteApiImpl(writeOptions, retrofit.create(WriteService.class), options, autoCloseables);
     }

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -109,13 +109,27 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
     @Nonnull
     @Override
     public WriteApi getWriteApi() {
-        return getWriteApi(WriteOptions.DEFAULTS);
+        return makeWriteApi();
     }
 
     @Nonnull
     @Override
     public WriteApi getWriteApi(@Nonnull final WriteOptions writeOptions) {
 
+        Arguments.checkNotNull(writeOptions, "WriteOptions");
+
+        return makeWriteApi(writeOptions);
+    }
+
+    @Nonnull
+    @Override
+    public WriteApi makeWriteApi() {
+        return makeWriteApi(WriteOptions.DEFAULTS);
+    }
+
+    @Nonnull
+    @Override
+    public WriteApi makeWriteApi(@Nonnull final WriteOptions writeOptions) {
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 
         return new WriteApiImpl(writeOptions, retrofit.create(WriteService.class), options, autoCloseables);

--- a/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
@@ -113,7 +113,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -149,7 +149,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -187,7 +187,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
     void writeErrorListenerTest () {
         String bucketName = "non_existing_bucket";
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -208,7 +208,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -230,7 +230,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -252,7 +252,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -274,7 +274,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -308,7 +308,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -341,7 +341,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -367,7 +367,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -448,7 +448,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
                 .addField("water_level", 1)
                 .time(Instant.now(), WritePrecision.MS);
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -465,7 +465,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(100_000)
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(100_000)
                 .flushInterval(100_000).build());
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
@@ -489,7 +489,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(100_000)
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(100_000)
                 .flushInterval(500).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
@@ -519,7 +519,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(6)
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(6)
                 .flushInterval(100_000).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
@@ -553,7 +553,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1)
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1)
                 .jitterInterval(4_000)
                 .build());
 
@@ -577,7 +577,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
         String record2 = "h2o_feet,location=coyote_hill level\\ water_level=2.0 2x";
@@ -596,7 +596,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteErrorEvent> errorListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, errorListener);
 
@@ -640,7 +640,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         influxDBClient = InfluxDBClientFactory.create(options);
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -684,7 +684,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         influxDBClient = InfluxDBClientFactory.create(options);
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -724,7 +724,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         influxDBClient = InfluxDBClientFactory.create(options);
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -755,7 +755,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -791,7 +791,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         InfluxDBClient client = InfluxDBClientFactory.create(influxDB_URL, token.toCharArray());
 
-        WriteApi writeApi = client.getWriteApi();
+        WriteApi writeApi = client.makeWriteApi();
 
         writeApi.writeRecord(bucket.getName(), organization.getId(), WritePrecision.NS, "temperature,location=north value=60.0 1");
 
@@ -810,7 +810,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
 
         InfluxDBClient client = InfluxDBClientFactory.create(influxDB_URL, token.toCharArray(), organization.getId(), bucket.getName());
 
-        WriteApi writeApi = client.getWriteApi();
+        WriteApi writeApi = client.makeWriteApi();
 
         writeApi.writeRecord(WritePrecision.NS, "temperature,location=north value=60.0 1");
         writeApi.close();

--- a/client/src/test/java/com/influxdb/client/ITWriteTooManyData.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteTooManyData.java
@@ -60,7 +60,7 @@ class ITWriteTooManyData extends AbstractITWrite {
         List<AbstractWriteEvent> events = new CopyOnWriteArrayList<>();
 
         WriteApi api = influxDBClient
-                .getWriteApi(WriteOptions.builder().batchSize(BATCH_SIZE).flushInterval(1_000_000).build());
+                .makeWriteApi(WriteOptions.builder().batchSize(BATCH_SIZE).flushInterval(1_000_000).build());
 
         api.listenEvents(AbstractWriteEvent.class, events::add)                        ;
 

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
@@ -48,8 +48,8 @@ class InfluxDBClientTest extends AbstractInfluxDBClientTest {
     @Test
     void createWriteClient() {
 
-        Assertions.assertThat(influxDBClient.getWriteApi()).isNotNull();
-        Assertions.assertThat(influxDBClient.getWriteApi(WriteOptions.DEFAULTS)).isNotNull();
+        Assertions.assertThat(influxDBClient.makeWriteApi()).isNotNull();
+        Assertions.assertThat(influxDBClient.makeWriteApi(WriteOptions.DEFAULTS)).isNotNull();
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -85,7 +85,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writePoint("b1", "org1", Point.measurement("h2o").addTag("location", "europe").addField("level", 2));
 
@@ -107,7 +107,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writePoint("b1", "org1", null);
 
@@ -120,7 +120,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         Point point1 = Point.measurement("h2o").addTag("location", "europe").addField("level", 1).time(1L, WritePrecision.MS);
         Point point2 = Point.measurement("h2o").addTag("location", "europe").addField("level", 2).time(2L, WritePrecision.S);
@@ -146,7 +146,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(new MockResponse());
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         H2OFeetMeasurement measurement = new H2OFeetMeasurement(
                 "coyote_creek", 2.927, "below 3 feet", 1440046800L);
@@ -172,7 +172,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(new MockResponse());
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         Metric measurement = new Visitor();
         //noinspection CastCanBeRemovedNarrowingVariableType
@@ -200,7 +200,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writeMeasurement("b1", "org1", WritePrecision.S, null);
 
@@ -210,7 +210,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
     @Test
     void writeMeasurementWhichIsNotMappableToPoint() {
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         WriteEventListener<WriteErrorEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, listener);
 
@@ -230,7 +230,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
     @Test
     void writeMeasurements() throws InterruptedException {
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         mockServer.enqueue(new MockResponse());
         mockServer.enqueue(new MockResponse());
@@ -263,7 +263,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writeRecord("b1", "org1", WritePrecision.NS,
                 "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1");
@@ -281,7 +281,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
     @Test
     void emptyRequest() {
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         WriteEventListener<WriteErrorEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, listener);
@@ -303,7 +303,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1";
         writeApi.writeRecord("b1", "org1", WritePrecision.NS, record1);
@@ -336,7 +336,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         enqueuedResponse();
         enqueuedResponse();
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().flushInterval(10_000).batchSize(2).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().flushInterval(10_000).batchSize(2).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1";
         String record2 = "h2o_feet,location=coyote_creek level\\ description=\"feet 2\",water_level=2.0 2";
@@ -360,7 +360,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).flushInterval(10_00000).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).flushInterval(10_00000).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1";
         String record2 = "h2o_feet,location=coyote_creek level\\ description=\"feet 2\",water_level=2.0 2";
@@ -393,7 +393,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createResponse("{}"));
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         String record1 = "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1";
         String record2 = "h2o_feet,location=coyote_creek level\\ description=\"feet 2\",water_level=2.0 2";
@@ -436,7 +436,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
                 .flushInterval(100_000_000)
                 .build();
 
-        writeApi = influxDBClient.getWriteApi(writeOptions);
+        writeApi = influxDBClient.makeWriteApi(writeOptions);
 
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
@@ -463,7 +463,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
                 .writeScheduler(scheduler)
                 .build();
 
-        writeApi = influxDBClient.getWriteApi(writeOptions);
+        writeApi = influxDBClient.makeWriteApi(writeOptions);
         
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
@@ -494,7 +494,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
                 .writeScheduler(scheduler)
                 .build();
 
-        writeApi = influxDBClient.getWriteApi(writeOptions);
+        writeApi = influxDBClient.makeWriteApi(writeOptions);
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
 
@@ -521,7 +521,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writeRecord("b1", "org1", WritePrecision.NS,
                 "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1");
@@ -541,7 +541,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener);
@@ -569,7 +569,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         WriteEventListener<WriteSuccessEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, listener).dispose();
@@ -589,7 +589,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createErrorResponse("no token was sent and they are required", true, 403));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
         WriteEventListener<WriteErrorEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, listener);
 
@@ -614,7 +614,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createErrorResponse("token is temporarily over quota", true, 429));
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writePoint("b1", "org1", Point.measurement("h2o").addTag("location", "europe").addField("level", 2));
 
@@ -636,7 +636,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(errorResponse);
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         WriteEventListener<WriteRetriableErrorEvent> retriableListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteRetriableErrorEvent.class, retriableListener);
@@ -675,7 +675,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(errorResponse);
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).maxRetryTime(500).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).maxRetryTime(500).build());
 
         WriteEventListener<WriteErrorEvent> errorListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, errorListener);
@@ -708,7 +708,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         //create delayed success response
         mockServer.enqueue(createResponse("{}", "text/csv", true, 3000));
         //write api with retry timeout does not affect normal requests
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).maxRetryTime(2000).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).maxRetryTime(2000).build());
 
         WriteEventListener<WriteSuccessEvent> successListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteSuccessEvent.class, successListener);
@@ -730,7 +730,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createResponse("{}"));
 
         int retryInterval = 100;
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).retryInterval(retryInterval).maxRetryTime(3000).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).retryInterval(retryInterval).maxRetryTime(3000).build());
 
         WriteEventListener<WriteRetriableErrorEvent> retriableListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteRetriableErrorEvent.class, retriableListener);
@@ -778,7 +778,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(createErrorResponse("no token was sent and they are required", true, 403));
         mockServer.enqueue(createErrorResponse("write has been rejected because the payload is too large. Error message returns max size supported. All data in body was rejected and not written", true, 413));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         WriteEventListener<WriteErrorEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteErrorEvent.class, listener);
@@ -842,7 +842,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
                 .maxRetryDelay(3_000)
                 .maxRetries(3)
                 .build();
-        writeApi = influxDBClient.getWriteApi(options);
+        writeApi = influxDBClient.makeWriteApi(options);
 
         WriteEventListener<WriteRetriableErrorEvent> retriableListener = new WriteEventListener<>();
         writeApi.listenEvents(WriteRetriableErrorEvent.class, retriableListener);
@@ -866,7 +866,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         mockServer.enqueue(errorResponse);
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         WriteEventListener<WriteRetriableErrorEvent> listener = new WriteEventListener<>();
         writeApi.listenEvents(WriteRetriableErrorEvent.class, listener);
@@ -899,7 +899,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         influxDBClient = InfluxDBClientFactory.create(options);
 
-        writeApi = influxDBClient.getWriteApi(WriteOptions.builder().batchSize(1).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1).build());
 
         // Points
         mockServer.enqueue(createResponse("{}"));
@@ -973,7 +973,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
     @Test
     public void callingClose() {
         
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
         writeApi.close();
         writeApi.close();
 
@@ -985,14 +985,14 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
     @Test
     public void writeToClosedClient() {
         
-        WriteApi writeApiSelfClose = influxDBClient.getWriteApi();
+        WriteApi writeApiSelfClose = influxDBClient.makeWriteApi();
         writeApiSelfClose.close();
 
         Assertions.assertThatThrownBy(() -> writeApiSelfClose.writeRecord("b1", "org1", WritePrecision.NS,"h2o_feet water_level=1.0 1"))
                 .isInstanceOf(InfluxException.class)
                 .hasMessage("WriteApi is closed. Data should be written before calling InfluxDBClient.close or WriteApi.close.");
 
-        WriteApi writeApiClientClose = influxDBClient.getWriteApi();
+        WriteApi writeApiClientClose = influxDBClient.makeWriteApi();
         influxDBClient.close();
 
         Assertions.assertThatThrownBy(() -> writeApiClientClose.writePoint("b1", "org1", Point.measurement("h2o").addField("level", 1)))
@@ -1005,7 +1005,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         mockServer.enqueue(createResponse("{}"));
 
-        writeApi = influxDBClient.getWriteApi();
+        writeApi = influxDBClient.makeWriteApi();
 
         writeApi.writeRecord("b1", "org1", WritePrecision.NS, "h2o,location=coyote_creek level\\ description=\"below 3 feet\",water_level=2.927 1440046800000000");
 

--- a/examples/src/main/java/example/InfluxDB18Example.java
+++ b/examples/src/main/java/example/InfluxDB18Example.java
@@ -47,7 +47,7 @@ public class InfluxDB18Example {
 
         System.out.println("*** Write Points ***");
 
-        try (WriteApi writeApi = client.getWriteApi()) {
+        try (WriteApi writeApi = client.makeWriteApi()) {
 
             Point point = Point.measurement("mem")
                     .addTag("host", "host1")

--- a/examples/src/main/java/example/InfluxDB2Example.java
+++ b/examples/src/main/java/example/InfluxDB2Example.java
@@ -29,7 +29,7 @@ import com.influxdb.annotations.Measurement;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.QueryApi;
-import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import com.influxdb.query.FluxRecord;
@@ -48,33 +48,32 @@ public class InfluxDB2Example {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
 
-            //
-            // Write by Data Point
-            //
-            Point point = Point.measurement("temperature")
-                    .addTag("location", "west")
-                    .addField("value", 55D)
-                    .time(Instant.now().toEpochMilli(), WritePrecision.MS);
+        //
+        // Write by Data Point
+        //
+        Point point = Point.measurement("temperature")
+                .addTag("location", "west")
+                .addField("value", 55D)
+                .time(Instant.now().toEpochMilli(), WritePrecision.MS);
 
-            writeApi.writePoint(point);
+        writeApi.writePoint(point);
 
-            //
-            // Write by LineProtocol
-            //
-            writeApi.writeRecord(WritePrecision.NS, "temperature,location=north value=60.0");
+        //
+        // Write by LineProtocol
+        //
+        writeApi.writeRecord(WritePrecision.NS, "temperature,location=north value=60.0");
 
-            //
-            // Write by POJO
-            //
-            Temperature temperature = new Temperature();
-            temperature.location = "south";
-            temperature.value = 62D;
-            temperature.time = Instant.now();
+        //
+        // Write by POJO
+        //
+        Temperature temperature = new Temperature();
+        temperature.location = "south";
+        temperature.value = 62D;
+        temperature.time = Instant.now();
 
-            writeApi.writeMeasurement( WritePrecision.NS, temperature);
-        }
+        writeApi.writeMeasurement( WritePrecision.NS, temperature);
 
         //
         // Query data

--- a/examples/src/main/java/example/PlatformExample.java
+++ b/examples/src/main/java/example/PlatformExample.java
@@ -115,7 +115,7 @@ public class PlatformExample {
         //
         // Write data
         //
-        try (WriteApi writeApi = client.getWriteApi(WriteOptions.builder()
+        try (WriteApi writeApi = client.makeWriteApi(WriteOptions.builder()
                 .batchSize(5000)
                 .flushInterval(1000)
                 .backpressureStrategy(BackpressureOverflowStrategy.DROP_OLDEST)

--- a/examples/src/main/java/example/WriteDataEverySecond.java
+++ b/examples/src/main/java/example/WriteDataEverySecond.java
@@ -73,7 +73,7 @@ public class WriteDataEverySecond {
         //
         // Initialize write API with flush interval to 5sec
         //
-        WriteApi writeApi = client.getWriteApi(WriteOptions.builder().flushInterval(5_000).build());
+        WriteApi writeApi = client.makeWriteApi(WriteOptions.builder().flushInterval(5_000).build());
 
         //
         // Produce DataPoint every seconds and pass it to WriteApi

--- a/examples/src/main/java/example/WriteDataPoint.java
+++ b/examples/src/main/java/example/WriteDataPoint.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 
@@ -42,18 +43,17 @@ public class WriteDataPoint {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
 
-            //
-            // Write by Data Point
-            //
-            Point point = Point.measurement("temperature")
-                    .addTag("location", "west")
-                    .addField("value", 55D)
-                    .time(Instant.now().toEpochMilli(), WritePrecision.MS);
+        //
+        // Write by Data Point
+        //
+        Point point = Point.measurement("temperature")
+                .addTag("location", "west")
+                .addField("value", 55D)
+                .time(Instant.now().toEpochMilli(), WritePrecision.MS);
 
-            writeApi.writePoint(point);
-        }
+        writeApi.writePoint(point);
 
         influxDBClient.close();
     }

--- a/examples/src/main/java/example/WriteLineProtocol.java
+++ b/examples/src/main/java/example/WriteLineProtocol.java
@@ -24,6 +24,7 @@ package example;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 
 public class WriteLineProtocol {
@@ -39,15 +40,14 @@ public class WriteLineProtocol {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
 
-            //
-            // Write by LineProtocol
-            //
-            String record = "temperature,location=north value=60.0";
+        //
+        // Write by LineProtocol
+        //
+        String record = "temperature,location=north value=60.0";
 
-            writeApi.writeRecord(WritePrecision.NS, record);
-        }
+        writeApi.writeRecord(WritePrecision.NS, record);
 
         influxDBClient.close();
     }

--- a/examples/src/main/java/example/WritePojo.java
+++ b/examples/src/main/java/example/WritePojo.java
@@ -28,6 +28,7 @@ import com.influxdb.annotations.Measurement;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 
 public class WritePojo {
@@ -43,18 +44,17 @@ public class WritePojo {
         //
         // Write data
         //
-        try (WriteApi writeApi = influxDBClient.getWriteApi()) {
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
 
-            //
-            // Write by POJO
-            //
-            Temperature temperature = new Temperature();
-            temperature.location = "south";
-            temperature.value = 62D;
-            temperature.time = Instant.now();
+        //
+        // Write by POJO
+        //
+        Temperature temperature = new Temperature();
+        temperature.location = "south";
+        temperature.value = 62D;
+        temperature.time = Instant.now();
 
-            writeApi.writeMeasurement(WritePrecision.NS, temperature);
-        }
+        writeApi.writeMeasurement(WritePrecision.NS, temperature);
 
         influxDBClient.close();
     }


### PR DESCRIPTION
Closes #167

## Proposed Changes

1. Deprecated `com.influxdb.client.InfluxDBClient#getWriteApi()` to use `com.influxdb.client.InfluxDBClient#makeWriteApi()`
1. Use `WriteApiBlocking` in simple examples
1. Added warning if there is to much created `WriteApi` instances: 
> There is already created 10 instances of 'WriteApi'. The 'WriteApi' is suppose to run as a singleton and should be reused across threads.  Use 'WriteApiBlocking` if you would like to use one-time ingesting.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
