### PR TITLE
fix: avoid requirements to jdk.unsupported module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 3.3.0 [unreleased]
+                                                                     
+### Bug Fixes
+1. [#258](https://github.com/influxdata/influxdb-client-java/pull/258): Avoid requirements to `jdk.unsupported` module
+
+### Dependencies
+1. [#258](https://github.com/influxdata/influxdb-client-java/pull/258): Update dependencies:
+    - Gson to 2.8.8
 
 ## 3.2.0 [2021-08-20]
 

--- a/client/src/generated/java/com/influxdb/client/JSON.java
+++ b/client/src/generated/java/com/influxdb/client/JSON.java
@@ -47,7 +47,6 @@ import java.util.HashMap;
 public class JSON {
     private Gson gson;
     private DateTypeAdapter dateTypeAdapter = new DateTypeAdapter();
-    private SqlDateTypeAdapter sqlDateTypeAdapter = new SqlDateTypeAdapter();
     private OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter();
     private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
 
@@ -174,7 +173,6 @@ public class JSON {
     public JSON() {
         gson = createGson()
             .registerTypeAdapter(Date.class, dateTypeAdapter)
-            .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
             .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
             .create();
@@ -304,60 +302,6 @@ public class JSON {
         return this;
     }
 
-    /**
-     * Gson TypeAdapter for java.sql.Date type
-     * If the dateFormat is null, a simple "yyyy-MM-dd" format will be used
-     * (more efficient than SimpleDateFormat).
-     */
-    public static class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
-
-        private DateFormat dateFormat;
-
-        public SqlDateTypeAdapter() {
-        }
-
-        public SqlDateTypeAdapter(DateFormat dateFormat) {
-            this.dateFormat = dateFormat;
-        }
-
-        public void setFormat(DateFormat dateFormat) {
-            this.dateFormat = dateFormat;
-        }
-
-        @Override
-        public void write(JsonWriter out, java.sql.Date date) throws IOException {
-            if (date == null) {
-                out.nullValue();
-            } else {
-                String value;
-                if (dateFormat != null) {
-                    value = dateFormat.format(date);
-                } else {
-                    value = date.toString();
-                }
-                out.value(value);
-            }
-        }
-
-        @Override
-        public java.sql.Date read(JsonReader in) throws IOException {
-            switch (in.peek()) {
-                case NULL:
-                    in.nextNull();
-                    return null;
-                default:
-                    String date = in.nextString();
-                    try {
-                        if (dateFormat != null) {
-                            return new java.sql.Date(dateFormat.parse(date).getTime());
-                        }
-                        return new java.sql.Date(ISO8601Utils.parse(date, new ParsePosition(0)).getTime());
-                    } catch (ParseException e) {
-                        throw new JsonParseException(e);
-                    }
-            }
-        }
-    }
 
     /**
      * Gson TypeAdapter for java.util.Date type
@@ -421,10 +365,4 @@ public class JSON {
         dateTypeAdapter.setFormat(dateFormat);
         return this;
     }
-
-    public JSON setSqlDateFormat(DateFormat dateFormat) {
-        sqlDateTypeAdapter.setFormat(dateFormat);
-        return this;
-    }
-
 }

--- a/client/src/generated/java/com/influxdb/client/JSON.java
+++ b/client/src/generated/java/com/influxdb/client/JSON.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 public class JSON {
     private Gson gson;
     private DateTypeAdapter dateTypeAdapter = new DateTypeAdapter();
+    private SqlDateTypeAdapter sqlDateTypeAdapter = new SqlDateTypeAdapter();
     private OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter();
     private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
 
@@ -173,6 +174,7 @@ public class JSON {
     public JSON() {
         gson = createGson()
             .registerTypeAdapter(Date.class, dateTypeAdapter)
+            .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
             .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
             .create();
@@ -302,6 +304,60 @@ public class JSON {
         return this;
     }
 
+    /**
+     * Gson TypeAdapter for java.sql.Date type
+     * If the dateFormat is null, a simple "yyyy-MM-dd" format will be used
+     * (more efficient than SimpleDateFormat).
+     */
+    public static class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
+
+        private DateFormat dateFormat;
+
+        public SqlDateTypeAdapter() {
+        }
+
+        public SqlDateTypeAdapter(DateFormat dateFormat) {
+            this.dateFormat = dateFormat;
+        }
+
+        public void setFormat(DateFormat dateFormat) {
+            this.dateFormat = dateFormat;
+        }
+
+        @Override
+        public void write(JsonWriter out, java.sql.Date date) throws IOException {
+            if (date == null) {
+                out.nullValue();
+            } else {
+                String value;
+                if (dateFormat != null) {
+                    value = dateFormat.format(date);
+                } else {
+                    value = date.toString();
+                }
+                out.value(value);
+            }
+        }
+
+        @Override
+        public java.sql.Date read(JsonReader in) throws IOException {
+            switch (in.peek()) {
+                case NULL:
+                    in.nextNull();
+                    return null;
+                default:
+                    String date = in.nextString();
+                    try {
+                        if (dateFormat != null) {
+                            return new java.sql.Date(dateFormat.parse(date).getTime());
+                        }
+                        return new java.sql.Date(ISO8601Utils.parse(date, new ParsePosition(0)).getTime());
+                    } catch (ParseException e) {
+                        throw new JsonParseException(e);
+                    }
+            }
+        }
+    }
 
     /**
      * Gson TypeAdapter for java.util.Date type
@@ -365,4 +421,10 @@ public class JSON {
         dateTypeAdapter.setFormat(dateFormat);
         return this;
     }
+
+    public JSON setSqlDateFormat(DateFormat dateFormat) {
+        sqlDateTypeAdapter.setFormat(dateFormat);
+        return this;
+    }
+
 }

--- a/client/src/generated/java/com/influxdb/client/domain/ArrayExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/ArrayExpression.java
@@ -138,7 +138,7 @@ public class ArrayExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ArrayExpressionElementsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ArrayExpressionElementsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ArrayExpressionElementsAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/BinaryExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/BinaryExpression.java
@@ -179,7 +179,7 @@ public class BinaryExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class BinaryExpressionLeftAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class BinaryExpressionLeftAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public BinaryExpressionLeftAdapter() {
     }
@@ -277,7 +277,7 @@ public class BinaryExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class BinaryExpressionRightAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class BinaryExpressionRightAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public BinaryExpressionRightAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/Block.java
+++ b/client/src/generated/java/com/influxdb/client/domain/Block.java
@@ -138,7 +138,7 @@ public class Block extends Node {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class BlockBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class BlockBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public BlockBodyAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/CallExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/CallExpression.java
@@ -163,7 +163,7 @@ public class CallExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class CallExpressionArgumentsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class CallExpressionArgumentsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public CallExpressionArgumentsAdapter() {
     }
@@ -267,7 +267,7 @@ public class CallExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class CallExpressionCalleeAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class CallExpressionCalleeAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public CallExpressionCalleeAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/ConditionalExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/ConditionalExpression.java
@@ -180,7 +180,7 @@ public class ConditionalExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ConditionalExpressionAlternateAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ConditionalExpressionAlternateAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ConditionalExpressionAlternateAdapter() {
     }
@@ -278,7 +278,7 @@ public class ConditionalExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class ConditionalExpressionTestAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ConditionalExpressionTestAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ConditionalExpressionTestAdapter() {
     }
@@ -376,7 +376,7 @@ public class ConditionalExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class ConditionalExpressionConsequentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ConditionalExpressionConsequentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ConditionalExpressionConsequentAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/DictItem.java
+++ b/client/src/generated/java/com/influxdb/client/domain/DictItem.java
@@ -153,7 +153,7 @@ public class DictItem {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class DictItemValAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class DictItemValAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public DictItemValAdapter() {
     }
@@ -251,7 +251,7 @@ public class DictItem {
       return context.deserialize(json, Object.class);
     }
   }
-  public class DictItemKeyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class DictItemKeyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public DictItemKeyAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/ExpressionStatement.java
+++ b/client/src/generated/java/com/influxdb/client/domain/ExpressionStatement.java
@@ -130,7 +130,7 @@ public class ExpressionStatement extends Statement {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ExpressionStatementExpressionAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ExpressionStatementExpressionAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ExpressionStatementExpressionAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/File.java
+++ b/client/src/generated/java/com/influxdb/client/domain/File.java
@@ -218,7 +218,7 @@ public class File {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class FileBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class FileBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public FileBodyAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/FunctionExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/FunctionExpression.java
@@ -163,7 +163,7 @@ public class FunctionExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class FunctionExpressionBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class FunctionExpressionBodyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public FunctionExpressionBodyAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/IndexExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/IndexExpression.java
@@ -155,7 +155,7 @@ public class IndexExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class IndexExpressionArrayAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class IndexExpressionArrayAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public IndexExpressionArrayAdapter() {
     }
@@ -253,7 +253,7 @@ public class IndexExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class IndexExpressionIndexAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class IndexExpressionIndexAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public IndexExpressionIndexAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/LogicalExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/LogicalExpression.java
@@ -179,7 +179,7 @@ public class LogicalExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class LogicalExpressionLeftAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class LogicalExpressionLeftAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public LogicalExpressionLeftAdapter() {
     }
@@ -277,7 +277,7 @@ public class LogicalExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class LogicalExpressionRightAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class LogicalExpressionRightAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public LogicalExpressionRightAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/MemberAssignment.java
+++ b/client/src/generated/java/com/influxdb/client/domain/MemberAssignment.java
@@ -155,7 +155,7 @@ public class MemberAssignment extends Statement {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class MemberAssignmentInitAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class MemberAssignmentInitAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public MemberAssignmentInitAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/MemberExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/MemberExpression.java
@@ -156,7 +156,7 @@ public class MemberExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class MemberExpressionPropertyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class MemberExpressionPropertyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public MemberExpressionPropertyAdapter() {
     }
@@ -191,7 +191,7 @@ public class MemberExpression extends Expression {
       return context.deserialize(json, Object.class);
     }
   }
-  public class MemberExpressionObjectAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class MemberExpressionObjectAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public MemberExpressionObjectAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/OptionStatement.java
+++ b/client/src/generated/java/com/influxdb/client/domain/OptionStatement.java
@@ -129,7 +129,7 @@ public class OptionStatement extends Statement {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class OptionStatementAssignmentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class OptionStatementAssignmentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public OptionStatementAssignmentAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/ParenExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/ParenExpression.java
@@ -130,7 +130,7 @@ public class ParenExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ParenExpressionExpressionAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ParenExpressionExpressionAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ParenExpressionExpressionAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/PipeExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/PipeExpression.java
@@ -155,7 +155,7 @@ public class PipeExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class PipeExpressionArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class PipeExpressionArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public PipeExpressionArgumentAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/Property.java
+++ b/client/src/generated/java/com/influxdb/client/domain/Property.java
@@ -154,7 +154,7 @@ public class Property {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class PropertyKeyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class PropertyKeyAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public PropertyKeyAdapter() {
     }
@@ -189,7 +189,7 @@ public class Property {
       return context.deserialize(json, Object.class);
     }
   }
-  public class PropertyValueAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class PropertyValueAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public PropertyValueAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/ReturnStatement.java
+++ b/client/src/generated/java/com/influxdb/client/domain/ReturnStatement.java
@@ -130,7 +130,7 @@ public class ReturnStatement extends Statement {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ReturnStatementArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ReturnStatementArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ReturnStatementArgumentAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/UnaryExpression.java
+++ b/client/src/generated/java/com/influxdb/client/domain/UnaryExpression.java
@@ -154,7 +154,7 @@ public class UnaryExpression extends Expression {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class UnaryExpressionArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class UnaryExpressionArgumentAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public UnaryExpressionArgumentAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/Variable.java
+++ b/client/src/generated/java/com/influxdb/client/domain/Variable.java
@@ -329,7 +329,7 @@ public class Variable {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class VariableArgumentsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class VariableArgumentsAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public VariableArgumentsAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/VariableAssignment.java
+++ b/client/src/generated/java/com/influxdb/client/domain/VariableAssignment.java
@@ -155,7 +155,7 @@ public class VariableAssignment extends Statement {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class VariableAssignmentInitAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class VariableAssignmentInitAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public VariableAssignmentInitAdapter() {
     }

--- a/client/src/generated/java/com/influxdb/client/domain/View.java
+++ b/client/src/generated/java/com/influxdb/client/domain/View.java
@@ -167,7 +167,7 @@ public class View {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public class ViewPropertiesAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
+  public static class ViewPropertiesAdapter implements JsonDeserializer<Object>, JsonSerializer<Object> {
 
     public ViewPropertiesAdapter() {
     }

--- a/client/src/test/java/com/influxdb/client/GeneratedCodeTest.java
+++ b/client/src/test/java/com/influxdb/client/GeneratedCodeTest.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client;
+
+import com.influxdb.client.domain.File;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jakub Bednar (26/08/2021 6:24)
+ */
+@RunWith(JUnitPlatform.class)
+class GeneratedCodeTest {
+    @Test
+    void adapterCanBeInstantiateWithoutParameters() {
+        Assertions.assertThat(new File.FileBodyAdapter()).isNotNull();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
         <dependency.retrofit.version>2.9.0</dependency.retrofit.version>
         <dependency.okhttp3.version>4.7.2</dependency.okhttp3.version>
-        <dependency.gson.version>2.8.5</dependency.gson.version>
+        <dependency.gson.version>2.8.8</dependency.gson.version>
 
         <plugin.surefire.version>2.22.2</plugin.surefire.version>
         <plugin.javadoc.version>3.2.0</plugin.javadoc.version>


### PR DESCRIPTION
Closes #256

## Proposed Changes

1. Avoid requirements to `jdk.unsupported` module. workaround: `--add-modules jdk.unsupported`
2. Update GSON to 2.8.8:
![image](https://user-images.githubusercontent.com/455137/130899993-cd20f9da-c96f-4309-b903-f2df676b4c48.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
