### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
     parameters:
       maven-image:
         type: string
-        default: &default-maven-image "circleci/openjdk:8"
+        default: &default-maven-image "cimg/openjdk:8.0"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -182,10 +182,10 @@ workflows:
           name: jdk-8
       - tests-java:
           name: jdk-11
-          maven-image: "circleci/openjdk:11"
+          maven-image: "cimg/openjdk:11.0"
       - tests-java:
           name: jdk-16
-          maven-image: "circleci/openjdk:16-buster"
+          maven-image: "cimg/openjdk:16.0"
       - tests-java:
           name: jdk-8-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
@@ -210,4 +210,4 @@ workflows:
       - tests-java
       - tests-java:
           name: jdk-11-beta
-          maven-image: "circleci/openjdk:11"
+          maven-image: "cimg/openjdk:11.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 1. [#258](https://github.com/influxdata/influxdb-client-java/pull/258): Update dependencies:
     - Gson to 2.8.8
 
+### CI
+1. [#266](https://github.com/influxdata/influxdb-client-java/pull/266): Switch to next-gen CircleCI's convenience images
+ 
 ## 3.2.0 [2021-08-20]
 
 ### Bug Fixes


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:

- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
