### PR TITLE
chore: use JDK 17 as the latest supported JDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,8 +184,8 @@ workflows:
           name: jdk-11
           maven-image: "cimg/openjdk:11.0"
       - tests-java:
-          name: jdk-16
-          maven-image: "cimg/openjdk:16.0"
+          name: jdk-17
+          maven-image: "cimg/openjdk:17.0"
       - tests-java:
           name: jdk-8-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.4.0 [unreleased]
+
+### CI
+1. [#267](https://github.com/influxdata/influxdb-client-java/pull/267): Add JDK 17 (LTS) to CI pipeline instead of JDK 16
                                                                      
 ## 3.3.0 [2021-09-17]
                                                                      


### PR DESCRIPTION
## Proposed Changes

Added JDK 17 (LTS) to CI pipeline instead of JDK 16.

## Checklist

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
