### PR TITLE
fix: `influxdb-client-utils` uses different package then `influxdb-client-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.5.0 [unreleased]
+## 4.0.0 [unreleased]
+
+### Breaking Changes
+
+The `Arguments` helper moved from package `com.influxdb` to package `com.influxdb.utils`.
 
 ### Deprecates
 - `InfluxDBClient.health()`: instead use `InfluxDBClient.ping()`
@@ -7,6 +11,9 @@
 
 ### Features
 1. [#272](https://github.com/influxdata/influxdb-client-java/pull/272): Add `PingService` to check status of OSS and Cloud instance
+
+### Bug Fixes
+1. [#276](https://github.com/influxdata/influxdb-client-java/pull/276): `influxdb-client-utils` uses different package then `influxdb-client-core`[java module system]
 
 ### CI
 1. [#275](https://github.com/influxdata/influxdb-client-java/pull/275): Deploy `influxdb-client-test` package into Maven repository

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-core</artifactId>

--- a/client-core/src/main/java/com/influxdb/internal/AbstractQueryApi.java
+++ b/client-core/src/main/java/com/influxdb/internal/AbstractQueryApi.java
@@ -36,12 +36,12 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.Cancellable;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.internal.FluxCsvParser;
 import com.influxdb.query.internal.FluxResultMapper;
+import com.influxdb.utils.Arguments;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
+++ b/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
@@ -28,7 +28,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.LogLevel;
 import com.influxdb.exceptions.BadGatewayException;
 import com.influxdb.exceptions.BadRequestException;
@@ -46,6 +45,7 @@ import com.influxdb.exceptions.RequestTimeoutException;
 import com.influxdb.exceptions.ServiceUnavailableException;
 import com.influxdb.exceptions.UnauthorizedException;
 import com.influxdb.exceptions.UnprocessableEntityException;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.MediaType;
 import okhttp3.RequestBody;

--- a/client-core/src/main/java/com/influxdb/internal/UserAgentInterceptor.java
+++ b/client-core/src/main/java/com/influxdb/internal/UserAgentInterceptor.java
@@ -24,7 +24,7 @@ package com.influxdb.internal;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;

--- a/client-core/src/main/java/com/influxdb/query/FluxRecord.java
+++ b/client-core/src/main/java/com/influxdb/query/FluxRecord.java
@@ -30,7 +30,7 @@ import java.util.StringJoiner;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 
 /**

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -35,13 +35,13 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.Cancellable;
 import com.influxdb.query.FluxColumn;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 import com.influxdb.query.exceptions.FluxCsvParserException;
 import com.influxdb.query.exceptions.FluxQueryException;
+import com.influxdb.utils.Arguments;
 
 import okio.BufferedSource;
 import org.apache.commons.csv.CSVFormat;

--- a/client-kotlin/pom.xml
+++ b/client-kotlin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
@@ -21,9 +21,9 @@
  */
 package com.influxdb.client.kotlin
 
-import com.influxdb.Arguments
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.kotlin.internal.InfluxDBClientKotlinImpl
+import com.influxdb.utils.Arguments
 
 /**
  * The Factory that creates an instance of a Flux client.

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
@@ -21,7 +21,6 @@
  */
 package com.influxdb.client.kotlin.internal
 
-import com.influxdb.Arguments
 import com.influxdb.Cancellable
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.domain.Dialect
@@ -33,6 +32,7 @@ import com.influxdb.internal.AbstractQueryApi
 import com.influxdb.query.FluxRecord
 import com.influxdb.query.FluxTable
 import com.influxdb.query.internal.FluxCsvParser.FluxResponseConsumer
+import com.influxdb.utils.Arguments
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import java.util.function.BiConsumer

--- a/client-legacy/pom.xml
+++ b/client-legacy/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.influxdb</groupId>
         <artifactId>influxdb-client</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-flux</artifactId>

--- a/client-legacy/src/main/java/com/influxdb/client/flux/FluxClientFactory.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/FluxClientFactory.java
@@ -23,8 +23,8 @@ package com.influxdb.client.flux;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.flux.internal.FluxApiImpl;
+import com.influxdb.utils.Arguments;
 
 /**
  * The Factory that creates an instance of a Flux client.

--- a/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/FluxConnectionOptions.java
@@ -31,8 +31,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
-import com.influxdb.Arguments;
 import com.influxdb.exceptions.InfluxException;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;

--- a/client-legacy/src/main/java/com/influxdb/client/flux/internal/FluxApiImpl.java
+++ b/client-legacy/src/main/java/com/influxdb/client/flux/internal/FluxApiImpl.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.Cancellable;
 import com.influxdb.LogLevel;
 import com.influxdb.client.flux.FluxClient;
@@ -39,6 +38,7 @@ import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 import com.influxdb.query.internal.FluxCsvParser.FluxResponseConsumer;
 import com.influxdb.query.internal.FluxCsvParser.FluxResponseConsumerTable;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;

--- a/client-osgi/pom.xml
+++ b/client-osgi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-osgi</artifactId>

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
@@ -24,9 +24,9 @@ package com.influxdb.client.reactive;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.reactive.internal.InfluxDBClientReactiveImpl;
+import com.influxdb.utils.Arguments;
 
 /**
  * The Factory that create an instance of a InfluxDB reactive client.

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/InfluxDBClientReactiveImpl.java
@@ -23,7 +23,6 @@ package com.influxdb.client.reactive.internal;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.LogLevel;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteOptions;
@@ -34,6 +33,7 @@ import com.influxdb.client.reactive.QueryReactiveApi;
 import com.influxdb.client.reactive.WriteReactiveApi;
 import com.influxdb.client.service.QueryService;
 import com.influxdb.client.service.WriteService;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.Single;
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
@@ -25,7 +25,6 @@ import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.Cancellable;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.domain.Dialect;
@@ -37,6 +36,7 @@ import com.influxdb.internal.AbstractQueryApi;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 import com.influxdb.query.internal.FluxCsvParser;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/WriteReactiveApiImpl.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.WritePrecision;
@@ -34,6 +33,7 @@ import com.influxdb.client.reactive.WriteReactiveApi;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.client.write.Point;
 import com.influxdb.client.write.events.AbstractWriteEvent;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;

--- a/client-scala/cross/2.12/pom.xml
+++ b/client-scala/cross/2.12/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
@@ -21,9 +21,9 @@
  */
 package com.influxdb.client.scala
 
-import com.influxdb.Arguments
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.scala.internal.InfluxDBClientScalaImpl
+import com.influxdb.utils.Arguments
 
 import javax.annotation.Nonnull
 

--- a/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
@@ -23,7 +23,6 @@ package com.influxdb.client.scala.internal
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.influxdb.Arguments
 import com.influxdb.client.InfluxDBClientOptions
 import com.influxdb.client.domain.{Dialect, Query}
 import com.influxdb.client.internal.AbstractInfluxDBClient
@@ -31,6 +30,7 @@ import com.influxdb.client.scala.QueryScalaApi
 import com.influxdb.client.service.QueryService
 import com.influxdb.internal.AbstractQueryApi
 import com.influxdb.query.FluxRecord
+import com.influxdb.utils.Arguments
 
 import javax.annotation.Nonnull
 

--- a/client-test/pom.xml
+++ b/client-test/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-test</artifactId>

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-utils</artifactId>

--- a/client-utils/src/main/java/com/influxdb/utils/Arguments.java
+++ b/client-utils/src/main/java/com/influxdb/utils/Arguments.java
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.influxdb;
+package com.influxdb.utils;
 
 import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;

--- a/client-utils/src/test/java/com/influxdb/ArgumentsDurationTest.java
+++ b/client-utils/src/test/java/com/influxdb/ArgumentsDurationTest.java
@@ -21,6 +21,8 @@
  */
 package com.influxdb;
 
+import com.influxdb.utils.Arguments;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;

--- a/client-utils/src/test/java/com/influxdb/ArgumentsTest.java
+++ b/client-utils/src/test/java/com/influxdb/ArgumentsTest.java
@@ -23,6 +23,8 @@ package com.influxdb;
 
 import java.time.temporal.ChronoUnit;
 
+import com.influxdb.utils.Arguments;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;

--- a/client-utils/src/test/java/com/influxdb/utils/ArgumentsDurationTest.java
+++ b/client-utils/src/test/java/com/influxdb/utils/ArgumentsDurationTest.java
@@ -19,9 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.influxdb;
-
-import com.influxdb.utils.Arguments;
+package com.influxdb.utils;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/client-utils/src/test/java/com/influxdb/utils/ArgumentsTest.java
+++ b/client-utils/src/test/java/com/influxdb/utils/ArgumentsTest.java
@@ -19,11 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.influxdb;
+package com.influxdb.utils;
 
 import java.time.temporal.ChronoUnit;
-
-import com.influxdb.utils.Arguments;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
@@ -24,10 +24,10 @@ package com.influxdb.client;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.domain.OnboardingRequest;
 import com.influxdb.client.domain.OnboardingResponse;
 import com.influxdb.client.internal.InfluxDBClientImpl;
+import com.influxdb.utils.Arguments;
 
 /**
  * The Factory that create an instance of a InfluxDB 2.0 client.

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -33,10 +33,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import com.influxdb.Arguments;
 import com.influxdb.LogLevel;
 import com.influxdb.client.write.PointSettings;
 import com.influxdb.exceptions.InfluxException;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.BackpressureOverflowStrategy;
 import io.reactivex.Scheduler;

--- a/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
@@ -29,7 +29,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.JSON;
 import com.influxdb.client.domain.Dialect;
@@ -39,6 +38,7 @@ import com.influxdb.client.service.PingService;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.internal.AbstractRestClient;
 import com.influxdb.internal.UserAgentInterceptor;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteBlockingClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteBlockingClient.java
@@ -28,12 +28,12 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataMeasurement;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -32,7 +32,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteOptions;
 import com.influxdb.client.domain.WritePrecision;
@@ -45,6 +44,7 @@ import com.influxdb.client.write.events.WriteRetriableErrorEvent;
 import com.influxdb.client.write.events.WriteSuccessEvent;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;

--- a/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
@@ -29,8 +29,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.Call;
 import okhttp3.Cookie;

--- a/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.AuthorizationsApi;
 import com.influxdb.client.domain.Authorization;
 import com.influxdb.client.domain.AuthorizationPostRequest;
@@ -37,6 +36,7 @@ import com.influxdb.client.domain.Permission;
 import com.influxdb.client.domain.User;
 import com.influxdb.client.service.AuthorizationsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/BucketsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/BucketsApiImpl.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.BucketsApi;
 import com.influxdb.client.FindOptions;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
@@ -50,6 +49,7 @@ import com.influxdb.client.domain.ResourceOwners;
 import com.influxdb.client.domain.User;
 import com.influxdb.client.service.BucketsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/ChecksApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/ChecksApiImpl.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.ChecksApi;
 import com.influxdb.client.FindOptions;
 import com.influxdb.client.domain.Check;
@@ -44,6 +43,7 @@ import com.influxdb.client.domain.Threshold;
 import com.influxdb.client.domain.ThresholdCheck;
 import com.influxdb.client.service.ChecksService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/DashboardsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/DashboardsApiImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.DashboardsApi;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
 import com.influxdb.client.domain.Cell;
@@ -48,6 +47,7 @@ import com.influxdb.client.domain.User;
 import com.influxdb.client.domain.View;
 import com.influxdb.client.service.DashboardsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/DeleteApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/DeleteApiImpl.java
@@ -26,13 +26,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.DeleteApi;
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.DeletePredicateRequest;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.service.DeleteService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.LogLevel;
 import com.influxdb.client.AuthorizationsApi;
 import com.influxdb.client.BucketsApi;
@@ -78,6 +77,7 @@ import com.influxdb.client.service.VariablesService;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.UnprocessableEntityException;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/LabelsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/LabelsApiImpl.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.LabelsApi;
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelCreateRequest;
@@ -38,6 +37,7 @@ import com.influxdb.client.domain.LabelsResponse;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.service.LabelsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
+++ b/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
@@ -30,12 +30,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.annotations.Column;
 import com.influxdb.annotations.Measurement;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import com.influxdb.exceptions.InfluxException;
+import com.influxdb.utils.Arguments;
 
 /**
  * @author Jakub Bednar (bednar@github) (15/10/2018 13:04)

--- a/client/src/main/java/com/influxdb/client/internal/NotificationEndpointsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/NotificationEndpointsApiImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.FindOptions;
 import com.influxdb.client.NotificationEndpointsApi;
 import com.influxdb.client.domain.HTTPNotificationEndpoint;
@@ -43,6 +42,7 @@ import com.influxdb.client.domain.PagerDutyNotificationEndpoint;
 import com.influxdb.client.domain.SlackNotificationEndpoint;
 import com.influxdb.client.service.NotificationEndpointsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/NotificationRulesApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/NotificationRulesApiImpl.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.FindOptions;
 import com.influxdb.client.NotificationRulesApi;
 import com.influxdb.client.domain.HTTPNotificationEndpoint;
@@ -48,6 +47,7 @@ import com.influxdb.client.domain.TagRule;
 import com.influxdb.client.domain.TaskStatusType;
 import com.influxdb.client.service.NotificationRulesService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/OrganizationsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/OrganizationsApiImpl.java
@@ -27,7 +27,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.OrganizationsApi;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
 import com.influxdb.client.domain.Organization;
@@ -44,6 +43,7 @@ import com.influxdb.client.domain.User;
 import com.influxdb.client.service.OrganizationsService;
 import com.influxdb.client.service.SecretsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
@@ -30,7 +30,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.Cancellable;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.QueryApi;
@@ -41,6 +40,7 @@ import com.influxdb.internal.AbstractQueryApi;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 import com.influxdb.query.internal.FluxCsvParser;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;

--- a/client/src/main/java/com/influxdb/client/internal/ScraperTargetsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/ScraperTargetsApiImpl.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.ScraperTargetsApi;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
 import com.influxdb.client.domain.Label;
@@ -45,6 +44,7 @@ import com.influxdb.client.domain.ScraperTargetResponses;
 import com.influxdb.client.domain.User;
 import com.influxdb.client.service.ScraperTargetsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/SourcesApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/SourcesApiImpl.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.SourcesApi;
 import com.influxdb.client.domain.Bucket;
 import com.influxdb.client.domain.Buckets;
@@ -36,6 +35,7 @@ import com.influxdb.client.domain.Source;
 import com.influxdb.client.domain.Sources;
 import com.influxdb.client.service.SourcesService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.TasksApi;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
 import com.influxdb.client.domain.Label;
@@ -53,6 +52,7 @@ import com.influxdb.client.domain.Tasks;
 import com.influxdb.client.domain.User;
 import com.influxdb.client.service.TasksService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/TelegrafsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/TelegrafsApiImpl.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.TelegrafsApi;
 import com.influxdb.client.domain.AddResourceMemberRequestBody;
 import com.influxdb.client.domain.Label;
@@ -53,6 +52,7 @@ import com.influxdb.client.domain.Telegrafs;
 import com.influxdb.client.domain.User;
 import com.influxdb.client.service.TelegrafsService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/TemplatesApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/TemplatesApiImpl.java
@@ -24,7 +24,6 @@ package com.influxdb.client.internal;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.TemplatesApi;
 import com.influxdb.client.domain.Document;
 import com.influxdb.client.domain.DocumentCreate;
@@ -38,6 +37,7 @@ import com.influxdb.client.domain.LabelsResponse;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.service.TemplatesService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/UsersApiImpl.java
@@ -26,7 +26,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.UsersApi;
 import com.influxdb.client.domain.PasswordResetBody;
 import com.influxdb.client.domain.PostUser;
@@ -34,6 +33,7 @@ import com.influxdb.client.domain.User;
 import com.influxdb.client.domain.Users;
 import com.influxdb.client.service.UsersService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import okhttp3.Credentials;
 import retrofit2.Call;

--- a/client/src/main/java/com/influxdb/client/internal/VariablesApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/VariablesApiImpl.java
@@ -24,7 +24,6 @@ package com.influxdb.client.internal;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.VariablesApi;
 import com.influxdb.client.domain.Label;
 import com.influxdb.client.domain.LabelMapping;
@@ -35,6 +34,7 @@ import com.influxdb.client.domain.Variable;
 import com.influxdb.client.domain.Variables;
 import com.influxdb.client.service.VariablesService;
 import com.influxdb.internal.AbstractRestClient;
+import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
 

--- a/client/src/main/java/com/influxdb/client/internal/WriteApiBlockingImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/WriteApiBlockingImpl.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
@@ -39,6 +38,7 @@ import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataPoint;
 import com.influxdb.client.internal.AbstractWriteClient.BatchWriteDataRecord;
 import com.influxdb.client.service.WriteService;
 import com.influxdb.client.write.Point;
+import com.influxdb.utils.Arguments;
 
 /**
  * @author Jakub Bednar (bednar@github) (16/07/2019 06:48)

--- a/client/src/main/java/com/influxdb/client/internal/WriteApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/WriteApiImpl.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.InfluxDBClientOptions;
 import com.influxdb.client.WriteApi;
 import com.influxdb.client.WriteOptions;
@@ -38,6 +37,7 @@ import com.influxdb.client.write.Point;
 import com.influxdb.client.write.events.AbstractWriteEvent;
 import com.influxdb.client.write.events.EventListener;
 import com.influxdb.client.write.events.ListenerRegistration;
+import com.influxdb.utils.Arguments;
 
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -36,9 +36,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import com.influxdb.Arguments;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.internal.NanosecondConverter;
+import com.influxdb.utils.Arguments;
 
 /**
  * Point defines the values that will be written to the database.

--- a/client/src/main/java/com/influxdb/client/write/PointSettings.java
+++ b/client/src/main/java/com/influxdb/client/write/PointSettings.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 /**
  * The setting for store data point: default values, threshold, ...

--- a/client/src/main/java/com/influxdb/client/write/events/WriteErrorEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteErrorEvent.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 /**
  * The event is published when occurs a write exception.

--- a/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteRetriableErrorEvent.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 /**
  * The event is published when occurs a retriable write exception.

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -1015,7 +1015,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         String userAgent = recordedRequest.getHeader("User-Agent");
 
-        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/3.");
+        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/4.");
     }
 
     @Nonnull

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,12 +27,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>
-        <influxdb-client.version>3.5.0-SNAPSHOT</influxdb-client.version>
+        <influxdb-client.version>4.0.0-SNAPSHOT</influxdb-client.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flux-dsl/pom.xml
+++ b/flux-dsl/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flux-dsl</artifactId>

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.functions.AbstractParametrizedFlux;
 import com.influxdb.query.dsl.functions.AggregateWindow;
 import com.influxdb.query.dsl.functions.CountFlux;
@@ -80,6 +79,7 @@ import com.influxdb.query.dsl.functions.WindowFlux;
 import com.influxdb.query.dsl.functions.YieldFlux;
 import com.influxdb.query.dsl.functions.properties.FunctionsParameters;
 import com.influxdb.query.dsl.functions.restriction.Restrictions;
+import com.influxdb.utils.Arguments;
 
 /**
  * <a href="http://bit.ly/flux-spec#basic-syntax">Flux</a> - Data Scripting Language.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFluxWithUpstream.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFluxWithUpstream.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Abstract base class for operators that take an upstream source of {@link Flux}.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AggregateWindow.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AggregateWindow.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Applies an aggregate or selector function (any function with a column parameter) to fixed windows of time.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CountFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CountFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Counts the number of results. <a href="http://bit.ly/flux-spec#count">See SPEC</a>.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CovarianceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CovarianceFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Covariance is an aggregate operation. Covariance computes the covariance between two columns.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CumulativeSumFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CumulativeSumFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Cumulative sum computes a running sum for non null records in the table.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DerivativeFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DerivativeFlux.java
@@ -25,8 +25,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Computes the time based difference between subsequent non null records.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DifferenceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DifferenceFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Difference computes the difference between subsequent non null records.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DistinctFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DistinctFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Distinct produces the unique values for a given column.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DropFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DropFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Drop will exclude specified columns from a table.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DuplicateFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DuplicateFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Duplicate will duplicate a specified column in a table.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ExpressionFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ExpressionFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * The custom Flux expression.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FilterFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FilterFlux.java
@@ -23,9 +23,9 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
 import com.influxdb.query.dsl.functions.restriction.Restrictions;
+import com.influxdb.utils.Arguments;
 
 /**
  * Filters the results using an expression.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/GroupFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/GroupFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Groups results by a user-specified set of tags.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/IntegralFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/IntegralFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * For each aggregate column, it outputs the area under the curve of non null records.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
@@ -28,8 +28,8 @@ import java.util.StringJoiner;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Join two time series together on time and the list of <i>on</i> keys.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/KeepFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/KeepFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Keep is the inverse of drop. It will return a table containing only columns that are specified, ignoring all others.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Returns the last result of the query.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Restricts the number of rows returned in the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MapFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MapFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Applies a function to each row of the table.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MaxFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MaxFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Returns the max value within the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MeanFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MeanFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Returns the mean of the within the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MinFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MinFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Returns the min value within the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PercentileFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PercentileFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Percentile is both an aggregate operation and a selector operation depending on selected options.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PivotFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PivotFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Pivot collects values stored vertically (column-wise) in a table and aligns them horizontally (row-wise)

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RangeFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RangeFlux.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Filters the results by time boundaries.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ReduceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ReduceFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Reduce aggregates records in each table according to the reducer.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RenameFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RenameFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Rename will rename specified columns in a table. If a column is renamed and is part of the group key,

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SetFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SetFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Assigns a static value to each record.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SkewFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SkewFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Skew of the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SortFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SortFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Sorts the results by the specified columns Default sort is ascending.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SpreadFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SpreadFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Difference between min and max values.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/StddevFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/StddevFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Standard Deviation of the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SumFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SumFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Sum of the results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TailFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TailFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Tail caps the number of records in output tables to a fixed size <i>n</i>.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TimeShiftFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TimeShiftFlux.java
@@ -25,8 +25,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Shift add a fixed duration to time columns.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
@@ -24,8 +24,8 @@ package com.influxdb.query.dsl.functions;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * The To operation takes data from a stream and writes it to a bucket.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/WindowFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/WindowFlux.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Groups the results by a given time range.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/YieldFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/YieldFlux.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * Yield a query results to yielded results.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/FunctionsParameters.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/FunctionsParameters.java
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
+import com.influxdb.utils.Arguments;
 
 /**
  * The function properties. Support named-property, property with values.

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/TimeInterval.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/TimeInterval.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
+import com.influxdb.utils.Arguments;
 
 /**
  * Flux duration literal -

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
@@ -23,8 +23,8 @@ package com.influxdb.query.dsl.functions.restriction;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.functions.properties.FunctionsParameters;
+import com.influxdb.utils.Arguments;
 
 /**
  * The column restrictions.

--- a/flux-dsl/src/test/java/com/example/flux/CustomFunction.java
+++ b/flux-dsl/src/test/java/com/example/flux/CustomFunction.java
@@ -23,9 +23,9 @@ package com.example.flux;
 
 import javax.annotation.Nonnull;
 
-import com.influxdb.Arguments;
 import com.influxdb.query.dsl.Flux;
 import com.influxdb.query.dsl.functions.AbstractParametrizedFlux;
+import com.influxdb.utils.Arguments;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/karaf/karaf-assembly/pom.xml
+++ b/karaf/karaf-assembly/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-assembly</artifactId>

--- a/karaf/karaf-features/pom.xml
+++ b/karaf/karaf-features/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-features</artifactId>

--- a/karaf/karaf-kar/pom.xml
+++ b/karaf/karaf-kar/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-kar</artifactId>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>influxdb-karaf-features</artifactId>
-            <version>3.5.0-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.influxdb</groupId>
     <artifactId>influxdb-client</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -473,38 +473,38 @@
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-test</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-core</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-utils</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-reactive</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-flux</artifactId>
-                <version>3.5.0-SNAPSHOT</version>
+                <version>4.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>influxdb-spring</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring Integration for InfluxDB 2.0</name>


### PR DESCRIPTION
Closes #270

## Proposed Changes

The Java Module System requires to have separate package for each module. For more info see `package splitting` - https://www.logicbig.com/tutorials/core-java-tutorial/modules/split-packages.html

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
