### PR TITLE
fix: session authentication for InfluxDB 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 
 ### Features
 1. [#272](https://github.com/influxdata/influxdb-client-java/pull/272): Add `PingService` to check status of OSS and Cloud instance
-2. [#278](https://github.com/influxdata/influxdb-client-java/pull/278): Add query method with all params for BucketsApi, OrganizationApi and TasksApi
+1. [#278](https://github.com/influxdata/influxdb-client-java/pull/278): Add query method with all params for BucketsApi, OrganizationApi and TasksApi
+
+### Bug Fixes
+1. [#279](https://github.com/influxdata/influxdb-client-java/pull/279): Session authentication for InfluxDB `2.1`
 
 ### CI
 1. [#275](https://github.com/influxdata/influxdb-client-java/pull/275): Deploy `influxdb-client-test` package into Maven repository

--- a/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthenticateInterceptor.java
@@ -147,16 +147,18 @@ class AuthenticateInterceptor implements Interceptor {
             return;
         }
 
-        Request authRequest = new Request.Builder()
+        Request.Builder authRequest = new Request.Builder()
                 .url(buildPath("api/v2/signout"))
-                .post(RequestBody.create("application/json", null))
-                .header("Cookie", string(sessionCookies))
-                .build();
+                .post(RequestBody.create("application/json", null));
 
-        this.signout.set(true);
-        this.sessionCookies = null;
+        if (sessionCookies != null) {
+            authRequest.addHeader("Cookie", string(sessionCookies));
+        }
 
-        Response response = this.okHttpClient.newCall(authRequest).execute();
+        signout.set(true);
+        sessionCookies = null;
+
+        Response response = okHttpClient.newCall(authRequest.build()).execute();
         response.close();
     }
 

--- a/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
@@ -117,7 +117,7 @@ class AuthenticateInterceptorTest extends AbstractMockServerTest {
         RecordedRequest requestToTasks = mockServer.takeRequest();
         Assertions.assertThat(requestToTasks.getPath()).endsWith("/api/v2/tasks");
         Assertions.assertThat(requestToTasks.getHeader("Cookie"))
-                .isEqualTo("session=yCgXaEBF8mYSmJUweRcW0g_5jElMs7mv6_-G1bNcau4Z0ZLQYtj0BkHZYRnBVA6uXHtyuhflcOzyNDNRxnaC0A==");
+                .isEqualTo("session=yCgXaEBF8mYSmJUweRcW0g_5jElMs7mv6_-G1bNcau4Z0ZLQYtj0BkHZYRnBVA6uXHtyuhflcOzyNDNRxnaC0A==; path=/api/v2");
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

The InfluxDB 2.1 OSS changed name of session cookie to `influxdb-oss-session`. As a solution this PR store all cookies from auth request.

https://github.com/influxdata/influxdb/pull/22632

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
