### PR TITLE
chore: use async HTTP call in batching writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 1. [#272](https://github.com/influxdata/influxdb-client-java/pull/272): Add `PingService` to check status of OSS and Cloud instance
 1. [#278](https://github.com/influxdata/influxdb-client-java/pull/278): Add query method with all params for BucketsApi, OrganizationApi and TasksApi
+1. [#280](https://github.com/influxdata/influxdb-client-java/pull/280): Use async HTTP calls in the Batching writer
 
 ### Bug Fixes
 1. [#279](https://github.com/influxdata/influxdb-client-java/pull/279): Session authentication for InfluxDB `2.1`

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -57,6 +57,7 @@ import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.PublishSubject;
 import org.reactivestreams.Publisher;
 import retrofit2.Call;
+import retrofit2.Callback;
 import retrofit2.HttpException;
 import retrofit2.Response;
 
@@ -450,12 +451,21 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
             String bucket = batchWrite.batchWriteOptions.bucket;
             WritePrecision precision = batchWrite.batchWriteOptions.precision;
 
-            Maybe<Response<Void>> requestSource = Maybe
-                    .fromCallable(() -> service
-                            .postWrite(organization, bucket, content, null,
-                                    "identity", "text/plain; charset=utf-8", null,
-                                    "application/json", null, precision))
-                    .map(Call::execute);
+            Maybe<Response<Void>> requestSource = Maybe.create(emitter -> service
+                    .postWrite(organization, bucket, content, null,
+                            "identity", "text/plain; charset=utf-8", null,
+                            "application/json", null, precision)
+                    .enqueue(new Callback<Void>() {
+                        @Override
+                        public void onResponse(@Nonnull final Call<Void> call, @Nonnull final Response<Void> response) {
+                            emitter.onSuccess(response);
+                        }
+
+                        @Override
+                        public void onFailure(@Nonnull final Call<Void> call, @Nonnull final Throwable throwable) {
+                            emitter.onError(throwable);
+                        }
+                    }));
 
             return requestSource
                     //

--- a/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
@@ -461,12 +461,15 @@ class ITWriteQueryApi extends AbstractITClientTest {
     }
 
     @Test
-    void flush() throws InterruptedException {
+    void flush() {
 
         String bucketName = bucket.getName();
 
-        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(100_000)
-                .flushInterval(100_000).build());
+        writeApi = influxDBClient.makeWriteApi(WriteOptions.builder().batchSize(1_000_000)
+                .flushInterval(1_000_000).build());
+
+        WriteEventListener<WriteSuccessEvent> successListener = new WriteEventListener<>();
+        writeApi.listenEvents(WriteSuccessEvent.class, successListener);
 
         String record = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1";
 
@@ -476,7 +479,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
         Assertions.assertThat(query).hasSize(0);
 
         writeApi.flush();
-        Thread.sleep(10);
+        waitToCallback(successListener.countDownLatch, 10);
 
         query = queryApi.query("from(bucket:\"" + bucketName + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", organization.getId());
 


### PR DESCRIPTION
## Proposed Changes

Use asynchronous HTTP calls in batching writer to achieve better performance in a multithreading environment.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
