### PR TITLE
fix: serialization null tag's value into LineProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.1.0 [unreleased]
 
+### Bug Fixes
+1. [#283](https://github.com/influxdata/influxdb-client-java/pull/283): Serialization `null` tag's value into LineProtocol
+
 ## 4.0.0 [2021-11-26]
 
 ### Breaking Changes

--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -347,7 +347,7 @@ public final class Point {
             String key = tag.getKey();
             String value = tag.getValue();
 
-            if (key.isEmpty() || value.isEmpty()) {
+            if (key.isEmpty() || value == null || value.isEmpty()) {
                 continue;
             }
 

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -104,6 +104,17 @@ class PointTest {
     }
 
     @Test
+    void tagNullValue() {
+
+        Point point = Point.measurement("h2o")
+                .addTag("location", "europe")
+                .addTag("log", null)
+                .addField("level", 2);
+
+        Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2o,location=europe level=2i");
+    }
+
+    @Test
     public void tagEscapingKeyAndValue() {
 
         Point point = Point.measurement("h\n2\ro\t_data")


### PR DESCRIPTION
Closes #282

## Proposed Changes

Fixed serialization a Point into LineProtocol when tag's value is `null`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
