### PR TITLE
fix: default dialect (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 1. [#285](https://github.com/influxdata/influxdb-client-java/pull/285): Fix default dialect in `QueryApi`
-1. [#283](https://github.com/influxdata/influxdb-client-java/pull/284): Serialization `null` tag's value into LineProtocol
+1. [#283](https://github.com/influxdata/influxdb-client-java/pull/283): Serialization `null` tag's value into LineProtocol
 
 ## 4.0.0 [2021-11-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 4.1.0 [unreleased]
 
 ### Bug Fixes
-1. [#283](https://github.com/influxdata/influxdb-client-java/pull/283): Serialization `null` tag's value into LineProtocol
+1. [#285](https://github.com/influxdata/influxdb-client-java/pull/285): Fix default dialect in `QueryApi`
+1. [#283](https://github.com/influxdata/influxdb-client-java/pull/284): Serialization `null` tag's value into LineProtocol
 
 ## 4.0.0 [2021-11-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 4.1.0 [unreleased]
 
 ### Bug Fixes
-1. [#285](https://github.com/influxdata/influxdb-client-java/pull/285): Fix default dialect in `QueryApi`
 1. [#283](https://github.com/influxdata/influxdb-client-java/pull/283): Serialization `null` tag's value into LineProtocol
+1. [#285](https://github.com/influxdata/influxdb-client-java/pull/285): Default dialect for Query APIs
 
 ## 4.0.0 [2021-11-26]
 

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/internal/QueryKotlinApiImpl.kt
@@ -194,7 +194,7 @@ internal class QueryKotlinApiImpl(private val service: QueryService, private val
         val channel = Channel<T>()
 
         val queryCall = service.postQueryResponseBody(null, null,
-                null, org, null, query)
+                null, org, null, query.dialect(AbstractInfluxDBClient.DEFAULT_DIALECT))
 
         val responseConsumer = object : FluxResponseConsumer {
 

--- a/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/internal/QueryScalaApiImpl.scala
@@ -102,7 +102,8 @@ class QueryScalaApiImpl(@Nonnull service: QueryService, @Nonnull options: Influx
 
     Source.unfoldResource[FluxRecord, AbstractQueryApi#FluxRecordIterator](
       () => {
-        val call = service.postQueryResponseBody(null, null, null, org, null, query)
+        val call = service.postQueryResponseBody(null, null, null, org, null,
+          query.dialect(AbstractInfluxDBClient.DEFAULT_DIALECT))
 
         queryIterator(call)
 

--- a/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/QueryApiImpl.java
@@ -80,7 +80,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
         Arguments.checkNonEmpty(query, "query");
         Arguments.checkNonEmpty(org, "org");
 
-        return query(new Query().query(query).dialect(AbstractInfluxDBClient.DEFAULT_DIALECT), org);
+        return query(new Query().query(query), org);
     }
 
     @Nonnull
@@ -124,7 +124,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
 
         Arguments.checkNonEmpty(query, "query");
 
-        Query dialect = new Query().query(query).dialect(AbstractInfluxDBClient.DEFAULT_DIALECT);
+        Query dialect = new Query().query(query);
 
         return query(dialect, org, measurementType);
     }
@@ -383,7 +383,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
         Arguments.checkNotNull(onError, "onError");
         Arguments.checkNotNull(onComplete, "onComplete");
 
-        Query queryObj = new Query().query(query).dialect(AbstractInfluxDBClient.DEFAULT_DIALECT);
+        Query queryObj = new Query().query(query);
 
         query(queryObj, org, onNext, onError, onComplete);
     }
@@ -458,7 +458,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
         Arguments.checkNotNull(onComplete, "onComplete");
         Arguments.checkNotNull(measurementType, "measurementType");
 
-        Query queryObj = new Query().query(query).dialect(AbstractInfluxDBClient.DEFAULT_DIALECT);
+        Query queryObj = new Query().query(query);
 
         query(queryObj, org, measurementType,  onNext, onError, onComplete);
     }
@@ -793,7 +793,7 @@ final class QueryApiImpl extends AbstractQueryApi implements QueryApi {
                        @Nonnull final Boolean asynchronously) {
 
         Call<ResponseBody> queryCall = service
-                .postQueryResponseBody(null, null, null, org, null, query);
+            .postQueryResponseBody(null, null, null, org, null, query.dialect(AbstractInfluxDBClient.DEFAULT_DIALECT));
 
 
         LOG.log(Level.FINEST, "Prepare query \"{0}\" with dialect \"{1}\" on organization \"{2}\".",

--- a/client/src/test/java/com/influxdb/client/QueryApiTest.java
+++ b/client/src/test/java/com/influxdb/client/QueryApiTest.java
@@ -22,9 +22,13 @@
 package com.influxdb.client;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
+import com.google.gson.Gson;
 import com.influxdb.client.domain.Dialect;
 import com.influxdb.client.domain.Query;
+import static com.influxdb.client.internal.AbstractInfluxDBClient.DEFAULT_DIALECT;
 import com.influxdb.client.internal.AbstractInfluxDBClientTest;
 
 import okhttp3.mockwebserver.RecordedRequest;
@@ -84,6 +88,15 @@ class QueryApiTest extends AbstractInfluxDBClientTest {
         request = takeRequest();
 
         Assertions.assertThat(request.getRequestUrl().queryParameter("org")).isEqualTo("123456");
+
+        // check default dialect presence
+        Gson gson = JSON.createGson().create();
+        Map dialect = (Map) gson.fromJson(request.getBody().readUtf8(), Map.class).get("dialect");
+        Assertions.assertThat(dialect.get("header")).isEqualTo(DEFAULT_DIALECT.getHeader());
+        Assertions.assertThat(dialect.get("delimiter")).isEqualTo(DEFAULT_DIALECT.getDelimiter());
+        Assertions.assertThat(dialect.get("annotations")).isEqualTo(Arrays.asList("datatype", "group", "default"));
+        Assertions.assertThat(dialect.get("dateTimeFormat")).isEqualTo(DEFAULT_DIALECT.getDateTimeFormat().toString());
+        Assertions.assertThat(dialect.get("commentPrefix")).isEqualTo(DEFAULT_DIALECT.getCommentPrefix());
 
         // String Measurement
         enqueuedResponse();


### PR DESCRIPTION
Closes #284 

This PR fixes usage of default dialect in QueryAPI.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
