### PR TITLE
fix: publishing runtime error as a WriteErrorEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#285](https://github.com/influxdata/influxdb-client-java/pull/285): Default dialect for Query APIs
 1. [#294](https://github.com/influxdata/influxdb-client-java/pull/294): Mapping measurement with primitive `float`
 1. [#297](https://github.com/influxdata/influxdb-client-java/pull/297): Transient dependency of `okhttp`, `retrofit` and `rxjava`
+1. [#292](https://github.com/influxdata/influxdb-client-java/pull/292): Publishing runtime error as a WriteErrorEvent
 
 ## 4.0.0 [2021-11-26]
 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -181,7 +181,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
                     if (responseNotification.isOnError()) {
                         publish(new WriteErrorEvent(toInfluxException(responseNotification.getError())));
                     }
-                }, throwable -> new WriteErrorEvent(toInfluxException(throwable)));
+                }, throwable -> publish(new WriteErrorEvent(toInfluxException(throwable))));
 
         autoCloseables.add(this);
     }

--- a/client/src/test/java/com/influxdb/client/internal/PublishRuntimeErrorAsWriteErrorEventTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/PublishRuntimeErrorAsWriteErrorEventTest.java
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  * https://github.com/influxdata/influxdb-client-java/issues/291
  */
 @RunWith(JUnitPlatform.class)
-public class PublishRuntimeErrorAsWriteErrorEvent extends AbstractInfluxDBClientTest {
+public class PublishRuntimeErrorAsWriteErrorEventTest extends AbstractInfluxDBClientTest {
 
     @Test
     void publishRuntimeErrorAsWriteErrorEvent() {

--- a/client/src/test/java/com/influxdb/client/internal/PublishRuntimeErrorAsWriteErrorEventTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/PublishRuntimeErrorAsWriteErrorEventTest.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.internal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.influxdb.client.WriteApi;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import com.influxdb.client.write.events.WriteErrorEvent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * This test ensures publish is called with WriteErrorEvent as described in
+ * https://github.com/influxdata/influxdb-client-java/issues/291
+ */
+@RunWith(JUnitPlatform.class)
+public class PublishRuntimeErrorAsWriteErrorEvent extends AbstractInfluxDBClientTest {
+
+    @Test
+    void publishRuntimeErrorAsWriteErrorEvent() {
+        WriteApi writeApi = influxDBClient.makeWriteApi();
+
+        CompletableFuture<Throwable> errorEventTriggered = new CompletableFuture<>();
+        writeApi.listenEvents(WriteErrorEvent.class, event -> {
+            Throwable exception = event.getThrowable();
+            errorEventTriggered.complete(exception);
+        });
+        CompletableFuture<Object> supplyAsync = CompletableFuture.supplyAsync(() -> {
+            for (int i = 0; i < 100000; i++) {
+                writeApi.writePoint("my-bucket", "my-org", new Point("foo" + i).time(Instant.now(), WritePrecision.MS).addField("value", i));
+            }
+            return null;
+        });
+        try {
+            supplyAsync.get(1, TimeUnit.MINUTES);
+            assertNotNull(errorEventTriggered.get(1, TimeUnit.MINUTES));
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            e.printStackTrace();
+            fail(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #291

## Proposed Changes

Publishing runtime error as a WriteErrorEvent

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
