### PR TITLE
fix: add missing PermissionResources from Cloud API definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.2.0 [unreleased]
 
+### Bug Fixes
+1. [#300](https://github.com/influxdata/influxdb-client-java/pull/300): Add missing PermissionResources from Cloud API definition
+
 ## 4.1.0 [2022-01-20]
 
 ### Features

--- a/client/src/generated/java/com/influxdb/client/domain/PermissionResource.java
+++ b/client/src/generated/java/com/influxdb/client/domain/PermissionResource.java
@@ -76,7 +76,11 @@ public class PermissionResource {
     
     REMOTES("remotes"),
     
-    REPLICATIONS("replications");
+    REPLICATIONS("replications"),
+    
+    FLOWS("flows"),
+    
+    FUNCTIONS("functions");
 
     private String value;
 


### PR DESCRIPTION
## Proposed Changes

Added missing `PermissionResource` types.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
