### PR TITLE
fix: use native support for Rx request instead of callback emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.3.0 [unreleased]
 
+### Bug Fixes
+1. [#300](https://github.com/influxdata/influxdb-client-java/pull/300): Uses native support for Rx requests to better performance
+
 ## 4.2.0 [2022-02-04]
 
 ### Bug Fixes

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -128,6 +128,25 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>adapter-rxjava2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.retrofit2</groupId>
+                    <artifactId>retrofit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava2</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -58,8 +58,6 @@ import io.reactivex.functions.Function;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.PublishSubject;
 import org.reactivestreams.Publisher;
-import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.HttpException;
 import retrofit2.Response;
 
@@ -434,21 +432,11 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
             String bucket = batchWrite.batchWriteOptions.bucket;
             WritePrecision precision = batchWrite.batchWriteOptions.precision;
 
-            Maybe<Response<Void>> requestSource = Maybe.create(emitter -> service
-                    .postWrite(organization, bucket, content, null,
+            Maybe<Response<Void>> requestSource = service
+                    .postWriteRx(organization, bucket, content, null,
                             "identity", "text/plain; charset=utf-8", null,
                             "application/json", null, precision)
-                    .enqueue(new Callback<Void>() {
-                        @Override
-                        public void onResponse(@Nonnull final Call<Void> call, @Nonnull final Response<Void> response) {
-                            emitter.onSuccess(response);
-                        }
-
-                        @Override
-                        public void onFailure(@Nonnull final Call<Void> call, @Nonnull final Throwable throwable) {
-                            emitter.onError(throwable);
-                        }
-                    }));
+                    .toMaybe();
 
             return requestSource
                     //

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client.internal;
 
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -78,6 +79,7 @@ import com.influxdb.exceptions.UnprocessableEntityException;
 import com.influxdb.utils.Arguments;
 
 import retrofit2.Call;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 
 /**
  * @author Jakub Bednar (bednar@github) (11/10/2018 09:36)
@@ -92,7 +94,7 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
 
     public InfluxDBClientImpl(@Nonnull final InfluxDBClientOptions options) {
 
-        super(options, "java");
+        super(options, "java", Collections.singletonList(RxJava2CallAdapterFactory.create()));
 
         setupService = retrofit.create(SetupService.class);
         readyService = retrofit.create(ReadyService.class);


### PR DESCRIPTION
## Proposed Changes

Use native support for Rx request instead of callback emitter.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
