### PR TITLE
fix: change type of `PermissionResource.type` to String to avoid exception for non-existing item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 4.4.0 [unreleased]
+## 5.0.0 [unreleased]
+
+### Breaking Changes
+
+- Change type of `PermissionResource.type` to `String`. You are able to easily migrate by:
+    ```diff
+    - resource.setType(PermissionResource.TypeEnum.BUCKETS);
+    + resource.setType(PermissionResource.TYPE_BUCKETS);
+    ```
+
+### Bug Fixes
+1. [#303](https://github.com/influxdata/influxdb-client-java/pull/303): Change `PermissionResource.type` to `String`
 
 ## 4.3.0 [2022-02-18]
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ public class InfluxDB2ManagementExample {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID("12bdc4164c2e8141");
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         // Read permission
         Permission read = new Permission();

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-core</artifactId>

--- a/client-kotlin/pom.xml
+++ b/client-kotlin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
@@ -84,7 +84,7 @@ internal class ITQueryKotlinApi : AbstractITInfluxDBClientKotlin() {
 
         val resource = PermissionResource()
         resource.orgID = organization.id
-        resource.type = PermissionResource.TypeEnum.BUCKETS
+        resource.type = PermissionResource.TYPE_BUCKETS
         resource.id = bucket.id
 
         val readBucket = Permission()

--- a/client-legacy/pom.xml
+++ b/client-legacy/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.influxdb</groupId>
         <artifactId>influxdb-client</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-flux</artifactId>

--- a/client-osgi/pom.xml
+++ b/client-osgi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-osgi</artifactId>

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -80,7 +80,7 @@ class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
         resource.setId(bucket.getId());
 
         Permission readBucket = new Permission();

--- a/client-scala/cross/2.12/pom.xml
+++ b/client-scala/cross/2.12/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/ITQueryScalaApiQuery.scala
@@ -73,7 +73,7 @@ class ITQueryScalaApiQuery extends AbstractITQueryScalaApi with Matchers {
 
     val resource = new PermissionResource
     resource.setOrgID(organization.getId)
-    resource.setType(PermissionResource.TypeEnum.BUCKETS)
+    resource.setType(PermissionResource.TYPE_BUCKETS)
     resource.setId(bucket.getId)
 
     val readBucket = new Permission

--- a/client-test/pom.xml
+++ b/client-test/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-test</artifactId>

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-utils</artifactId>

--- a/client/README.md
+++ b/client/README.md
@@ -835,7 +835,7 @@ public class InfluxDB2ManagementExample {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID("12bdc4164c2e8141");
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         // Read permission
         Permission read = new Permission();

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/src/generated/java/com/influxdb/client/domain/PermissionResource.java
+++ b/client/src/generated/java/com/influxdb/client/domain/PermissionResource.java
@@ -29,100 +29,34 @@ import java.io.IOException;
  */
 
 public class PermissionResource {
-  /**
-   * Gets or Sets type
-   */
-  @JsonAdapter(TypeEnum.Adapter.class)
-  public enum TypeEnum {
-    AUTHORIZATIONS("authorizations"),
-    
-    BUCKETS("buckets"),
-    
-    DASHBOARDS("dashboards"),
-    
-    ORGS("orgs"),
-    
-    SOURCES("sources"),
-    
-    TASKS("tasks"),
-    
-    TELEGRAFS("telegrafs"),
-    
-    USERS("users"),
-    
-    VARIABLES("variables"),
-    
-    SCRAPERS("scrapers"),
-    
-    SECRETS("secrets"),
-    
-    LABELS("labels"),
-    
-    VIEWS("views"),
-    
-    DOCUMENTS("documents"),
-    
-    NOTIFICATIONRULES("notificationRules"),
-    
-    NOTIFICATIONENDPOINTS("notificationEndpoints"),
-    
-    CHECKS("checks"),
-    
-    DBRP("dbrp"),
-    
-    NOTEBOOKS("notebooks"),
-    
-    ANNOTATIONS("annotations"),
-    
-    REMOTES("remotes"),
-    
-    REPLICATIONS("replications"),
-    
-    FLOWS("flows"),
-    
-    FUNCTIONS("functions");
-
-    private String value;
-
-    TypeEnum(String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    public static TypeEnum fromValue(String text) {
-      for (TypeEnum b : TypeEnum.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
-        }
-      }
-      return null;
-    }
-
-    public static class Adapter extends TypeAdapter<TypeEnum> {
-      @Override
-      public void write(final JsonWriter jsonWriter, final TypeEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
-      }
-
-      @Override
-      public TypeEnum read(final JsonReader jsonReader) throws IOException {
-        String value = jsonReader.nextString();
-        return TypeEnum.fromValue(String.valueOf(value));
-      }
-    }
-  }
-
+  // Possible values for type property:
+  public static String TYPE_AUTHORIZATIONS = "authorizations";
+  public static String TYPE_BUCKETS = "buckets";
+  public static String TYPE_DASHBOARDS = "dashboards";
+  public static String TYPE_ORGS = "orgs";
+  public static String TYPE_SOURCES = "sources";
+  public static String TYPE_TASKS = "tasks";
+  public static String TYPE_TELEGRAFS = "telegrafs";
+  public static String TYPE_USERS = "users";
+  public static String TYPE_VARIABLES = "variables";
+  public static String TYPE_SCRAPERS = "scrapers";
+  public static String TYPE_SECRETS = "secrets";
+  public static String TYPE_LABELS = "labels";
+  public static String TYPE_VIEWS = "views";
+  public static String TYPE_DOCUMENTS = "documents";
+  public static String TYPE_NOTIFICATIONRULES = "notificationRules";
+  public static String TYPE_NOTIFICATIONENDPOINTS = "notificationEndpoints";
+  public static String TYPE_CHECKS = "checks";
+  public static String TYPE_DBRP = "dbrp";
+  public static String TYPE_NOTEBOOKS = "notebooks";
+  public static String TYPE_ANNOTATIONS = "annotations";
+  public static String TYPE_REMOTES = "remotes";
+  public static String TYPE_REPLICATIONS = "replications";
+  public static String TYPE_FLOWS = "flows";
+  public static String TYPE_FUNCTIONS = "functions";
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
-  private TypeEnum type;
+  private String type;
 
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
@@ -140,7 +74,7 @@ public class PermissionResource {
   @SerializedName(SERIALIZED_NAME_ORG)
   private String org;
 
-  public PermissionResource type(TypeEnum type) {
+  public PermissionResource type(String type) {
     this.type = type;
     return this;
   }
@@ -150,11 +84,11 @@ public class PermissionResource {
    * @return type
   **/
   @ApiModelProperty(required = true, value = "")
-  public TypeEnum getType() {
+  public String getType() {
     return type;
   }
 
-  public void setType(TypeEnum type) {
+  public void setType(String type) {
     this.type = type;
   }
 

--- a/client/src/test/java/com/influxdb/client/AbstractITWrite.java
+++ b/client/src/test/java/com/influxdb/client/AbstractITWrite.java
@@ -52,7 +52,7 @@ abstract class AbstractITWrite extends AbstractITClientTest {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         //
         // Add Permissions to read and write to the Bucket

--- a/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
@@ -68,7 +68,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource userResource = new PermissionResource();
         userResource.setOrgID(organization.getId());
-        userResource.setType(PermissionResource.TypeEnum.USERS);
+        userResource.setType(PermissionResource.TYPE_USERS);
 
         Permission readUsers = new Permission();
         readUsers.setAction(Permission.ActionEnum.READ);
@@ -76,7 +76,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource orgResource = new PermissionResource();
         orgResource.setOrgID(organization.getId());
-        orgResource.setType(PermissionResource.TypeEnum.ORGS);
+        orgResource.setType(PermissionResource.TYPE_ORGS);
 
         Permission writeOrganizations = new Permission();
         writeOrganizations.setAction(Permission.ActionEnum.WRITE);
@@ -100,11 +100,11 @@ class ITAuthorizationsApi extends AbstractITClientTest {
         Assertions.assertThat(authorization.getStatus()).isEqualTo(Authorization.StatusEnum.ACTIVE);
 
         Assertions.assertThat(authorization.getPermissions()).hasSize(2);
-        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.USERS);
+        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TYPE_USERS);
         Assertions.assertThat(authorization.getPermissions().get(0).getResource().getOrgID()).isEqualTo(organization.getId());
         Assertions.assertThat(authorization.getPermissions().get(0).getAction()).isEqualTo(Permission.ActionEnum.READ);
 
-        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.ORGS);
+        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TYPE_ORGS);
         Assertions.assertThat(authorization.getPermissions().get(1).getResource().getOrgID()).isEqualTo(organization.getId());
         Assertions.assertThat(authorization.getPermissions().get(1).getAction()).isEqualTo(Permission.ActionEnum.WRITE);
 
@@ -118,7 +118,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.SOURCES);
+        resource.setType(PermissionResource.TYPE_SOURCES);
 
         Permission createSource = new Permission();
         createSource.setResource(resource);
@@ -144,7 +144,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.TASKS);
+        resource.setType(PermissionResource.TYPE_TASKS);
 
         Permission createTask = new Permission();
         createTask.setResource(resource);
@@ -161,10 +161,10 @@ class ITAuthorizationsApi extends AbstractITClientTest {
         Authorization authorization = authorizationsApi.createAuthorization(organization, permissions);
 
         Assertions.assertThat(authorization.getPermissions()).hasSize(2);
-        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.TASKS);
+        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TYPE_TASKS);
         Assertions.assertThat(authorization.getPermissions().get(0).getResource().getOrgID()).isEqualTo(organization.getId());
         Assertions.assertThat(authorization.getPermissions().get(0).getAction()).isEqualTo(Permission.ActionEnum.READ);
-        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.TASKS);
+        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TYPE_TASKS);
         Assertions.assertThat(authorization.getPermissions().get(1).getResource().getOrgID()).isEqualTo(organization.getId());
         Assertions.assertThat(authorization.getPermissions().get(1).getAction()).isEqualTo(Permission.ActionEnum.WRITE);
     }
@@ -177,7 +177,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
         resource.setId(bucket.getId());
 
         Permission readBucket = new Permission();
@@ -196,10 +196,10 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         Assertions.assertThat(authorization.getPermissions()).hasSize(2);
         Assertions.assertThat(authorization.getPermissions().get(0).getResource().getId()).isEqualTo(bucket.getId());
-        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.BUCKETS);
+        Assertions.assertThat(authorization.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TYPE_BUCKETS);
         Assertions.assertThat(authorization.getPermissions().get(0).getAction()).isEqualTo(Permission.ActionEnum.READ);
         Assertions.assertThat(authorization.getPermissions().get(1).getResource().getId()).isEqualTo(bucket.getId());
-        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.BUCKETS);
+        Assertions.assertThat(authorization.getPermissions().get(1).getResource().getType()).isEqualTo(PermissionResource.TYPE_BUCKETS);
         Assertions.assertThat(authorization.getPermissions().get(1).getAction()).isEqualTo(Permission.ActionEnum.WRITE);
     }
 
@@ -283,7 +283,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.USERS);
+        resource.setType(PermissionResource.TYPE_USERS);
 
         Permission readUsers = new Permission();
         readUsers.setAction(Permission.ActionEnum.READ);
@@ -341,7 +341,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
         Assertions.assertThat(cloned.getDescription()).isEqualTo(source.getDescription());
         Assertions.assertThat(cloned.getPermissions()).hasSize(1);
         Assertions.assertThat(cloned.getPermissions().get(0).getAction()).isEqualTo(Permission.ActionEnum.READ);
-        Assertions.assertThat(cloned.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TypeEnum.USERS);
+        Assertions.assertThat(cloned.getPermissions().get(0).getResource().getType()).isEqualTo(PermissionResource.TYPE_USERS);
         Assertions.assertThat(cloned.getPermissions().get(0).getResource().getOrgID()).isEqualTo(organization.getId());
     }
 
@@ -358,7 +358,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.USERS);
+        resource.setType(PermissionResource.TYPE_USERS);
 
         Permission permission = new Permission();
         permission.setAction(Permission.ActionEnum.READ);

--- a/client/src/test/java/com/influxdb/client/ITDeleteApi.java
+++ b/client/src/test/java/com/influxdb/client/ITDeleteApi.java
@@ -67,7 +67,7 @@ class ITDeleteApi extends AbstractITClientTest {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         //
         // Add Permissions to read and write to the Bucket

--- a/client/src/test/java/com/influxdb/client/ITTasksApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTasksApi.java
@@ -731,7 +731,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         PermissionResource resource = new PermissionResource();
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.TASKS);
+        resource.setType(PermissionResource.TYPE_TASKS);
 
         Permission createTask = new Permission();
         createTask.setResource(resource);
@@ -742,7 +742,7 @@ class ITTasksApi extends AbstractITClientTest {
         deleteTask.setAction(Permission.ActionEnum.WRITE);
 
         PermissionResource orgResource = new PermissionResource();
-        orgResource.setType(PermissionResource.TypeEnum.ORGS);
+        orgResource.setType(PermissionResource.TYPE_ORGS);
 
         Permission createOrg = new Permission();
         createOrg.setAction(Permission.ActionEnum.WRITE);
@@ -753,14 +753,14 @@ class ITTasksApi extends AbstractITClientTest {
         readOrg.setResource(orgResource);
 
         PermissionResource userResource = new PermissionResource();
-        userResource.setType(PermissionResource.TypeEnum.USERS);
+        userResource.setType(PermissionResource.TYPE_USERS);
 
         Permission createUsers = new Permission();
         createUsers.setAction(Permission.ActionEnum.WRITE);
         createUsers.setResource(userResource);
 
         PermissionResource labelResource = new PermissionResource();
-        labelResource.setType(PermissionResource.TypeEnum.LABELS);
+        labelResource.setType(PermissionResource.TYPE_LABELS);
 
         Permission createLabels = new Permission();
         createLabels.setAction(Permission.ActionEnum.WRITE);
@@ -771,7 +771,7 @@ class ITTasksApi extends AbstractITClientTest {
         readLabels.setResource(labelResource);
 
         PermissionResource authResource = new PermissionResource();
-        authResource.setType(PermissionResource.TypeEnum.AUTHORIZATIONS);
+        authResource.setType(PermissionResource.TYPE_AUTHORIZATIONS);
 
         Permission createAuth = new Permission();
         createAuth.setAction(Permission.ActionEnum.WRITE);
@@ -782,7 +782,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         PermissionResource bucketResource = new PermissionResource();
         bucketResource.setOrgID(organization.getId());
-        bucketResource.setType(PermissionResource.TypeEnum.BUCKETS);
+        bucketResource.setType(PermissionResource.TYPE_BUCKETS);
         bucketResource.setId(bucket.getId());
 
         Permission readBucket = new Permission();

--- a/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
@@ -78,7 +78,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID(organization.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         //
         // Add Permissions to read and write to the Bucket
@@ -409,7 +409,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
         PermissionResource bucketResource = new PermissionResource();
         bucketResource.setId(bucket.getId());
         bucketResource.setOrgID(organization.getId());
-        bucketResource.setType(PermissionResource.TypeEnum.BUCKETS);
+        bucketResource.setType(PermissionResource.TYPE_BUCKETS);
 
         Permission readBucket = new Permission();
         readBucket.setResource(bucketResource);
@@ -422,7 +422,7 @@ class ITWriteQueryApi extends AbstractITClientTest {
         PermissionResource orgResource = new PermissionResource();
         orgResource.setId(organization.getId());
         orgResource.setOrgID(organization.getId());
-        orgResource.setType(PermissionResource.TypeEnum.ORGS);
+        orgResource.setType(PermissionResource.TYPE_ORGS);
 
         Permission readOrganization = new Permission();
         readOrganization.setResource(orgResource);

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -1017,7 +1017,7 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         String userAgent = recordedRequest.getHeader("User-Agent");
 
-        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/4.");
+        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/5.");
     }
 
     public abstract class Metric {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,12 +27,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>
-        <influxdb-client.version>4.4.0-SNAPSHOT</influxdb-client.version>
+        <influxdb-client.version>5.0.0-SNAPSHOT</influxdb-client.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/src/main/java/example/InfluxDB2ManagementExample.java
+++ b/examples/src/main/java/example/InfluxDB2ManagementExample.java
@@ -53,7 +53,7 @@ public class InfluxDB2ManagementExample {
         PermissionResource resource = new PermissionResource();
         resource.setId(bucket.getId());
         resource.setOrgID("12bdc4164c2e8141");
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         // Read permission
         Permission read = new Permission();

--- a/examples/src/main/java/example/PlatformExample.java
+++ b/examples/src/main/java/example/PlatformExample.java
@@ -92,7 +92,7 @@ public class PlatformExample {
         PermissionResource resource = new PermissionResource();
         resource.setId(temperatureBucket.getId());
         resource.setOrgID(medicalGMBH.getId());
-        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+        resource.setType(PermissionResource.TYPE_BUCKETS);
 
         Permission readBucket = new Permission();
         readBucket.setResource(resource);
@@ -180,7 +180,7 @@ public class PlatformExample {
                 .filter(authorization -> authorization.getPermissions().stream()
                         .map(Permission::getResource)
                         .anyMatch(resource ->
-                                resource.getType().equals(PermissionResource.TypeEnum.ORGS) &&
+                                resource.getType().equals(PermissionResource.TYPE_ORGS) &&
                                         resource.getId() == null &&
                                         resource.getOrgID() == null))
                 .findFirst()

--- a/flux-dsl/pom.xml
+++ b/flux-dsl/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flux-dsl</artifactId>

--- a/karaf/karaf-assembly/pom.xml
+++ b/karaf/karaf-assembly/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-assembly</artifactId>

--- a/karaf/karaf-features/pom.xml
+++ b/karaf/karaf-features/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-features</artifactId>

--- a/karaf/karaf-kar/pom.xml
+++ b/karaf/karaf-kar/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-kar</artifactId>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>influxdb-karaf-features</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>5.0.0-SNAPSHOT</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.influxdb</groupId>
     <artifactId>influxdb-client</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -473,38 +473,38 @@
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-test</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-core</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-utils</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-reactive</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-flux</artifactId>
-                <version>4.4.0-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>influxdb-spring</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring Integration for InfluxDB 2.0</name>


### PR DESCRIPTION
## Proposed Changes

The `PermissionResource.type` is not constant value and can evolve as the API of InfluxDB changing. 

=>

Change type of `PermissionResource.type` to `String`. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
