### PR TITLE
fix: installation instruction for Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Download the latest version:
 
 ```groovy
 dependencies {
-    compile "com.influxdb:influxdb-client-java:4.3.0"
+    implementation "com.influxdb:influxdb-client-java:4.3.0"
 }
 ```
 
@@ -225,7 +225,7 @@ Download the latest version:
 
 ```groovy
 dependencies {
-    compile "com.influxdb:influxdb-client-java:4.3.0"
+    implementation "com.influxdb:influxdb-client-java:4.3.0"
 }
 ```
 
@@ -326,7 +326,7 @@ Download the latest version:
 
 ```groovy
 dependencies {
-    compile "com.influxdb:influxdb-client-flux:4.3.0"
+    implementation "com.influxdb:influxdb-client-flux:4.3.0"
 }
 ``` 
 


### PR DESCRIPTION
Closes #

## Proposed Changes

_Briefly describe your proposed changes:_

Correct compile in README.md which doesn't exist anymore with Gradle 7.0 and was deprecated in favour of implementation since Gradle 5.0

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [✅] Rebased/mergeable
- [✅] A test has been added if appropriate
- [✅] `mvn test` completes successfully
- [✅] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [✅] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
