### PR TITLE
fix(reactive): do not deliver exception when the consumer is disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.1.0 [unreleased]
 
+### Bug Fixes
+1. [#313](https://github.com/influxdata/influxdb-client-java/pull/313): Do not deliver `exception` when the consumer is already disposed [influxdb-client-reactive]
+
 ## 5.0.0 [2022-03-18]
 
 ### Breaking Changes
@@ -12,7 +15,6 @@
 
 ### Bug Fixes
 1. [#303](https://github.com/influxdata/influxdb-client-java/pull/303): Change `PermissionResource.type` to `String`
-1. [#313](https://github.com/influxdata/influxdb-client-java/pull/313): Do not deliver `exception` when the consumer is already disposed [influxdb-client-reactive]
 
 ### CI
 1. [#304](https://github.com/influxdata/influxdb-client-java/pull/304): Use new Codecov uploader for reporting code coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 1. [#303](https://github.com/influxdata/influxdb-client-java/pull/303): Change `PermissionResource.type` to `String`
+1. [#313](https://github.com/influxdata/influxdb-client-java/pull/313): Do not deliver `exception` when the consumer is already disposed [influxdb-client-reactive]
 
 ### CI
 1. [#304](https://github.com/influxdata/influxdb-client-java/pull/304): Use new Codecov uploader for reporting code coverage

--- a/client-core/src/main/java/com/influxdb/internal/AbstractQueryApi.java
+++ b/client-core/src/main/java/com/influxdb/internal/AbstractQueryApi.java
@@ -62,7 +62,7 @@ import retrofit2.Response;
  */
 public abstract class AbstractQueryApi extends AbstractRestClient {
 
-    private static final Logger LOG = Logger.getLogger(AbstractQueryApi.class.getName());
+    protected static final Logger LOG = Logger.getLogger(AbstractQueryApi.class.getName());
 
     protected final FluxCsvParser fluxCsvParser = new FluxCsvParser();
     protected final FluxResultMapper resultMapper = new FluxResultMapper();

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.client.reactive;
+
+import java.io.InterruptedIOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.influxdb.test.AbstractMockServerTest;
+
+import io.reactivex.Flowable;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jakub Bednar (03/16/2022 08:28)
+ */
+@RunWith(JUnitPlatform.class)
+class QueryReactiveApiTest extends AbstractMockServerTest {
+
+    private InfluxDBClientReactive influxDBClient;
+
+    @BeforeEach
+    void setUp() {
+
+        influxDBClient = InfluxDBClientReactiveFactory.create(startMockServer());
+    }
+
+    @AfterEach
+    void tearDown() {
+
+        influxDBClient.close();
+    }
+
+    @Test
+    public void doNotPropagateErrorOnCanceledConsumer() throws InterruptedException {
+
+        mockServer.enqueue(createErrorResponse("Request Timeout", true, 408)
+                .setBodyDelay(3, TimeUnit.SECONDS));
+
+        QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
+
+        final Throwable[] throwable = new Throwable[1];
+        Future<?> future = Executors
+                .newSingleThreadScheduledExecutor()
+                .scheduleWithFixedDelay(() -> Flowable
+                                .fromPublisher(queryApi.queryRaw("from()", "my-org"))
+                                .subscribe(
+                                        s -> {
+
+                                        },
+                                        t -> throwable[0] = t),
+                        0, 1, TimeUnit.SECONDS);
+
+        Thread.sleep(2_000);
+        future.cancel(true);
+        Thread.sleep(2_000);
+
+        Assertions.assertThat(throwable[0]).isNotNull();
+        Assertions.assertThat(throwable[0]).isInstanceOf(InterruptedIOException.class);
+    }
+}


### PR DESCRIPTION
Closes #311 

## Proposed Changes

Do not deliver `throwable` if the consumer is already disposed or cancelled.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
