### PR TITLE
feat(flux_dsl): add support for timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     + resource.setType(PermissionResource.TYPE_BUCKETS);
     ```
 
+### Features
+1. [#315](https://github.com/influxdata/influxdb-client-java/pull/315): Add support for timezones [FluxDSL]
+
 ### Bug Fixes
 1. [#303](https://github.com/influxdata/influxdb-client-java/pull/303): Change `PermissionResource.type` to `String`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#316](https://github.com/influxdata/influxdb-client-java/pull/316): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+1. [#315](https://github.com/influxdata/influxdb-client-java/pull/315): Add support for timezones [FluxDSL]
 
 ### Bug Fixes
 1. [#313](https://github.com/influxdata/influxdb-client-java/pull/313): Do not deliver `exception` when the consumer is already disposed [influxdb-client-reactive]
@@ -15,9 +16,6 @@
     - resource.setType(PermissionResource.TypeEnum.BUCKETS);
     + resource.setType(PermissionResource.TYPE_BUCKETS);
     ```
-
-### Features
-1. [#315](https://github.com/influxdata/influxdb-client-java/pull/315): Add support for timezones [FluxDSL]
 
 ### Bug Fixes
 1. [#303](https://github.com/influxdata/influxdb-client-java/pull/303): Change `PermissionResource.type` to `String`

--- a/flux-dsl/README.md
+++ b/flux-dsl/README.md
@@ -1,6 +1,13 @@
 # flux-dsl
 
-## Operator properties
+## Features
+
+- [Function properties](#function-properties)
+- [Supported functions](#supported-functions)
+- [Custom function](#custom-function)
+- [Time zones](#time-zones)
+
+## Function properties
 There are four possibilities how to add properties to the functions.
 
 ### Use built-in constructor
@@ -41,7 +48,7 @@ Flux flux = Flux
     .sum();
 ```
 
-## Supported operators
+## Supported functions
 
 ### from
 
@@ -793,7 +800,7 @@ Flux flux = Flux
     .yield("0");
 ```
 
-## Custom operator
+## Custom function
 We assume that exist custom function measurement that filter measurement by their name. The `Flux` implementation looks like this: 
 
 ```flux
@@ -849,3 +856,44 @@ from(bucket:"telegraf")
     |> sum()
 ```
 
+## Time zones
+
+The Flux option sets the default time zone of all times in the script. The default value is `timezone.utc`.
+
+You can construct a timezone with a fixed offset:
+
+```java
+Flux flux = Flux
+    .from("telegraf")
+    .withLocationFixed("-8h")
+    .count();
+```
+
+The Flux script:
+```
+import "timezone"
+
+option location = timezone.fixed(offset: -8h)
+
+from(bucket:"telegraf")
+    |> count()
+```
+
+or you can construct a timezone based on a location name:
+
+```java
+Flux flux = Flux
+    .from("telegraf")
+    .withLocationNamed("America/Los_Angeles")
+    .count(
+```
+
+The Flux script:
+```
+import "timezone"
+
+option location = timezone.location(name: "America/Los_Angeles")
+
+from(bucket:"telegraf")
+    |> count()
+```

--- a/flux-dsl/README.md
+++ b/flux-dsl/README.md
@@ -885,7 +885,7 @@ or you can construct a timezone based on a location name:
 Flux flux = Flux
     .from("telegraf")
     .withLocationNamed("America/Los_Angeles")
-    .count(
+    .count();
 ```
 
 The Flux script:

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
@@ -149,10 +149,10 @@ public abstract class Flux {
      * @return {@link FromFlux}
      */
     @Nonnull
-    public static Flux from(@Nonnull final String bucket) {
+    public static FromFlux from(@Nonnull final String bucket) {
         Arguments.checkNonEmpty(bucket, "Bucket name");
 
-        return new FromFlux().withPropertyValueEscaped("bucket", bucket);
+        return new FromFlux().withBucket(bucket);
     }
 
     /**
@@ -163,13 +163,13 @@ public abstract class Flux {
      * @return {@link FromFlux}
      */
     @Nonnull
-    public static Flux from(@Nonnull final String bucket, @Nonnull final Collection<String> hosts) {
+    public static FromFlux from(@Nonnull final String bucket, @Nonnull final Collection<String> hosts) {
         Arguments.checkNonEmpty(bucket, "Bucket name");
         Arguments.checkNotNull(hosts, "Hosts are required");
 
         return new FromFlux()
-                .withPropertyValueEscaped("bucket", bucket)
-                .withPropertyValue("hosts", hosts);
+                .withBucket(bucket)
+                .withHosts(hosts);
     }
 
     /**
@@ -180,13 +180,13 @@ public abstract class Flux {
      * @return {@link FromFlux}
      */
     @Nonnull
-    public static Flux from(@Nonnull final String bucket, @Nonnull final String[] hosts) {
+    public static FromFlux from(@Nonnull final String bucket, @Nonnull final String[] hosts) {
         Arguments.checkNonEmpty(bucket, "Database name");
         Arguments.checkNotNull(hosts, "Hosts are required");
 
         return new FromFlux()
-                .withPropertyValueEscaped("bucket", bucket)
-                .withPropertyValue("hosts", hosts);
+                .withBucket(bucket)
+                .withHosts(hosts);
     }
 
     /**

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
@@ -125,7 +125,7 @@ public final class JoinFlux extends AbstractParametrizedFlux {
     }
 
     /**
-     * Map of table to join. Currently only two tables are allowed.
+     * Map of table to join. Currently, only two tables are allowed.
      *
      * @param name  table name
      * @param table Flux script to map table

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/FluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/FluxTest.java
@@ -88,4 +88,26 @@ class FluxTest {
 
         Assertions.assertThat(flux.toString()).isEqualToIgnoringWhitespace("from(bucket:\"telegraf\") |> count()");
     }
+
+    @Test
+    void withLocationNamed() {
+
+        Flux flux = Flux
+                .from("telegraf")
+                .withLocationNamed("America/Los_Angeles")
+                .count();
+
+        Assertions.assertThat(flux.toString()).isEqualToIgnoringWhitespace("import \"timezone\" option location = timezone.location(name: \"America/Los_Angeles\") from(bucket:\"telegraf\") |> count()");
+    }
+
+    @Test
+    void withLocationFixed() {
+
+        Flux flux = Flux
+                .from("telegraf")
+                .withLocationFixed("-8h")
+                .count();
+
+        Assertions.assertThat(flux.toString()).isEqualToIgnoringWhitespace("import \"timezone\" option location = timezone.fixed(offset: -8h) from(bucket:\"telegraf\") |> count()");
+    }
 }


### PR DESCRIPTION
Closes #309 

## Proposed Changes

Add support for timezones:

```java
Flux flux = Flux
    .from("telegraf")
    .withLocationFixed("-8h")
    .count();
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
