### PR TITLE
chore: update readme to use 2.x InfluxDB version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 [![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/influxdata/influxdb-client-java.svg)](https://github.com/influxdata/influxdb-client-java/pulls)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://www.influxdata.com/slack)
 
-This repository contains the reference JVM clients for the InfluxDB 2.0. Currently, Java, Reactive, Kotlin and Scala clients are implemented.
+This repository contains the reference JVM clients for the InfluxDB 2.x. Currently, Java, Reactive, Kotlin and Scala clients are implemented.
 
 #### Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+ ([see details](#influxdb-18-api-compatibility)). For connecting to InfluxDB 1.7 or earlier instances, use the [influxdb-java](https://github.com/influxdata/influxdb-java) client library.
 
 - [Features](#features)
 - [Clients](#clients)
 - [How To Use](#how-to-use)
-    - [Writes and Queries in InfluxDB 2.0](#writes-and-queries-in-influxdb-20)
-    - [Use Management API to create a new Bucket in InfluxDB 2.0](#use-management-api-to-create-a-new-bucket-in-influxdb-20)
+    - [Writes and Queries in InfluxDB 2.x](#writes-and-queries-in-influxdb-2x)
+    - [Use Management API to create a new Bucket in InfluxDB 2.x](#use-management-api-to-create-a-new-bucket-in-influxdb-2x)
     - [Flux queries in InfluxDB 1.7+](#flux-queries-in-influxdb-17)
 - [Build Requirements](#build-requirements)
 - [Contributing](#contributing)
@@ -27,20 +27,20 @@ This repository contains the reference JVM clients for the InfluxDB 2.0. Current
 
 This section contains links to the client library documentation.
 
-* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#how-to-use)
+* [Product documentation](https://docs.influxdata.com/influxdb/v2.x/api-guide/client-libraries/), [Getting Started](#how-to-use)
 * [Examples](examples)
 * [API Reference](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/index.html)
 * [Changelog](CHANGELOG.md)
 
 ## Features
 
-- InfluxDB 2.0 client
+- InfluxDB 2.x client
     - Querying data using the Flux language
     - Writing data using
         - [Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/) 
         - [Data Point](https://github.com/influxdata/influxdb-client-java/blob/master/client/src/main/java/org/influxdata/client/write/Point.java#L46) 
         - POJO
-    - InfluxDB 2.0 Management API client for managing
+    - InfluxDB 2.x Management API client for managing
         - sources, buckets
         - tasks
         - authorizations
@@ -50,16 +50,16 @@ This section contains links to the client library documentation.
          
 ## Clients
 
-The Java, Reactive, OSGi, Kotlin and Scala clients are implemented for the InfluxDB 2.0:
+The Java, Reactive, OSGi, Kotlin and Scala clients are implemented for the InfluxDB 2.x:
 
 | Client | Description | Documentation | Compatibility |
 | --- | --- | --- |                                      --- |
-| **[java](./client)** | The reference Java client that allows query, write and InfluxDB 2.0 management. |  [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/index.html), [readme](./client#influxdb-client-java/)| 2.0 |
-| **[reactive](./client-reactive)**  | The reference RxJava client for the InfluxDB 2.0 that allows query and write in a reactive way.| [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/index.html), [readme](./client-reactive#influxdb-client-reactive/) |2.0 |
-| **[kotlin](./client-kotlin)** | The reference Kotlin client that allows query and write for the InfluxDB 2.0 by Kotlin [Channel](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/index.html) and [Flow](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/index.html) coroutines. | [KDoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-kotlin/dokka/influxdb-client-kotlin/com.influxdb.client.kotlin/index.html), [readme](./client-kotlin#influxdb-client-kotlin/) | 2.0|
-| **[scala](./client-scala)** | The reference Scala client that allows query and write for the InfluxDB 2.0 by [Akka Streams](https://doc.akka.io/docs/akka/2.6/stream/). | [Scaladoc](https://influxdata.github.io/influxdb-client-java/client-scala/cross/influxdb-client-scala_2.13/scaladocs/com/influxdb/client/scala/index.html), [readme](./client-scala#influxdb-client-scala/) | 2.0 |
-| **[osgi](./client-osgi)** | The reference OSGi (R6) client embedding Java and reactive clients and providing standard features (declarative services, configuration, event processing) for the InfluxDB 2.0. | [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-osgi/apidocs/index.html), [readme](./client-osgi) | 2.0 |
-| **[karaf](./karaf)** | The Apache Karaf feature definition for the InfluxDB 2.0. | [readme](./karaf) | 2.0 |
+| **[java](./client)** | The reference Java client that allows query, write and InfluxDB 2.x management. |  [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/index.html), [readme](./client#influxdb-client-java/)| 2.x |
+| **[reactive](./client-reactive)**  | The reference RxJava client for the InfluxDB 2.x that allows query and write in a reactive way.| [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/index.html), [readme](./client-reactive#influxdb-client-reactive/) |2.x |
+| **[kotlin](./client-kotlin)** | The reference Kotlin client that allows query and write for the InfluxDB 2.x by Kotlin [Channel](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/index.html) and [Flow](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/index.html) coroutines. | [KDoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-kotlin/dokka/influxdb-client-kotlin/com.influxdb.client.kotlin/index.html), [readme](./client-kotlin#influxdb-client-kotlin/) | 2.x|
+| **[scala](./client-scala)** | The reference Scala client that allows query and write for the InfluxDB 2.x by [Akka Streams](https://doc.akka.io/docs/akka/2.6/stream/). | [Scaladoc](https://influxdata.github.io/influxdb-client-java/client-scala/cross/influxdb-client-scala_2.13/scaladocs/com/influxdb/client/scala/index.html), [readme](./client-scala#influxdb-client-scala/) | 2.x |
+| **[osgi](./client-osgi)** | The reference OSGi (R6) client embedding Java and reactive clients and providing standard features (declarative services, configuration, event processing) for the InfluxDB 2.x. | [javadoc](https://influxdata.github.io/influxdb-client-java/influxdb-client-osgi/apidocs/index.html), [readme](./client-osgi) | 2.x |
+| **[karaf](./karaf)** | The Apache Karaf feature definition for the InfluxDB 2.x. | [readme](./karaf) | 2.x |
 
 There is also possibility to use the Flux language over the InfluxDB 1.7+ provided by: 
 
@@ -78,7 +78,7 @@ Flux flux = Flux
 
 | Module | Description | Documentation | Compatibility |
 | --- | --- | --- |                                      --- |
-| **[flux-dsl](./flux-dsl)** | A Java query builder for the Flux language | [javadoc](https://influxdata.github.io/influxdb-client-java/flux-dsl/apidocs/index.html), [readme](./flux-dsl#flux-dsl/)| 1.7+, 2.0 |
+| **[flux-dsl](./flux-dsl)** | A Java query builder for the Flux language | [javadoc](https://influxdata.github.io/influxdb-client-java/flux-dsl/apidocs/index.html), [readme](./flux-dsl#flux-dsl/)| 1.7+, 2.x |
 
 
 ## How To Use  
@@ -87,9 +87,9 @@ This clients are hosted in Maven central Repository.
 
 If you want to use it with the Maven, you have to add only the dependency on the artifact.
 
-### Writes and Queries in InfluxDB 2.0
+### Writes and Queries in InfluxDB 2.x
 
-The following example demonstrates how to write data to InfluxDB 2.0 and read them back using the Flux language.
+The following example demonstrates how to write data to InfluxDB 2.x and read them back using the Flux language.
 
 #### Installation
 
@@ -203,9 +203,9 @@ public class InfluxDB2Example {
 }
 ```    
 
-### Use Management API to create a new Bucket in InfluxDB 2.0  
+### Use Management API to create a new Bucket in InfluxDB 2.x  
 
-The following example demonstrates how to use a InfluxDB 2.0 Management API. For further information see [client documentation](./client#management-api).
+The following example demonstrates how to use a InfluxDB 2.x Management API. For further information see [client documentation](./client#management-api).
 
 #### Installation
 
@@ -292,14 +292,14 @@ public class InfluxDB2ManagementExample {
 
 ### InfluxDB 1.8 API compatibility
 
-[InfluxDB 1.8.0 introduced forward compatibility APIs](https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints) for InfluxDB 2.0. This allow you to easily move from InfluxDB 1.x to InfluxDB 2.0 Cloud or open source.
+[InfluxDB 1.8.0 introduced forward compatibility APIs](https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints) for InfluxDB 2.x. This allow you to easily move from InfluxDB 1.x to InfluxDB 2.x Cloud or open source.
 
 The following forward compatible APIs are available:
 
 | API | Endpoint | Description |
 |:----------|:----------|:----------|
-| [QueryApi.java](client/src/main/java/com/influxdb/client/QueryApi.java) | [/api/v2/query](https://docs.influxdata.com/influxdb/latest/tools/api/#api-v2-query-http-endpoint) | Query data in InfluxDB 1.8.0+ using the InfluxDB 2.0 API and [Flux](https://docs.influxdata.com/flux/latest/) _(endpoint should be enabled by [`flux-enabled` option](https://docs.influxdata.com/influxdb/latest/administration/config/#flux-enabled-false))_  |
-| [WriteApi.java](client/src/main/java/com/influxdb/client/WriteApi.java) | [/api/v2/write](https://docs.influxdata.com/influxdb/latest/tools/api/#api-v2-write-http-endpoint) | Write data to InfluxDB 1.8.0+ using the InfluxDB 2.0 API |
+| [QueryApi.java](client/src/main/java/com/influxdb/client/QueryApi.java) | [/api/v2/query](https://docs.influxdata.com/influxdb/latest/tools/api/#api-v2-query-http-endpoint) | Query data in InfluxDB 1.8.0+ using the InfluxDB 2.x API and [Flux](https://docs.influxdata.com/flux/latest/) _(endpoint should be enabled by [`flux-enabled` option](https://docs.influxdata.com/influxdb/latest/administration/config/#flux-enabled-false))_  |
+| [WriteApi.java](client/src/main/java/com/influxdb/client/WriteApi.java) | [/api/v2/write](https://docs.influxdata.com/influxdb/latest/tools/api/#api-v2-write-http-endpoint) | Write data to InfluxDB 1.8.0+ using the InfluxDB 2.x API |
 | [health()](client/src/main/java/com/influxdb/client/InfluxDBClient.java#L236) | [/health](https://docs.influxdata.com/influxdb/latest/tools/api/#health-http-endpoint) | Check the health of your InfluxDB instance |    
 
 For detail info see [InfluxDB 1.8 example](examples/src/main/java/example/InfluxDB18Example.java).
@@ -395,7 +395,7 @@ public class FluxExample {
 * Java 1.8+ (tested with jdk8)
 * Maven 3.0+ (tested with maven 3.5.0)
 * Docker daemon running
-* The latest InfluxDB 2.0 and InfluxDB 1.X docker instances, which can be started using the `./scripts/influxdb-restart.sh` script
+* The latest InfluxDB 2.x and InfluxDB 1.X docker instances, which can be started using the `./scripts/influxdb-restart.sh` script
 
 
 Once these are in place you can build influxdb-client-java with all tests with:
@@ -429,4 +429,4 @@ If you would like to contribute code you can do through GitHub by forking the re
 
 ## License
 
-The InfluxDB 2.0 JVM Based Clients are released under the [MIT License](https://opensource.org/licenses/MIT).
+The InfluxDB 2.x JVM Based Clients are released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/client-kotlin/README.md
+++ b/client-kotlin/README.md
@@ -2,13 +2,13 @@
 
 [![KDoc](https://img.shields.io/badge/KDoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-kotlin/dokka/influxdb-client-kotlin/com.influxdb.client.kotlin/index.html)
 
-The reference Kotlin client that allows query and write for the InfluxDB 2.0 by Kotlin Channel coroutines. 
+The reference Kotlin client that allows query and write for the InfluxDB 2.x by Kotlin Channel coroutines. 
 
 ## Documentation
 
 This section contains links to the client library documentation.
 
-* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#queries)
+* [Product documentation](https://docs.influxdata.com/influxdb/latest/api-guide/client-libraries/), [Getting Started](#queries)
 * [Examples](../examples)
 * [API Reference](https://influxdata.github.io/influxdb-client-java/influxdb-client-kotlin/dokka/influxdb-client-kotlin/com.influxdb.client.kotlin/index.html)
 * [Changelog](../CHANGELOG.md)

--- a/client-kotlin/pom.xml
+++ b/client-kotlin/pom.xml
@@ -33,9 +33,9 @@
     <artifactId>influxdb-client-kotlin</artifactId>
     <packaging>jar</packaging>
 
-    <name>The Kotlin InfluxDB 2.0 Client</name>
+    <name>The Kotlin InfluxDB 2.x Client</name>
     <description>
-        The reference Kotlin client that allows query and write for the InfluxDB 2.0
+        The reference Kotlin client that allows query and write for the InfluxDB 2.x
         by Kotlin Channel and Flow coroutines.
     </description>
 

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlin.kt
@@ -27,7 +27,7 @@ import java.io.Closeable
 import javax.annotation.Nonnull
 
 /**
- * The reference Kotlin client that allows query and write for the InfluxDB 2.0 by Kotlin Channel coroutines.
+ * The reference Kotlin client that allows query and write for the InfluxDB 2.x by Kotlin Channel coroutines.
  * 
  * @author Jakub Bednar (bednar@github) (07/02/2019 13:11)
  */

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
@@ -35,7 +35,7 @@ class InfluxDBClientKotlinFactory {
     companion object {
 
         /**
-         * Create an instance of the InfluxDB 2.0 client that is configured via {@code influx2.properties}.
+         * Create an instance of the InfluxDB 2.x client that is configured via {@code influx2.properties}.
          * The {@code influx2.properties} has to be located on classpath.
          *
          * @return client
@@ -50,7 +50,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 client. The url could be a connection string with various configurations.
+         * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
          *
          * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
          *
@@ -67,7 +67,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 reactive client.
+         * Create an instance of the InfluxDB 2.x reactive client.
          *
          * <p>
          * The <i>username/password</i> auth is based on
@@ -95,7 +95,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 reactive client.
+         * Create an instance of the InfluxDB 2.x reactive client.
          *
          * @param url   the url to connect to the InfluxDB
          * @param token the token to use for the authorization
@@ -108,7 +108,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 reactive client.
+         * Create an instance of the InfluxDB 2.x reactive client.
          *
          * @param url   the url to connect to the InfluxDB
          * @param token the token to use for the authorization
@@ -122,7 +122,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 reactive client.
+         * Create an instance of the InfluxDB 2.x reactive client.
          *
          * @param url   the url to connect to the InfluxDB
          * @param token the token to use for the authorization
@@ -144,7 +144,7 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.0 reactive client.
+         * Create an instance of the InfluxDB 2.x reactive client.
          *
          * @param options the connection configuration
          * @return client

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/WriteKotlinApi.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/WriteKotlinApi.kt
@@ -26,7 +26,7 @@ import com.influxdb.client.write.Point
 import kotlinx.coroutines.flow.Flow
 
 /**
- * The Kotlin API to write time-series data into InfluxDB 2.0.
+ * The Kotlin API to write time-series data into InfluxDB 2.x.
  *
  * @author Jakub Bednar (20/04/2021 8:18)
  */

--- a/client-legacy/README.md
+++ b/client-legacy/README.md
@@ -8,7 +8,7 @@ The client that allow perform Flux Query against the InfluxDB 1.7+.
 
 This section contains links to the client library documentation.
 
-* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#create-client)
+* [Product documentation](https://docs.influxdata.com/influxdb/latest/api-guide/client-libraries/), [Getting Started](#create-client)
 * [Examples](../examples)
 * [API Reference](https://influxdata.github.io/influxdb-client-java/influxdb-client-flux/apidocs/index.html)
 * [Changelog](../CHANGELOG.md)

--- a/client-osgi/README.md
+++ b/client-osgi/README.md
@@ -1,8 +1,8 @@
-# OSGi Client Bundle for InfluxDB 2.0
+# OSGi Client Bundle for InfluxDB 2.x
 
 [![javadoc](https://img.shields.io/badge/javadoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-osgi/apidocs/index.html)
 
-OSGi (R6) client bundle contains InfluxDB 2.0 client and dependencies excluding Kotlin and JSR-305 (FindBugs).
+OSGi (R6) client bundle contains InfluxDB 2.x client and dependencies excluding Kotlin and JSR-305 (FindBugs).
 
 ## Services
 

--- a/client-osgi/pom.xml
+++ b/client-osgi/pom.xml
@@ -34,9 +34,9 @@
     <artifactId>influxdb-client-osgi</artifactId>
     <packaging>bundle</packaging>
 
-    <name>The OSGi InfluxDB 2.0 Client</name>
+    <name>The OSGi InfluxDB 2.x Client</name>
     <description>
-        InfluxDB 2.0 Java client extension for OSGi environments.
+        InfluxDB 2.x Java client extension for OSGi environments.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java/tree/master/client-osgi</url>

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -2,7 +2,7 @@
 
 [![javadoc](https://img.shields.io/badge/javadoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/index.html)
 
-The reference reactive Java client for InfluxDB 2.0. The client provide supports for asynchronous stream processing with backpressure as is defined by the [Reactive Streams specification](http://www.reactive-streams.org/).
+The reference reactive Java client for InfluxDB 2.x. The client provide supports for asynchronous stream processing with backpressure as is defined by the [Reactive Streams specification](http://www.reactive-streams.org/).
 
 ## Important
 
@@ -13,7 +13,7 @@ That means no request to InfluxDB is trigger until register a subscription to `P
 
 This section contains links to the client library documentation.
 
-* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#queries)
+* [Product documentation](https://docs.influxdata.com/influxdb/latest/api-guide/client-libraries/), [Getting Started](#queries)
 * [Examples](../examples)
 * [API Reference](https://influxdata.github.io/influxdb-client-java/influxdb-client-reactive/apidocs/index.html)
 * [Changelog](../CHANGELOG.md)

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -33,9 +33,9 @@
     <artifactId>influxdb-client-reactive</artifactId>
     <packaging>jar</packaging>
 
-    <name>The RxJava InfluxDB 2.0 Client</name>
+    <name>The RxJava InfluxDB 2.x Client</name>
     <description>
-        The reference reactive Java client for InfluxDB 2.0. The client provide supports for asynchronous stream
+        The reference reactive Java client for InfluxDB 2.x. The client provide supports for asynchronous stream
         processing with backpressure as is defined by the Reactive Streams.
     </description>
 

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactive.java
@@ -30,7 +30,7 @@ import com.influxdb.client.domain.HealthCheck;
 import io.reactivex.Single;
 
 /**
- *  The reference RxJava client for the <a href="https://github.com/influxdata/influxdb">InfluxDB 2.0</a>
+ *  The reference RxJava client for the <a href="https://github.com/influxdata/influxdb">InfluxDB 2.x</a>
  *  that allows query and write in a reactive way.
  *
  * @author Jakub Bednar (bednar@github) (20/11/2018 07:08)

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
@@ -39,7 +39,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client that is configured via {@code influx2.properties}.
+     * Create an instance of the InfluxDB 2.x client that is configured via {@code influx2.properties}.
      * The {@code influx2.properties} has to be located on classpath.
      *
      * @return client
@@ -55,7 +55,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client. The url could be a connection string with various configurations.
+     * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
      * <p>
      * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
      *
@@ -73,7 +73,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 reactive client.
+     * Create an instance of the InfluxDB 2.x reactive client.
      *
      * <p>
      * The <i>username/password</i> auth is based on
@@ -102,7 +102,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 reactive client.
+     * Create an instance of the InfluxDB 2.x reactive client.
      *
      * @param url   the url to connect to the InfluxDB
      * @param token the token to use for the authorization
@@ -116,7 +116,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 reactive client.
+     * Create an instance of the InfluxDB 2.x reactive client.
      *
      * @param url   the url to connect to the InfluxDB
      * @param token the token to use for the authorization
@@ -133,7 +133,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 reactive client.
+     * Create an instance of the InfluxDB 2.x reactive client.
      *
      * @param url    the url to connect to the InfluxDB
      * @param token  the token to use for the authorization
@@ -159,7 +159,7 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 reactive client.
+     * Create an instance of the InfluxDB 2.x reactive client.
      *
      * @param options the connection configuration
      * @return client

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/QueryReactiveApi.java
@@ -33,7 +33,7 @@ import com.influxdb.query.FluxRecord;
 import org.reactivestreams.Publisher;
 
 /**
- * The client that allow perform Flux query against the InfluxDB 2.0 by a reactive way.
+ * The client that allow perform Flux query against the InfluxDB 2.x by a reactive way.
  *
  * For parametrized queries use {@link Query} object, see <code>com.influxdb.client.QueryApi</code> in Java module
  * for more details.
@@ -199,7 +199,7 @@ public interface QueryReactiveApi {
                            @Nonnull final Class<M> measurementType);
 
     /**
-     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.x server line by line.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
@@ -210,7 +210,7 @@ public interface QueryReactiveApi {
     Publisher<String> queryRaw(@Nonnull final String query);
 
     /**
-     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.x server line by line.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
@@ -221,7 +221,7 @@ public interface QueryReactiveApi {
     Publisher<String> queryRaw(@Nonnull Query query);
 
     /**
-     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting raw response fromInfluxDB 2.x server line by line.
      *
      * @param query the Flux query to execute
      * @param org   specifies the source organization
@@ -252,7 +252,7 @@ public interface QueryReactiveApi {
     Publisher<String> queryRaw(@Nonnull final Publisher<String> queryStream, @Nonnull final String org);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
@@ -266,7 +266,7 @@ public interface QueryReactiveApi {
                                @Nullable final Dialect dialect);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * @param dialect Dialect is an object defining the options to use when encoding the response.
      *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
@@ -280,7 +280,7 @@ public interface QueryReactiveApi {
                                @Nonnull final String org);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * @param dialect Dialect is an object defining the options to use when encoding the response.
      *                <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
@@ -294,7 +294,7 @@ public interface QueryReactiveApi {
                                @Nonnull final String org);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
      *
@@ -308,7 +308,7 @@ public interface QueryReactiveApi {
                                @Nullable final Dialect dialect);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * @param dialect     Dialect is an object defining the options to use when encoding the response.
      *                    <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.
@@ -322,7 +322,7 @@ public interface QueryReactiveApi {
                                @Nonnull final String org);
 
     /**
-     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.0server line by line.
+     * Returns {@link Publisher} emitting queryRaw response fromInfluxDB 2.x server line by line.
      *
      * @param dialect     Dialect is an object defining the options to use when encoding the response.
      *                    <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a>.

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/WriteReactiveApi.java
@@ -33,7 +33,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 /**
- * Write time-series data into by reactive way InfluxDB 2.0.
+ * Write time-series data into by reactive way InfluxDB 2.x.
  * <p>
  * The data are formatted in <a href="https://bit.ly/line-protocol">Line Protocol</a>.
  *

--- a/client-scala/README.md
+++ b/client-scala/README.md
@@ -2,14 +2,14 @@
 
 [![ScalaDoc](https://img.shields.io/badge/Scaladoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/client-scala/cross/influxdb-client-scala_2.13/scaladocs/com/influxdb/client/scala/index.html)
 
-The reference Scala client that allows query and write for the InfluxDB 2.0 by [Akka Streams](https://doc.akka.io/docs/akka/2.6/stream/).
+The reference Scala client that allows query and write for the InfluxDB 2.x by [Akka Streams](https://doc.akka.io/docs/akka/2.6/stream/).
 The client is cross-built against Scala `2.12` and `2.13`.
 
 ## Documentation
 
 This section contains links to the client library documentation.
 
-* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#queries)
+* [Product documentation](https://docs.influxdata.com/influxdb/latest/api-guide/client-libraries/), [Getting Started](#queries)
 * [Examples](../examples)
 * [API Reference](https://influxdata.github.io/influxdb-client-java/client-scala/cross/influxdb-client-scala_2.13/scaladocs/com/influxdb/client/scala/index.html)
 * [Changelog](../CHANGELOG.md)

--- a/client-scala/cross/2.12/pom.xml
+++ b/client-scala/cross/2.12/pom.xml
@@ -34,9 +34,9 @@
   <artifactId>influxdb-client-scala_2.12</artifactId>
   <packaging>jar</packaging>
 
-  <name>The Scala InfluxDB 2.0 Client [Scala 2.12]</name>
+  <name>The Scala InfluxDB 2.x Client [Scala 2.12]</name>
   <description>
-    The reference Scala client that allows query and write for the InfluxDB 2.0 by Akka Streams.
+    The reference Scala client that allows query and write for the InfluxDB 2.x by Akka Streams.
   </description>
 
   <url>https://github.com/influxdata/influxdb-client-java/tree/master/client-scala</url>

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -34,9 +34,9 @@
   <artifactId>influxdb-client-scala_2.13</artifactId>
   <packaging>jar</packaging>
 
-  <name>The Scala InfluxDB 2.0 Client [Scala 2.13]</name>
+  <name>The Scala InfluxDB 2.x Client [Scala 2.13]</name>
   <description>
-    The reference Scala client that allows query and write for the InfluxDB 2.0 by Akka Streams.
+    The reference Scala client that allows query and write for the InfluxDB 2.x by Akka Streams.
   </description>
 
   <url>https://github.com/influxdata/influxdb-client-java/tree/master/client-scala</url>

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScala.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScala.scala
@@ -26,7 +26,7 @@ import com.influxdb.client.domain.HealthCheck
 import javax.annotation.Nonnull
 
 /**
- * The reference Scala client that allows query and write for the InfluxDB 2.0 by Akka Streams.
+ * The reference Scala client that allows query and write for the InfluxDB 2.x by Akka Streams.
  *
  * @author Jakub Bednar (bednar@github) (08/02/2019 09:09)
  */

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
@@ -36,7 +36,7 @@ object InfluxDBClientScalaFactory {
 
 
   /**
-   * Create an instance of the InfluxDB 2.0 client that is configured via `influx2.properties`.
+   * Create an instance of the InfluxDB 2.x client that is configured via `influx2.properties`.
    * The `influx2.properties` has to be located on classpath.
    *
    * @return client
@@ -51,7 +51,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 client. The url could be a connection string with various configurations.
+   * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
    *
    * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
    *
@@ -68,7 +68,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 reactive client.
+   * Create an instance of the InfluxDB 2.x reactive client.
    *
    * The ''username/password'' auth is based on
    * [[http://bit.ly/http-basic-auth HTTP "Basic" authentication]]. The authorization expires when the
@@ -92,7 +92,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 reactive client.
+   * Create an instance of the InfluxDB 2.x reactive client.
    *
    * @param url   the url to connect to the InfluxDB
    * @param token the token to use for the authorization
@@ -105,7 +105,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 reactive client.
+   * Create an instance of the InfluxDB 2.x reactive client.
    *
    * @param url   the url to connect to the InfluxDB
    * @param token the token to use for the authorization
@@ -119,7 +119,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 reactive client.
+   * Create an instance of the InfluxDB 2.x reactive client.
    *
    * @param url   the url to connect to the InfluxDB
    * @param token the token to use for the authorization
@@ -141,7 +141,7 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.0 reactive client.
+   * Create an instance of the InfluxDB 2.x reactive client.
    *
    * @param options the connection configuration
    * @return client

--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 
 [![javadoc](https://img.shields.io/badge/javadoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/index.html)
 
-The reference Java client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.0.
+The reference Java client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.x.
 
 ## Features
  
@@ -13,7 +13,7 @@ The reference Java client that allows query, write and management (bucket, organ
     - [Data Point](#by-data-point) 
     - [POJO](#by-pojo)
     - [Default Tags](#default-tags)
-- [InfluxDB 2.0 Management API](#management-api)
+- [InfluxDB 2.x Management API](#management-api)
     - sources, buckets
     - tasks
     - authorizations
@@ -798,7 +798,7 @@ The client has following management API:
 | **/health** | Get the health of an instance anytime during execution | [InfluxDBClient#health()](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/com/influxdb/client/InfluxDBClient.html#health--) |
 
 
-The following example demonstrates how to use a InfluxDB 2.0 Management API. For further information see endpoints Javadoc.
+The following example demonstrates how to use a InfluxDB 2.x Management API. For further information see endpoints Javadoc.
 
 ```java
 package example;
@@ -994,7 +994,7 @@ influxDBClient
 
 ### Delete data
 
-The following example demonstrates how to delete data from InfluxDB 2.0.
+The following example demonstrates how to delete data from InfluxDB 2.x.
 
 ```java
 package example;

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -33,10 +33,10 @@
     <artifactId>influxdb-client-java</artifactId>
     <packaging>jar</packaging>
 
-    <name>The Java InfluxDB 2.0 Client</name>
+    <name>The Java InfluxDB 2.x Client</name>
     <description>
         The reference Java client that allows query, write
-        and management (bucket, organization, users) for the InfluxDB 2.0.
+        and management (bucket, organization, users) for the InfluxDB 2.x.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java/tree/master/client</url>

--- a/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
+++ b/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
@@ -32,7 +32,7 @@ import com.influxdb.client.domain.Permission;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement Authorization HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Authorization HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (17/09/2018 11:09)
  */

--- a/client/src/main/java/com/influxdb/client/BucketsApi.java
+++ b/client/src/main/java/com/influxdb/client/BucketsApi.java
@@ -38,7 +38,7 @@ import com.influxdb.client.domain.ResourceOwner;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement Bucket HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Bucket HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (13/09/2018 10:31)
  */

--- a/client/src/main/java/com/influxdb/client/ChecksApi.java
+++ b/client/src/main/java/com/influxdb/client/ChecksApi.java
@@ -36,7 +36,7 @@ import com.influxdb.client.domain.Threshold;
 import com.influxdb.client.domain.ThresholdCheck;
 
 /**
- * The client of the InfluxDB 2.0 that implement Check Api.
+ * The client of the InfluxDB 2.x that implement Check Api.
  *
  * @author Jakub Bednar (18/09/2019 08:07)
  */

--- a/client/src/main/java/com/influxdb/client/DashboardsApi.java
+++ b/client/src/main/java/com/influxdb/client/DashboardsApi.java
@@ -40,7 +40,7 @@ import com.influxdb.client.domain.User;
 import com.influxdb.client.domain.View;
 
 /**
- * The client of the InfluxDB 2.0 that implement Dashboards HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Dashboards HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (01/04/2019 10:47)
  */

--- a/client/src/main/java/com/influxdb/client/DeleteApi.java
+++ b/client/src/main/java/com/influxdb/client/DeleteApi.java
@@ -30,7 +30,7 @@ import com.influxdb.client.domain.DeletePredicateRequest;
 import com.influxdb.client.domain.Organization;
 
 /**
- * API to Delete time-series data from InfluxDB 2.0.
+ * API to Delete time-series data from InfluxDB 2.x.
  *
  * @author Pavlina Rolincova (rolincova@github) (25/10/2019).
  */

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -47,7 +47,7 @@ import com.influxdb.client.domain.Variable;
 import com.influxdb.exceptions.UnprocessableEntityException;
 
 /**
- * The client of theInfluxDB 2.0for Time Series that implements HTTP API defined by
+ * The client of theInfluxDB 2.x for Time Series that implements HTTP API defined by
  * <a href="https://github.com/influxdata/influxdb/blob/master/http/swagger.yml">Influx API Service swagger.yml</a>.
  *
  * @author Jakub Bednar (bednar@github) (11/10/2018 08:56)
@@ -291,7 +291,7 @@ public interface InfluxDBClient extends AutoCloseable {
     String version();
 
     /**
-     * The readiness of the InfluxDB 2.0.
+     * The readiness of the InfluxDB 2.x.
      *
      * @return return null if the InfluxDB is not ready
      */

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
@@ -30,7 +30,7 @@ import com.influxdb.client.internal.InfluxDBClientImpl;
 import com.influxdb.utils.Arguments;
 
 /**
- * The Factory that create an instance of a InfluxDB 2.0 client.
+ * The Factory that create an instance of a InfluxDB 2.x client.
  *
  * @author Jakub Bednar (bednar@github) (05/09/2018 10:04)
  */
@@ -40,7 +40,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client that is configured via {@code influx2.properties}.
+     * Create an instance of the InfluxDB 2.x client that is configured via {@code influx2.properties}.
      * The {@code influx2.properties} has to be located on classpath.
      *
      * @return client
@@ -56,7 +56,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client. The url could be a connection string with various configurations.
+     * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
      * <p>
      * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
      *
@@ -74,7 +74,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client.
+     * Create an instance of the InfluxDB 2.x client.
      *
      * <p>
      * The <i>username/password</i> auth is based on
@@ -103,7 +103,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client.
+     * Create an instance of the InfluxDB 2.x client.
      *
      * @param url   the url to connect to the InfluxDB
      * @param token the token to use for the authorization
@@ -117,7 +117,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client.
+     * Create an instance of the InfluxDB 2.x client.
      *
      * @param url   the url to connect to the InfluxDB
      * @param token the token to use for the authorization
@@ -134,7 +134,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client.
+     * Create an instance of the InfluxDB 2.x client.
      *
      * @param url    the url to connect to the InfluxDB
      * @param token  the token to use for the authorization
@@ -160,7 +160,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create a instance of the InfluxDB 2.0 client to connect into InfluxDB 1.8.
+     * Create a instance of the InfluxDB 2.x client to connect into InfluxDB 1.8.
      *
      * @param url             the url to connect to the InfluxDB 1.8
      * @param username        authorization username
@@ -191,7 +191,7 @@ public final class InfluxDBClientFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.0 client.
+     * Create an instance of the InfluxDB 2.x client.
      *
      * @param options the connection configuration
      * @return client

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -43,7 +43,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 
 /**
- * InfluxDBClientOptions are used to configure theInfluxDB 2.0 connections.
+ * InfluxDBClientOptions are used to configure theInfluxDB 2.x connections.
  *
  * @author Jakub Bednar (bednar@github) (05/09/2018 10:22)
  */

--- a/client/src/main/java/com/influxdb/client/LabelsApi.java
+++ b/client/src/main/java/com/influxdb/client/LabelsApi.java
@@ -33,7 +33,7 @@ import com.influxdb.client.domain.LabelUpdate;
 import com.influxdb.client.domain.Organization;
 
 /**
- * The client of the InfluxDB 2.0 that implement Labels HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Labels HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (28/01/2019 10:37)
  */

--- a/client/src/main/java/com/influxdb/client/NotificationEndpointsApi.java
+++ b/client/src/main/java/com/influxdb/client/NotificationEndpointsApi.java
@@ -37,7 +37,7 @@ import com.influxdb.client.domain.PagerDutyNotificationEndpoint;
 import com.influxdb.client.domain.SlackNotificationEndpoint;
 
 /**
- * The client of the InfluxDB 2.0 that implement NotificationEndpoint HTTP API.
+ * The client of the InfluxDB 2.x that implement NotificationEndpoint HTTP API.
  *
  * @author Jakub Bednar (11/09/2019 09:20)
  */

--- a/client/src/main/java/com/influxdb/client/NotificationRulesApi.java
+++ b/client/src/main/java/com/influxdb/client/NotificationRulesApi.java
@@ -40,7 +40,7 @@ import com.influxdb.client.domain.SlackNotificationRule;
 import com.influxdb.client.domain.TagRule;
 
 /**
- * The client of the InfluxDB 2.0 that implement NotificationRules HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement NotificationRules HTTP API endpoint.
  *
  * @author Jakub Bednar (23/09/2019 10:43)
  */

--- a/client/src/main/java/com/influxdb/client/OrganizationsApi.java
+++ b/client/src/main/java/com/influxdb/client/OrganizationsApi.java
@@ -34,7 +34,7 @@ import com.influxdb.client.domain.SecretKeysResponse;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement Organization HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Organization HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 14:58)
  */

--- a/client/src/main/java/com/influxdb/client/QueryApi.java
+++ b/client/src/main/java/com/influxdb/client/QueryApi.java
@@ -36,7 +36,7 @@ import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 
 /**
- * The client of the InfluxDB 2.0 that implement Query HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Query HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (01/10/2018 12:17)
  */
@@ -44,7 +44,7 @@ import com.influxdb.query.FluxTable;
 public interface QueryApi {
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@code List<FluxTable>}.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -59,7 +59,7 @@ public interface QueryApi {
     List<FluxTable> query(@Nonnull final String query);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@code List<FluxTable>}.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -73,7 +73,7 @@ public interface QueryApi {
     List<FluxTable> query(@Nonnull final String query, @Nonnull final String org);
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@code List<FluxTable>}. Query parameters currently are supported only in InfluxDB Cloud.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -112,7 +112,7 @@ public interface QueryApi {
                           @Nullable Map<String, Object> params);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@code List<FluxTable>}.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -127,7 +127,7 @@ public interface QueryApi {
     List<FluxTable> query(@Nonnull final Query query);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@code List<FluxTable>}.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -141,7 +141,7 @@ public interface QueryApi {
     List<FluxTable> query(@Nonnull final Query query, @Nonnull final String org);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to list of object with given type.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -158,7 +158,7 @@ public interface QueryApi {
     <M> List<M> query(@Nonnull final String query, @Nonnull final Class<M> measurementType);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to list of object with given type.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -175,7 +175,7 @@ public interface QueryApi {
                       @Nonnull final String org, @Nonnull final Class<M> measurementType);
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and synchronously map whole response
      * to list of object with given type.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -197,7 +197,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to list of object with given type.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -214,7 +214,7 @@ public interface QueryApi {
     <M> List<M> query(@Nonnull final Query query, @Nonnull final Class<M> measurementType);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to list of object with given type.
      * <p>
      * NOTE: This method is not intended for large query results.
@@ -231,7 +231,7 @@ public interface QueryApi {
                       @Nonnull final String org, @Nonnull final Class<M> measurementType);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -244,7 +244,7 @@ public interface QueryApi {
                @Nonnull final BiConsumer<Cancellable, FluxRecord> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query  the flux query to execute
@@ -257,7 +257,7 @@ public interface QueryApi {
                @Nonnull final BiConsumer<Cancellable, FluxRecord> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -270,7 +270,7 @@ public interface QueryApi {
                @Nonnull final BiConsumer<Cancellable, FluxRecord> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query  the flux query to execute
@@ -283,7 +283,7 @@ public interface QueryApi {
                @Nonnull final BiConsumer<Cancellable, FluxRecord> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -299,7 +299,7 @@ public interface QueryApi {
                    @Nonnull final BiConsumer<Cancellable, M> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * @param <M>             the type of the measurement (POJO)
@@ -315,7 +315,7 @@ public interface QueryApi {
                    @Nonnull final BiConsumer<Cancellable, M> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -331,7 +331,7 @@ public interface QueryApi {
                    @Nonnull final BiConsumer<Cancellable, M> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * @param <M>             the type of the measurement (POJO)
@@ -347,7 +347,7 @@ public interface QueryApi {
                    @Nonnull final BiConsumer<Cancellable, M> onNext);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -361,7 +361,7 @@ public interface QueryApi {
                @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query   the flux query to execute
@@ -375,7 +375,7 @@ public interface QueryApi {
                @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -389,7 +389,7 @@ public interface QueryApi {
                @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query   the flux query to execute
@@ -403,7 +403,7 @@ public interface QueryApi {
                @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -420,7 +420,7 @@ public interface QueryApi {
                    @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * @param <M>             the type of the measurement (POJO)
@@ -436,7 +436,7 @@ public interface QueryApi {
                    @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -453,7 +453,7 @@ public interface QueryApi {
                    @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream POJO classes
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream POJO classes
      * to {@code onNext} consumer.
      *
      * @param <M>             the type of the measurement (POJO)
@@ -469,7 +469,7 @@ public interface QueryApi {
                    @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -485,7 +485,7 @@ public interface QueryApi {
                @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query      the flux query to execute
@@ -500,7 +500,7 @@ public interface QueryApi {
                @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query      the flux query to execute
@@ -520,7 +520,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -536,7 +536,7 @@ public interface QueryApi {
                @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream {@link FluxRecord}s
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream {@link FluxRecord}s
      * to {@code onNext} consumer.
      *
      * @param query      the flux query to execute
@@ -642,7 +642,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -657,7 +657,7 @@ public interface QueryApi {
     String queryRaw(@Nonnull final String query);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -671,7 +671,7 @@ public interface QueryApi {
     String queryRaw(@Nonnull final String query, @Nonnull final String org);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -689,7 +689,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -705,7 +705,7 @@ public interface QueryApi {
     String queryRaw(@Nonnull final String query, @Nullable final Dialect dialect, @Nonnull final String org);
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -726,7 +726,7 @@ public interface QueryApi {
                     @Nullable final Map<String, Object> params);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -741,7 +741,7 @@ public interface QueryApi {
     String queryRaw(@Nonnull final Query query);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+     * Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
      * to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large responses, that do not fit into memory.
@@ -755,7 +755,7 @@ public interface QueryApi {
     String queryRaw(@Nonnull final Query query, @Nonnull final String org);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -767,7 +767,7 @@ public interface QueryApi {
     void queryRaw(@Nonnull final String query, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -779,7 +779,7 @@ public interface QueryApi {
                   @Nonnull final String org, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -791,7 +791,7 @@ public interface QueryApi {
                   @Nonnull final String org, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -803,7 +803,7 @@ public interface QueryApi {
     void queryRaw(@Nonnull final Query query, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -817,7 +817,7 @@ public interface QueryApi {
                   @Nullable final Dialect dialect, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -831,7 +831,7 @@ public interface QueryApi {
                   @Nonnull final String org, @Nonnull final BiConsumer<Cancellable, String> onResponse);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -847,7 +847,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -862,7 +862,7 @@ public interface QueryApi {
 
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -880,7 +880,7 @@ public interface QueryApi {
                   @Nullable final Map<String, Object> params);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -895,7 +895,7 @@ public interface QueryApi {
                   @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -909,7 +909,7 @@ public interface QueryApi {
                   @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -926,7 +926,7 @@ public interface QueryApi {
                   @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -943,7 +943,7 @@ public interface QueryApi {
                   @Nonnull final Consumer<? super Throwable> onError);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -959,7 +959,7 @@ public interface QueryApi {
                   @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -975,7 +975,7 @@ public interface QueryApi {
                   @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>
@@ -996,7 +996,7 @@ public interface QueryApi {
                   @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -1016,7 +1016,7 @@ public interface QueryApi {
                   @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Parameterized Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Parameterized Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -1041,7 +1041,7 @@ public interface QueryApi {
                   @Nullable final Map<String, Object> params);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * @param query      the flux query to execute
@@ -1057,7 +1057,7 @@ public interface QueryApi {
                   @Nonnull final Runnable onComplete);
 
     /**
-     * Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
+     * Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
      * (line by line) to {@code onResponse}.
      *
      * <p>The {@link InfluxDBClientOptions#getOrg()} will be used as source organization.</p>

--- a/client/src/main/java/com/influxdb/client/SourcesApi.java
+++ b/client/src/main/java/com/influxdb/client/SourcesApi.java
@@ -31,7 +31,7 @@ import com.influxdb.client.domain.HealthCheck;
 import com.influxdb.client.domain.Source;
 
 /**
- * The client of the InfluxDB 2.0 that implement Source HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Source HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (18/09/2018 09:01)
  */

--- a/client/src/main/java/com/influxdb/client/TasksApi.java
+++ b/client/src/main/java/com/influxdb/client/TasksApi.java
@@ -41,7 +41,7 @@ import com.influxdb.client.domain.TaskUpdateRequest;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement Task HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Task HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 07:54)
  */

--- a/client/src/main/java/com/influxdb/client/TelegrafsApi.java
+++ b/client/src/main/java/com/influxdb/client/TelegrafsApi.java
@@ -41,7 +41,7 @@ import com.influxdb.client.domain.TelegrafRequestMetadata;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement Telegrafs HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Telegrafs HTTP API endpoint.
  * <br>
  * <br>
  * <p>

--- a/client/src/main/java/com/influxdb/client/UsersApi.java
+++ b/client/src/main/java/com/influxdb/client/UsersApi.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import com.influxdb.client.domain.User;
 
 /**
- * The client of the InfluxDB 2.0 that implement User HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement User HTTP API endpoint.
  *
  * @author Jakub Bednar (bednar@github) (11/09/2018 10:05)
  */

--- a/client/src/main/java/com/influxdb/client/VariablesApi.java
+++ b/client/src/main/java/com/influxdb/client/VariablesApi.java
@@ -30,7 +30,7 @@ import com.influxdb.client.domain.Organization;
 import com.influxdb.client.domain.Variable;
 
 /**
- * The client of the InfluxDB 2.0 that implement Variables HTTP API endpoint.
+ * The client of the InfluxDB 2.x that implement Variables HTTP API endpoint.
  *
  * @author Jakub Bednar (27/03/2019 09:35)
  */

--- a/client/src/main/java/com/influxdb/client/WriteApi.java
+++ b/client/src/main/java/com/influxdb/client/WriteApi.java
@@ -37,7 +37,7 @@ import com.influxdb.client.write.events.WriteRetriableErrorEvent;
 import com.influxdb.client.write.events.WriteSuccessEvent;
 
 /**
- * The asynchronous non-blocking API to Write time-series data into InfluxDB 2.0.
+ * The asynchronous non-blocking API to Write time-series data into InfluxDB 2.x.
  * <p>
  * The data are formatted in <a href="https://bit.ly/line-protocol">Line Protocol</a>.
  * <p>
@@ -228,7 +228,7 @@ public interface WriteApi extends AutoCloseable {
                                                                      @Nonnull final EventListener<T> listener);
 
     /**
-     * Forces the client to flush all pending writes from the buffer toInfluxDB 2.0via HTTP.
+     * Forces the client to flush all pending writes from the buffer toInfluxDB 2.x via HTTP.
      */
     void flush();
 

--- a/client/src/main/java/com/influxdb/client/WriteApiBlocking.java
+++ b/client/src/main/java/com/influxdb/client/WriteApiBlocking.java
@@ -32,7 +32,7 @@ import com.influxdb.exceptions.InfluxException;
 
 
 /**
- * The synchronous blocking API to Write time-series data into InfluxDB 2.0.
+ * The synchronous blocking API to Write time-series data into InfluxDB 2.x.
  * <p>
  * The data are formatted in <a href="https://bit.ly/line-protocol">Line Protocol</a>.
  * <p>
@@ -51,7 +51,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeRecord(WritePrecision, String)}.
      * </p>
@@ -68,7 +68,7 @@ public interface WriteApiBlocking {
      * Write Line Protocol record into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeRecords(String, String, WritePrecision, List)}.
      * </p>
@@ -94,7 +94,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeRecords(WritePrecision, List)}.
      * </p>
@@ -110,7 +110,7 @@ public interface WriteApiBlocking {
      * Write Line Protocol records into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeRecords(String, String, WritePrecision, List)}.
      * </p>
@@ -135,7 +135,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writePoint(Point)}.
      * </p>
@@ -149,7 +149,7 @@ public interface WriteApiBlocking {
      * Write Data point into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writePoint(String, String, Point)}.
      * </p>
@@ -172,7 +172,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writePoints(List)}.
      * </p>
@@ -187,7 +187,7 @@ public interface WriteApiBlocking {
      * Write Data points into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writePoints(String, String, List)}.
      * </p>
@@ -210,7 +210,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeMeasurement(WritePrecision, Object)}.
      * </p>
@@ -227,7 +227,7 @@ public interface WriteApiBlocking {
      * Write Measurement into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeMeasurement(String, String, WritePrecision, Object)}.
      * </p>
@@ -253,7 +253,7 @@ public interface WriteApiBlocking {
      * </p>
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeMeasurements(WritePrecision, List)}.
      * </p>
@@ -270,7 +270,7 @@ public interface WriteApiBlocking {
      * Write Measurements into specified bucket.
      *
      * <p>
-     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * NOTE: This method directly write data info InfluxDB 2.x without batching, jittering and backpressure.
      * The method blocks the executing thread until their operation finished.
      * There is also non-blocking alternative {@link WriteApi#writeMeasurements(String, String, WritePrecision, List)}.
      * </p>

--- a/client/src/main/java/com/influxdb/client/WriteOptions.java
+++ b/client/src/main/java/com/influxdb/client/WriteOptions.java
@@ -32,7 +32,7 @@ import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
 
 /**
- * WriteOptions are used to configure writes the data point into InfluxDB 2.0.
+ * WriteOptions are used to configure writes the data point into InfluxDB 2.x.
  *
  * <p>
  * The default setting use the batching configured to (consistent with Telegraf):

--- a/client/src/main/java/com/influxdb/client/write/events/WriteSuccessEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteSuccessEvent.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 import com.influxdb.client.domain.WritePrecision;
 
 /**
- * The event is published when arrived the success response from InfluxDB 2.0 server.
+ * The event is published when arrived the success response from InfluxDB 2.x server.
  *
  * @author Jakub Bednar (bednar@github) (25/09/2018 12:26)
  */

--- a/examples/src/main/java/example/PlatformExample.java
+++ b/examples/src/main/java/example/PlatformExample.java
@@ -47,7 +47,7 @@ import com.influxdb.query.FluxTable;
 import io.reactivex.BackpressureOverflowStrategy;
 
 /*
-  InfluxDB 2.0 onboarding tasks (create default user, organization and bucket) :
+  InfluxDB 2.x onboarding tasks (create default user, organization and bucket) :
 
   curl -i -X POST http://localhost:8086/api/v2/setup -H 'accept: application/json' \
       -d '{

--- a/karaf/README.md
+++ b/karaf/README.md
@@ -1,4 +1,4 @@
-# Apache Karaf Integration for InfluxDB 2.0
+# Apache Karaf Integration for InfluxDB 2.x
 
 ## Features
 
@@ -9,13 +9,13 @@
 
 ## Submodules
 
-The Apache Karaf feature definition modules supporting InfluxDB 2.0:
+The Apache Karaf feature definition modules supporting InfluxDB 2.x:
 
-| Module | Description |
-| --- | --- |
-| **karaf-features** | Apache Karaf feature definition (XML) artifact for InfluxDB 2.0. |
-| **karaf-kar**      | KAraf aRchive (KAR) artifact containing client for InfluxDB 2.0. |
-| **karaf-assembly** | Apache Karaf (sample) distribution having InfluxDB 2.0 client. |
+| Module | Description                                                      |
+| --- |------------------------------------------------------------------|
+| **karaf-features** | Apache Karaf feature definition (XML) artifact for InfluxDB 2.x. |
+| **karaf-kar**      | KAraf aRchive (KAR) artifact containing client for InfluxDB 2.x. |
+| **karaf-assembly** | Apache Karaf (sample) distribution having InfluxDB 2.x client.   |
 
 ## Installation
 
@@ -58,9 +58,9 @@ An alternate way to start the server is running `karaf-assembly/target/assembly/
 karaf@root()> feature:list | grep influx
 influxdb-client                      │ 2.2.0.SNAPSHOT   │          │ Started     │ influxdb-features-2.2.0-SNAPSHOT     │ InfluxDB client
 kotlin                               │ 1.3.72           │          │ Started     │ influxdb-features-2.2.0-SNAPSHOT     │ Kotlin
-influxdb-karaf-features              │ 2.2.0.SNAPSHOT   │          │ Uninstalled │ influxdb-features-2.2.0-SNAPSHOT     │ Apache Karaf Features for InfluxDB 2.0
+influxdb-karaf-features              │ 2.2.0.SNAPSHOT   │          │ Uninstalled │ influxdb-features-2.2.0-SNAPSHOT     │ Apache Karaf Features for InfluxDB 2.x
 karaf@root()> bundle:list | grep -i influx
-16 │ Active │  80 │ 2.2.0.SNAPSHOT │ The OSGi InfluxDB 2.0 Client
+16 │ Active │  80 │ 2.2.0.SNAPSHOT │ The OSGi InfluxDB 2.x Client
 ```
 
 Declarative services (i.e. that are writing data to InfluxDB by OSGi events) become available if you copy configuration files (see below) to `karaf-assembly/target/assembly/deploy` directory.

--- a/karaf/karaf-assembly/pom.xml
+++ b/karaf/karaf-assembly/pom.xml
@@ -34,9 +34,9 @@
     <artifactId>influxdb-karaf-assembly</artifactId>
     <packaging>karaf-assembly</packaging>
 
-    <name>Apache Karaf Assembly for InfluxDB 2.0</name>
+    <name>Apache Karaf Assembly for InfluxDB 2.x</name>
     <description>
-        Apache Karaf distribution including InfluxDB 2.0 client.
+        Apache Karaf distribution including InfluxDB 2.x client.
     </description>
 
     <build>

--- a/karaf/karaf-features/pom.xml
+++ b/karaf/karaf-features/pom.xml
@@ -34,9 +34,9 @@
     <artifactId>influxdb-karaf-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>Apache Karaf Features for InfluxDB 2.0</name>
+    <name>Apache Karaf Features for InfluxDB 2.x</name>
     <description>
-        Apache Karaf Features for InfluxDB 2.0: feature definition of client bundles and dependencies.
+        Apache Karaf Features for InfluxDB 2.x: feature definition of client bundles and dependencies.
     </description>
 
     <build>

--- a/karaf/karaf-kar/pom.xml
+++ b/karaf/karaf-kar/pom.xml
@@ -34,9 +34,9 @@
     <artifactId>influxdb-karaf-kar</artifactId>
     <packaging>kar</packaging>
 
-    <name>Apache Karaf KAR for InfluxDB 2.0</name>
+    <name>Apache Karaf KAR for InfluxDB 2.x</name>
     <description>
-        InfluxDB 2.0 KAR deployable artifact for Apache Karaf.
+        InfluxDB 2.x KAR deployable artifact for Apache Karaf.
     </description>
 
     <build>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -40,9 +40,9 @@
         <module>karaf-assembly</module>
     </modules>
 
-    <name>Apache Karaf Integration for InfluxDB 2.0</name>
+    <name>Apache Karaf Integration for InfluxDB 2.x</name>
     <description>
-        Apache Karaf Integration for InfluxDB 2.0: features and KAR file.
+        Apache Karaf Integration for InfluxDB 2.x: features and KAR file.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java/tree/master/karaf</url>

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         <module>examples</module>
     </modules>
 
-    <name>The InfluxDB 2.0 JVM Based Clients</name>
+    <name>The InfluxDB 2.x JVM Based Clients</name>
     <description>
-        The reference JVM clients for the InfluxDB 2.0 - currently Java, Reactive, Kotlin and Scala clients are implemented.
+        The reference JVM clients for the InfluxDB 2.x - currently Java, Reactive, Kotlin and Scala clients are implemented.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java</url>

--- a/scripts/influxdb-onboarding.sh
+++ b/scripts/influxdb-onboarding.sh
@@ -26,7 +26,7 @@ set -e
 echo "Wait to start InfluxDB"
 wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8086/ping
 
-echo "Wait to start InfluxDB 2.0"
+echo "Wait to start InfluxDB 2.x"
 wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:9999/metrics
 
 echo

--- a/scripts/influxdb-restart.sh
+++ b/scripts/influxdb-restart.sh
@@ -64,10 +64,10 @@ echo "Wait to start InfluxDB"
 wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:8086/ping
 
 #
-# InfluxDB 2.0
+# InfluxDB 2.x
 #
 echo
-echo "Restarting InfluxDB 2.0 [${INFLUXDB_V2_IMAGE}] ... "
+echo "Restarting InfluxDB 2.x [${INFLUXDB_V2_IMAGE}] ... "
 echo
 
 docker pull ${INFLUXDB_V2_IMAGE} || true
@@ -79,7 +79,7 @@ docker run \
        --publish 9999:9999 \
        ${INFLUXDB_V2_IMAGE}
 
-echo "Wait to start InfluxDB 2.0"
+echo "Wait to start InfluxDB 2.x"
 wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://localhost:9999/metrics
 
 echo
@@ -95,10 +95,10 @@ curl -i -X POST http://localhost:9999/api/v2/setup -H 'accept: application/json'
         }'
 
 #
-# InfluxDB 2.0
+# InfluxDB 2.x
 #
 echo
-echo "Restarting InfluxDB 2.0 for onboarding test... "
+echo "Restarting InfluxDB 2.x for onboarding test... "
 echo
 
 docker run \

--- a/scripts/site/site.xml
+++ b/scripts/site/site.xml
@@ -38,13 +38,13 @@
             <item name="Client Core" href="./influxdb-client-core/index.html" />
         </menu>
         <menu name="Clients" inheritAsRef="true">
-            <item name="InfluxDB 2.0 client" href="./influxdb-client-java/index.html" />
-            <item name="InfluxDB 2.0 client - Reactive" href="./influxdb-client-reactive/index.html" />
-            <item name="InfluxDB 2.0 client - Kotlin" href="./influxdb-client-kotlin/index.html" />
-            <item name="InfluxDB 2.0 client - Scala [2.12]" href="./client-scala/cross/influxdb-client-scala_2.12/index.html" />
-            <item name="InfluxDB 2.0 client - Scala [2.13]" href="./client-scala/cross/influxdb-client-scala_2.13/index.html" />
+            <item name="InfluxDB 2.x client" href="./influxdb-client-java/index.html" />
+            <item name="InfluxDB 2.x client - Reactive" href="./influxdb-client-reactive/index.html" />
+            <item name="InfluxDB 2.x client - Kotlin" href="./influxdb-client-kotlin/index.html" />
+            <item name="InfluxDB 2.x client - Scala [2.12]" href="./client-scala/cross/influxdb-client-scala_2.12/index.html" />
+            <item name="InfluxDB 2.x client - Scala [2.13]" href="./client-scala/cross/influxdb-client-scala_2.13/index.html" />
             <item name="InfluxDB 1.7+ Flux Client" href="./influxdb-client-flux/index.html" />
-            <item name="InfluxDB 2.0 client - OSGi" href="./influxdb-client-osgi/index.html" />
+            <item name="InfluxDB 2.x client - OSGi" href="./influxdb-client-osgi/index.html" />
         </menu>
         <menu ref="parent" inherit="top" />
         <menu ref="reports" inherit="top" />

--- a/spring/README.md
+++ b/spring/README.md
@@ -1,4 +1,4 @@
-# Spring Integration for InfluxDB 2.0
+# Spring Integration for InfluxDB 2.x
 
 [![javadoc](https://img.shields.io/badge/javadoc-link-brightgreen.svg)](https://influxdata.github.io/influxdb-client-java/influxdb-client-java/apidocs/index.html)
 
@@ -34,7 +34,7 @@ If you want to configure the `InfluxDBClientReactive` client, you need to includ
 
 ## Actuator for InfluxDB2 micrometer registry
 
-To enable export metrics to **InfluxDB 2.0** you need to include `micrometer-registry-influx` on your classpath.
+To enable export metrics to **InfluxDB 2.x** you need to include `micrometer-registry-influx` on your classpath.
 
 The default configuration can be override via properties:
 
@@ -71,12 +71,12 @@ dependencies {
  
 ## Actuator for InfluxDB2 health
 
-The `/health` endpoint can monitor an **InfluxDB 2.0** server.
+The `/health` endpoint can monitor an **InfluxDB 2.x** server.
 
-InfluxDB 2.0 health check relies on `InfluxDBClient` and can be configured via:
+InfluxDB 2.x health check relies on `InfluxDBClient` and can be configured via:
 
 ```yaml
-management.health.influx.enabled=true # Whether to enable InfluxDB 2.0 health check.
+management.health.influx.enabled=true # Whether to enable InfluxDB 2.x health check.
 ```
 
 ## Version

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -34,9 +34,9 @@
     <version>5.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Spring Integration for InfluxDB 2.0</name>
+    <name>Spring Integration for InfluxDB 2.x</name>
     <description>
-        The Spring Integration for InfluxDB 2.0: actuator for InfluxDB2 micrometer registry, actuator for InfluxDB2 health, InfluxDB2Client auto-configuration.
+        The Spring Integration for InfluxDB 2.x: actuator for InfluxDB2 micrometer registry, actuator for InfluxDB2 health, InfluxDB2Client auto-configuration.
     </description>
 
     <url>https://github.com/influxdata/influxdb-client-java/tree/master/spring</url>


### PR DESCRIPTION
This PR changes the main README to use InfluxDB `2.x` in place of InfluxDB `2.0` .

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
