### PR TITLE
feat: url to connect to the InfluxDB is always evaluate as a connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This release also uses new version of InfluxDB OSS API definitions - [oss.yml](h
 1. [#315](https://github.com/influxdata/influxdb-client-java/pull/315): Add support for timezones [FluxDSL]
 1. [#317](https://github.com/influxdata/influxdb-client-java/pull/317): Gets HTTP headers from the unsuccessful HTTP request
 1. [#334](https://github.com/influxdata/influxdb-client-java/pull/334): Supports not operator [FluxDSL]
+1. [#335](https://github.com/influxdata/influxdb-client-java/pull/335): URL to connect to the InfluxDB is always evaluate as a connection string
 1. [#329](https://github.com/influxdata/influxdb-client-java/pull/329): Add support for write `consistency` parameter [InfluxDB Enterprise]
     
     Configure `consistency` via `Write API`:

--- a/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
+++ b/client-kotlin/src/main/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactory.kt
@@ -50,9 +50,12 @@ class InfluxDBClientKotlinFactory {
         }
 
         /**
-         * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
+         * Create an instance of the InfluxDB 2.x client.
          *
-         * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+         * </p>
          *
          * @param connectionString connection string with various configurations.
          * @return client
@@ -76,7 +79,12 @@ class InfluxDBClientKotlinFactory {
          * and client produces {@link com.influxdb.exceptions.UnauthorizedException}.
          * </p>
          *
-         * @param url      the url to connect to the InfluxDB
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+         * </p>
+         *
+         * @param url      the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
          * @param username the username to use in the basic auth
          * @param password the password to use in the basic auth
          * @return client
@@ -97,7 +105,12 @@ class InfluxDBClientKotlinFactory {
         /**
          * Create an instance of the InfluxDB 2.x reactive client.
          *
-         * @param url   the url to connect to the InfluxDB
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+         * </p>
+         *
+         * @param url   the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
          * @param token the token to use for the authorization
          * @return client
          * @see InfluxDBClientOptions.Builder.url
@@ -110,7 +123,12 @@ class InfluxDBClientKotlinFactory {
         /**
          * Create an instance of the InfluxDB 2.x reactive client.
          *
-         * @param url   the url to connect to the InfluxDB
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+         * </p>
+         *
+         * @param url   the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
          * @param token the token to use for the authorization
          * @param org    the name of an organization
          * @return client
@@ -124,7 +142,12 @@ class InfluxDBClientKotlinFactory {
         /**
          * Create an instance of the InfluxDB 2.x reactive client.
          *
-         * @param url   the url to connect to the InfluxDB
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+         * </p>
+         *
+         * @param url   the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
          * @param token the token to use for the authorization
          * @param org    the name of an organization
          * @param bucket the name of a bucket

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
@@ -76,4 +76,13 @@ class InfluxDBClientKotlinFactoryTest : AbstractTest() {
             Assertions.assertThat(it).isNotNull
         }
     }
+
+    @Test
+    @Throws(NoSuchFieldException::class, IllegalAccessException::class)
+    fun connectionStringConfiguration() {
+        val client = InfluxDBClientKotlinFactory.create("http://localhost:8086?connectTimeout=45000", "xyz".toCharArray())
+        val retrofit = getDeclaredField<Retrofit>(client, "retrofit", AbstractInfluxDBClient::class.java)
+        val okHttpClient = retrofit.callFactory() as OkHttpClient
+        Assertions.assertThat(okHttpClient.connectTimeoutMillis).isEqualTo(45000)
+    }
 }

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactory.java
@@ -55,9 +55,12 @@ public final class InfluxDBClientReactiveFactory {
     }
 
     /**
-     * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
+     * Create an instance of the InfluxDB 2.x client.
+     *
      * <p>
-     * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
      *
      * @param connectionString connection string with various configurations.
      * @return client
@@ -82,7 +85,12 @@ public final class InfluxDBClientReactiveFactory {
      * and client produces {@link com.influxdb.exceptions.UnauthorizedException}.
      * </p>
      *
-     * @param url      the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url      url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param username the username to use in the basic auth
      * @param password the password to use in the basic auth
      * @return client
@@ -104,7 +112,12 @@ public final class InfluxDBClientReactiveFactory {
     /**
      * Create an instance of the InfluxDB 2.x reactive client.
      *
-     * @param url   the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url   url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token the token to use for the authorization
      * @return client
      * @see InfluxDBClientOptions.Builder#url(String)
@@ -118,7 +131,12 @@ public final class InfluxDBClientReactiveFactory {
     /**
      * Create an instance of the InfluxDB 2.x reactive client.
      *
-     * @param url   the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url   url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token the token to use for the authorization
      * @param org   the name of an organization
      * @return client
@@ -135,7 +153,12 @@ public final class InfluxDBClientReactiveFactory {
     /**
      * Create an instance of the InfluxDB 2.x reactive client.
      *
-     * @param url    the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url    url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token  the token to use for the authorization
      * @param org    the name of an organization
      * @param bucket the name of a bucket

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
@@ -91,4 +91,16 @@ class InfluxDBClientReactiveFactoryTest extends AbstractTest {
             Assertions.assertThat(client).isNotNull();
         } 
     }
+
+    @Test
+    void connectionStringConfiguration() throws NoSuchFieldException, IllegalAccessException {
+        InfluxDBClientReactive client = InfluxDBClientReactiveFactory.create("http://localhost:8086?readTimeout=15000", "xyz".toCharArray());
+
+        Assertions.assertThat(client).isNotNull();
+
+        Retrofit retrofit = getDeclaredField(client, "retrofit", AbstractInfluxDBClient.class);
+        OkHttpClient okHttpClient = (OkHttpClient) retrofit.callFactory();
+
+        Assertions.assertThat(okHttpClient.readTimeoutMillis()).isEqualTo(15_000);
+    }
 }

--- a/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
+++ b/client-scala/src/main/scala/com/influxdb/client/scala/InfluxDBClientScalaFactory.scala
@@ -51,9 +51,10 @@ object InfluxDBClientScalaFactory {
   }
 
   /**
-   * Create an instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
+   * Create an instance of the InfluxDB 2.x client.
    *
-   * e.g.: "http://localhost:8086?readTimeout=5000&amp;connectTimeout=5000&amp;logLevel=BASIC
+   * The url could be a connection string with various configurations. For more info
+   * see: [[InfluxDBClientOptions.Builder#connectionString(connectionString:java.lang.String)]].
    *
    * @param connectionString connection string with various configurations.
    * @return client
@@ -75,7 +76,10 @@ object InfluxDBClientScalaFactory {
    * [[http://bit.ly/session-length time-to-live (TTL)]] (default 60 minutes) is reached
    * and client produces [[com.influxdb.exceptions.UnauthorizedException]].
    *
-   * @param url      the url to connect to the InfluxDB
+   * The url could be a connection string with various configurations. For more info
+   * see: [[InfluxDBClientOptions.Builder#connectionString(connectionString:java.lang.String)]].
+   *
+   * @param url      the url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
    * @param username the username to use in the basic auth
    * @param password the password to use in the basic auth
    * @return client
@@ -94,7 +98,10 @@ object InfluxDBClientScalaFactory {
   /**
    * Create an instance of the InfluxDB 2.x reactive client.
    *
-   * @param url   the url to connect to the InfluxDB
+   * The url could be a connection string with various configurations. For more info
+   * see: [[InfluxDBClientOptions.Builder#connectionString(connectionString:java.lang.String)]].
+   *
+   * @param url   the url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
    * @param token the token to use for the authorization
    * @return client
    * @see [[InfluxDBClientOptions.Builder]]
@@ -107,7 +114,10 @@ object InfluxDBClientScalaFactory {
   /**
    * Create an instance of the InfluxDB 2.x reactive client.
    *
-   * @param url   the url to connect to the InfluxDB
+   * The url could be a connection string with various configurations. For more info
+   * see: [[InfluxDBClientOptions.Builder#connectionString(connectionString:java.lang.String)]].
+   *
+   * @param url   the url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
    * @param token the token to use for the authorization
    * @param org      the name of an organization
    * @return client
@@ -121,7 +131,10 @@ object InfluxDBClientScalaFactory {
   /**
    * Create an instance of the InfluxDB 2.x reactive client.
    *
-   * @param url   the url to connect to the InfluxDB
+   * The url could be a connection string with various configurations. For more info
+   * see: [[InfluxDBClientOptions.Builder#connectionString(connectionString:java.lang.String)]].
+   *
+   * @param url   the url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
    * @param token the token to use for the authorization
    * @param org      the name of an organization
    * @param bucket   the name of a bucket

--- a/client-scala/src/test/scala/com/influxdb/client/scala/InfluxDBClientScalaFactoryTest.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/InfluxDBClientScalaFactoryTest.scala
@@ -62,4 +62,16 @@ class InfluxDBClientScalaFactoryTest extends AnyFunSuite with Matchers {
     okHttpClient.writeTimeoutMillis should be(10000)
     okHttpClient.connectTimeoutMillis should be(18000)
   }
+
+  test("connectionStringConfiguration") {
+
+    val utils = new InfluxDBUtils {}
+
+    val client = InfluxDBClientScalaFactory.create("http://localhost:8086?readTimeout=55000", "xyz".toCharArray)
+
+    val retrofit = utils.getDeclaredField(client, "retrofit", classOf[AbstractInfluxDBClient]).asInstanceOf[Retrofit]
+    val okHttpClient = retrofit.callFactory.asInstanceOf[OkHttpClient]
+
+    okHttpClient.readTimeoutMillis should be(55000)
+  }
 }

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientFactory.java
@@ -84,7 +84,12 @@ public final class InfluxDBClientFactory {
      * and client produces {@link com.influxdb.exceptions.UnauthorizedException}.
      * </p>
      *
-     * @param url      the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url      url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param username the username to use in the basic auth
      * @param password the password to use in the basic auth
      * @return client
@@ -106,7 +111,12 @@ public final class InfluxDBClientFactory {
     /**
      * Create an instance of the InfluxDB 2.x client.
      *
-     * @param url   the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url   url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token the token to use for the authorization
      * @return client
      * @see InfluxDBClientOptions.Builder#url(String)
@@ -120,7 +130,12 @@ public final class InfluxDBClientFactory {
     /**
      * Create an instance of the InfluxDB 2.x client.
      *
-     * @param url   the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url   url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token the token to use for the authorization
      * @param org   the name of an organization
      * @return client
@@ -137,7 +152,12 @@ public final class InfluxDBClientFactory {
     /**
      * Create an instance of the InfluxDB 2.x client.
      *
-     * @param url    the url to connect to the InfluxDB
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url    url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
      * @param token  the token to use for the authorization
      * @param org    the name of an organization
      * @param bucket the name of a bucket
@@ -163,7 +183,12 @@ public final class InfluxDBClientFactory {
     /**
      * Create an instance of the InfluxDB 2.x client to connect into InfluxDB 1.8.
      *
-     * @param url             the url to connect to the InfluxDB 1.8
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url             the url to connect to InfluxDB 1.8 (required). http://localhost:8086?readTimeout=5000
      * @param username        authorization username
      * @param password        authorization password
      * @param database        database name
@@ -182,7 +207,12 @@ public final class InfluxDBClientFactory {
     /**
      * Create an instance of the InfluxDB 2.x client to connect into InfluxDB 1.8.
      *
-     * @param url             the url to connect to the InfluxDB 1.8
+     * <p>
+     * The url could be a connection string with various configurations. For more info
+     * see: {@link InfluxDBClientOptions.Builder#connectionString(String)}.
+     * </p>
+     *
+     * @param url             the url to connect to InfluxDB 1.8 (required). http://localhost:8086?readTimeout=5000
      * @param username        authorization username
      * @param password        authorization password
      * @param database        database name

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -259,15 +259,19 @@ public final class InfluxDBClientOptions {
 
         /**
          * Set the url to connect to InfluxDB.
+         * <p>
+         * The url could be a connection string with various configurations. For more info
+         * see: {@link #connectionString(String)}.
+         * </p>
          *
-         * @param url the url to connect to InfluxDB. It must be defined.
+         * @param url the url to connect to InfluxDB (required). Example: http://localhost:8086?readTimeout=5000
          * @return {@code this}
          */
         @Nonnull
         public InfluxDBClientOptions.Builder url(@Nonnull final String url) {
             Arguments.checkNonEmpty(url, "url");
 
-            this.url = new ParsedUrl(url).urlWithoutParams;
+            connectionString(url);
 
             return this;
         }
@@ -438,7 +442,24 @@ public final class InfluxDBClientOptions {
         }
 
         /**
-         * Configure Builder via connection string.
+         * Configure Builder via connection string. The allowed configuration:
+         *
+         * <ul>
+         *     <li><code>org</code> - default destination organization for writes and queries</li>
+         *     <li><code>bucket</code> - default destination bucket for writes</li>
+         *     <li><code>token</code> - the token to use for the authorization</li>
+         *     <li><code>logLevel</code> - rest client verbosity level</li>
+         *     <li><code>readTimeout</code> - read timeout</li>
+         *     <li><code>writeTimeout</code> - write timeout</li>
+         *     <li><code>connectTimeout</code> - socket timeout</li>
+         *     <li><code>precision</code> - default precision for unix timestamps in the line protocol</li>
+         *     <li><code>consistency</code> - specify the write consistency for the point</li>
+         * </ul>
+         *
+         * Connection string example:
+         * <pre>
+         * http://localhost:8086?readTimeout=30000&amp;token=my-token&amp;bucket=my-bucket&amp;org=my-org
+         * </pre>
          *
          * @return {@code this}
          */
@@ -547,7 +568,7 @@ public final class InfluxDBClientOptions {
                                                         @Nullable final String precision,
                                                         @Nullable final String consistency) {
 
-            url(url);
+            this.url = new ParsedUrl(url).urlWithoutParams;
             org(org);
             bucket(bucket);
 

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
@@ -179,4 +179,18 @@ class InfluxDBClientFactoryTest extends AbstractTest {
         Assertions.assertThat(options.getBucket()).isEqualTo("database/");
         Assertions.assertThat(options.getToken()).isEqualTo(":".toCharArray());
     }
+
+    @Test
+    void v1ConfigurationWithTimeout() throws NoSuchFieldException, IllegalAccessException {
+        InfluxDBClient client = InfluxDBClientFactory.createV1("http://localhost:8086?writeTimeout=30000",
+                "my-username",
+                "my-password".toCharArray(),
+                "database",
+                "week");
+
+        Retrofit retrofit = getDeclaredField(client, "retrofit", AbstractInfluxDBClient.class);
+        OkHttpClient okHttpClient = (OkHttpClient) retrofit.callFactory();
+
+        Assertions.assertThat(okHttpClient.writeTimeoutMillis()).isEqualTo(30_000);
+    }
 }

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -106,4 +106,16 @@ class InfluxDBClientOptionsTest {
         Assertions.assertThat(protocols).hasSize(1);
         Assertions.assertThat(protocols).contains(Protocol.HTTP_1_1);
     }
+
+    @Test
+    void parseURLAsConnectionString() {
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .url("http://localhost:9999?readTimeout=1000&writeTimeout=3000&connectTimeout=2000&logLevel=HEADERS&token=my-token&bucket=my-bucket&org=my-org")
+                .build();
+
+        Assertions.assertThat(options.getAuthScheme()).isEqualTo(InfluxDBClientOptions.AuthScheme.TOKEN);
+        Assertions.assertThat(options.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
+        Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
+    }
 }


### PR DESCRIPTION
## Proposed Changes

The url to connect to the InfluxDB is always evaluate as a connection string. The following code correctly set timeout:

```java
InfluxDBClient client = InfluxDBClientFactory.createV1("http://localhost:8086?writeTimeout=30000",
        "my-username",
        "my-password".toCharArray(),
        "database",
        "week");
```

---

Fixed flaky test: `doNotPropagateErrorOnCanceledConsumer()`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
