### PR TITLE
fix: evaluation of connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#337](https://github.com/influxdata/influxdb-client-java/pull/337): Supports `columns` function [FluxDSL]
 
+### Bug Fixes
+1. [#339](https://github.com/influxdata/influxdb-client-java/pull/339): Evaluation of connection string
+
 ## 6.0.0 [2022-04-19]
 
 ### Migration Notice

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -592,8 +592,10 @@ public final class InfluxDBClientOptions {
                 consistency(Enum.valueOf(WriteConsistency.class, consistency));
             }
 
-            okHttpClient = new OkHttpClient.Builder()
-                    .protocols(Collections.singletonList(Protocol.HTTP_1_1));
+            if (okHttpClient == null) {
+                okHttpClient = new OkHttpClient.Builder()
+                        .protocols(Collections.singletonList(Protocol.HTTP_1_1));
+            }
             if (readTimeout != null) {
                 okHttpClient.readTimeout(toDuration(readTimeout));
             }

--- a/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClientOptions.java
@@ -569,8 +569,12 @@ public final class InfluxDBClientOptions {
                                                         @Nullable final String consistency) {
 
             this.url = new ParsedUrl(url).urlWithoutParams;
-            org(org);
-            bucket(bucket);
+            if (org != null) {
+                org(org);
+            }
+            if (bucket != null) {
+                bucket(bucket);
+            }
 
             if (token != null) {
                 authenticateToken(token.toCharArray());

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -118,4 +118,18 @@ class InfluxDBClientOptionsTest {
         Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
         Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
     }
+
+    @Test
+    void keepBucketOrgSettingsIfAreBeforeURL()
+    {
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .bucket("my-bucket")
+                .org("my-org")
+                .url("http://localhost:8086")
+                .authenticateToken("my-token".toCharArray())
+                .build();
+
+        Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
+        Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
+    }
 }

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.client;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.influxdb.client.domain.WritePrecision;
@@ -120,8 +121,7 @@ class InfluxDBClientOptionsTest {
     }
 
     @Test
-    void keepBucketOrgSettingsIfAreBeforeURL()
-    {
+    void keepBucketOrgSettingsIfAreBeforeURL() {
         InfluxDBClientOptions options = InfluxDBClientOptions.builder()
                 .bucket("my-bucket")
                 .org("my-org")
@@ -131,5 +131,15 @@ class InfluxDBClientOptionsTest {
 
         Assertions.assertThat(options.getOrg()).isEqualTo("my-org");
         Assertions.assertThat(options.getBucket()).isEqualTo("my-bucket");
+    }
+
+    @Test
+    void okHttpBeforeURL() {
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .okHttpClient(new OkHttpClient.Builder().protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE)))
+                .url("http://localhost:8086")
+                .build();
+
+        Assertions.assertThat(options.getOkHttpClient().build().protocols()).containsExactly(Protocol.H2_PRIOR_KNOWLEDGE);
     }
 }


### PR DESCRIPTION
Related to #335, https://github.com/influxdata/influxdb-client-java/issues/338#issuecomment-1103785269

## Proposed Changes

Fix: If the `bucket` or the `org` is defined before `url` then the defaults for `bucket` and `org` is replaced with `null`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
