### PR TITLE
docs: fix RxJava3 imports, specify Maven dependency for flux-dsl

### DIFF
--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -40,7 +40,7 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 
 public class InfluxDB2ReactiveExample {
 
@@ -88,7 +88,7 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 
 public class InfluxDB2ReactiveExampleRaw {
 
@@ -136,7 +136,7 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.QueryReactiveApi;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 import org.reactivestreams.Publisher;
 
 public class InfluxDB2ReactiveExamplePojo {
@@ -223,8 +223,8 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 import com.influxdb.client.reactive.InfluxDBClientReactiveFactory;
 import com.influxdb.client.reactive.WriteReactiveApi;
 
-import io.reactivex.Flowable;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import org.reactivestreams.Publisher;
 
 public class InfluxDB2ReactiveExampleWriteEveryTenSeconds {
@@ -391,6 +391,8 @@ import com.influxdb.client.reactive.QueryReactiveApi;
 import com.influxdb.query.dsl.Flux;
 import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
+import io.reactivex.rxjava3.core.Flowable;
+
 public class InfluxDB2ReactiveExampleDSL {
 
     private static char[] token = "my-token".toCharArray();
@@ -409,8 +411,7 @@ public class InfluxDB2ReactiveExampleDSL {
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();
 
-        queryApi
-                .query(flux.toString())
+        Flowable.fromPublisher(queryApi.query(flux.toString()))
                 .subscribe(fluxRecord -> {
                     //
                     // The callback to consume a FluxRecord.

--- a/flux-dsl/README.md
+++ b/flux-dsl/README.md
@@ -911,3 +911,45 @@ option location = timezone.location(name: "America/Los_Angeles")
 from(bucket:"telegraf")
     |> count()
 ```
+
+## Version
+
+The latest version for Maven dependency:
+```xml
+<dependency>
+  <groupId>com.influxdb</groupId>
+  <artifactId>flux-dsl</artifactId>
+  <version>6.0.0</version>
+</dependency>
+```
+
+Or when using with Gradle:
+```groovy
+dependencies {
+    implementation "com.influxdb:flux-dsl:6.0.0"
+}
+```
+
+### Snapshot Repository
+The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+
+#### Maven
+```xml
+<repository>
+    <id>ossrh</id>
+    <name>OSS Snapshot repository</name>
+    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <releases>
+        <enabled>false</enabled>
+    </releases>
+    <snapshots>
+        <enabled>true</enabled>
+    </snapshots>
+</repository>
+```
+#### Gradle
+```
+repositories {
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+```


### PR DESCRIPTION
Closes #340

## Proposed Changes

1. Fixed `rxjava3` imports in READMEs.
2. Specified maven dependency in `flux-dsl`.
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
