### PR TITLE
chore: explicit exclusion old one `gson` dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -130,20 +130,6 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>adapter-rxjava3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.squareup.retrofit2</groupId>
-                    <artifactId>retrofit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.reactivex.rxjava2</groupId>
-                    <artifactId>rxjava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,20 @@
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>adapter-rxjava3</artifactId>
                 <version>${dependency.retrofit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.squareup.retrofit2</groupId>
+                        <artifactId>retrofit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.reactivex.rxjava3</groupId>
+                        <artifactId>rxjava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -525,6 +525,12 @@
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>converter-gson</artifactId>
                 <version>${dependency.retrofit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -561,6 +567,12 @@
                 <groupId>io.gsonfire</groupId>
                 <artifactId>gson-fire</artifactId>
                 <version>1.8.5</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -627,6 +639,12 @@
                 <groupId>com.moandjiezana.toml</groupId>
                 <artifactId>toml4j</artifactId>
                 <version>0.7.2</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Related to #342
Related to #338

## Proposed Changes

This PR explicitly exclude dependencies to `gson:2.8.x`. 

The Maven is not deterministic in resolving transient dependency. Maven chooses the first library it finds and it can be the older version (for more info see https://www.baeldung.com/maven-version-collision).

**Dependency report**

_**Before**_
```
...
[INFO] |  +- io.gsonfire:gson-fire:jar:1.8.5:compile
[INFO] |  |  \- (com.google.code.gson:gson:jar:2.8.6:compile - omitted for conflict with 2.9.0)
[INFO] |  +- com.squareup.retrofit2:converter-scalars:jar:2.9.0:compile
[INFO] |  |  \- (com.squareup.retrofit2:retrofit:jar:2.9.0:compile - omitted for duplicate)
[INFO] |  +- com.squareup.retrofit2:converter-gson:jar:2.9.0:compile
[INFO] |  |  +- (com.squareup.retrofit2:retrofit:jar:2.9.0:compile - omitted for duplicate)
[INFO] |  |  \- (com.google.code.gson:gson:jar:2.8.5:compile - omitted for conflict with 2.9.0)
[INFO] |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
...
```

_**After**_
```
[INFO] |  +- io.gsonfire:gson-fire:jar:1.8.5:compile
[INFO] |  +- com.squareup.retrofit2:converter-scalars:jar:2.9.0:compile
[INFO] |  |  \- (com.squareup.retrofit2:retrofit:jar:2.9.0:compile - omitted for duplicate)
[INFO] |  +- com.squareup.retrofit2:converter-gson:jar:2.9.0:compile
[INFO] |  |  \- (com.squareup.retrofit2:retrofit:jar:2.9.0:compile - omitted for duplicate)
[INFO] |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
