### PR TITLE
chore: rename InvocableScripts to InvokableScripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 6.1.0 [unreleased]
 
+### Breaking Changes
+1. [#344](https://github.com/influxdata/influxdb-client-java/pull/344): Rename `InvocableScripts` to `InvokableScripts`
+
 ### Features
 1. [#337](https://github.com/influxdata/influxdb-client-java/pull/337): Supports `columns` function [FluxDSL]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ This release also uses new version of InfluxDB OSS API definitions - [oss.yml](h
 ### Features
 1. [#324](https://github.com/influxdata/influxdb-client-java/pull/298) Removed dependency on `io.swagger:swagger-annotations` and updated swagger to the latest version
 1. [#289](https://github.com/influxdata/influxdb-client-java/pull/298): Upgrade `RxJava2` -> `RxJava3`, update outdated dependencies
-1. [#316](https://github.com/influxdata/influxdb-client-java/pull/316): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+1. [#316](https://github.com/influxdata/influxdb-client-java/pull/316): Add `InvokableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
 1. [#315](https://github.com/influxdata/influxdb-client-java/pull/315): Add support for timezones [FluxDSL]
 1. [#317](https://github.com/influxdata/influxdb-client-java/pull/317): Gets HTTP headers from the unsuccessful HTTP request
 1. [#334](https://github.com/influxdata/influxdb-client-java/pull/334): Supports not operator [FluxDSL]

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -73,7 +73,7 @@ public class FluxCsvParser {
     public enum ResponseMetadataMode {
         FULL,
 
-        // useful for Invocable scripts
+        // useful for Invokable scripts
         ONLY_NAMES
     }
 

--- a/client/src/generated/java/com/influxdb/client/service/InvokableScriptsService.java
+++ b/client/src/generated/java/com/influxdb/client/service/InvokableScriptsService.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public interface InvocableScriptsService {
+public interface InvokableScriptsService {
   /**
    * Delete a script
    * Deletes a script and all associated records.
@@ -44,7 +44,7 @@ public interface InvocableScriptsService {
 
   /**
    * Retrieve a script
-   * Uses script ID to retrieve details of an invocable script.
+   * Uses script ID to retrieve details of an invokable script.
    * @param scriptID The script ID. (required)
    * @return Call&lt;Script&gt;
    */
@@ -55,7 +55,7 @@ public interface InvocableScriptsService {
 
   /**
    * Update a script
-   * Updates properties (&#x60;name&#x60;, &#x60;description&#x60;, and &#x60;script&#x60;) of an invocable script.
+   * Updates properties (&#x60;name&#x60;, &#x60;description&#x60;, and &#x60;script&#x60;) of an invokable script.
    * @param scriptID The script ID. (required)
    * @param scriptUpdateRequest Script update to apply (required)
    * @return Call&lt;Script&gt;

--- a/client/src/main/java/com/influxdb/client/InfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/InfluxDBClient.java
@@ -245,12 +245,12 @@ public interface InfluxDBClient extends AutoCloseable {
     DeleteApi getDeleteApi();
 
     /**
-     * Create an InvocableScripts API instance.
+     * Create an InvokableScripts API instance.
      *
-     * @return InvocableScripts API instance
+     * @return InvokableScripts API instance
      */
     @Nonnull
-    InvocableScriptsApi getInvocableScriptsApi();
+    InvokableScriptsApi getInvokableScriptsApi();
 
     /**
      * Create an implementation of the API endpoints defined by the {@code service} interface.

--- a/client/src/main/java/com/influxdb/client/InvokableScriptsApi.java
+++ b/client/src/main/java/com/influxdb/client/InvokableScriptsApi.java
@@ -45,7 +45,7 @@ import com.influxdb.query.FluxTable;
  * @author Jakub Bednar (bednar@github) (03/21/2022 07:54)
  */
 @ThreadSafe
-public interface InvocableScriptsApi {
+public interface InvokableScriptsApi {
 
     /**
      * Create a script.
@@ -81,7 +81,7 @@ public interface InvocableScriptsApi {
      * @return scripts
      */
     @Nonnull
-    List<Script> findScripts(@Nonnull final InvocableScriptsQuery query);
+    List<Script> findScripts(@Nonnull final InvokableScriptsQuery query);
 
     /**
      * Delete a script.
@@ -94,7 +94,7 @@ public interface InvocableScriptsApi {
      * Executes the script and synchronously map whole response to {@code List<FluxTable>}.
      * <p>
      * NOTE: This method is not intended for large query results.
-     * Use {@link InvocableScriptsApi#invokeScript(String, Map, BiConsumer, Consumer, Runnable)}
+     * Use {@link InvokableScriptsApi#invokeScript(String, Map, BiConsumer, Consumer, Runnable)}
      * for large data streaming.
      *
      * @param scriptId The ID of the script to invoke. (required)
@@ -136,7 +136,7 @@ public interface InvocableScriptsApi {
      * Executes the script and synchronously map whole response to list of object with given type. <p>
      * <p>
      * NOTE: This method is not intended for large query results.
-     * Use {@link InvocableScriptsApi#invokeScript(String, Map, Class, BiConsumer, Consumer, Runnable)}
+     * Use {@link InvokableScriptsApi#invokeScript(String, Map, Class, BiConsumer, Consumer, Runnable)}
      * for large data streaming.
      *
      * @param scriptId        The ID of the script to invoke. (required)
@@ -188,7 +188,7 @@ public interface InvocableScriptsApi {
      * Executes the script and synchronously map whole response to {@link String} result.
      * <p>
      * NOTE: This method is not intended for large query results.
-     * Use {@link InvocableScriptsApi#invokeScriptRaw(String, Map, BiConsumer, Consumer, Runnable)}
+     * Use {@link InvokableScriptsApi#invokeScriptRaw(String, Map, BiConsumer, Consumer, Runnable)}
      * for large data streaming.
      *
      * @param scriptId The ID of the script to invoke. (required)

--- a/client/src/main/java/com/influxdb/client/InvokableScriptsQuery.java
+++ b/client/src/main/java/com/influxdb/client/InvokableScriptsQuery.java
@@ -23,7 +23,7 @@ package com.influxdb.client;
 
 import javax.annotation.Nullable;
 
-public class InvocableScriptsQuery {
+public class InvokableScriptsQuery {
 
     /**
      * Offset. (optional)

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -34,7 +34,7 @@ import com.influxdb.client.DashboardsApi;
 import com.influxdb.client.DeleteApi;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientOptions;
-import com.influxdb.client.InvocableScriptsApi;
+import com.influxdb.client.InvokableScriptsApi;
 import com.influxdb.client.LabelsApi;
 import com.influxdb.client.NotificationEndpointsApi;
 import com.influxdb.client.NotificationRulesApi;
@@ -59,7 +59,7 @@ import com.influxdb.client.service.BucketsService;
 import com.influxdb.client.service.ChecksService;
 import com.influxdb.client.service.DashboardsService;
 import com.influxdb.client.service.DeleteService;
-import com.influxdb.client.service.InvocableScriptsService;
+import com.influxdb.client.service.InvokableScriptsService;
 import com.influxdb.client.service.LabelsService;
 import com.influxdb.client.service.NotificationEndpointsService;
 import com.influxdb.client.service.NotificationRulesService;
@@ -244,8 +244,8 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
 
     @NotNull
     @Override
-    public InvocableScriptsApi getInvocableScriptsApi() {
-        return new InvocableScriptsApiImpl(retrofit.create(InvocableScriptsService.class));
+    public InvokableScriptsApi getInvokableScriptsApi() {
+        return new InvokableScriptsApiImpl(retrofit.create(InvokableScriptsService.class));
     }
 
     @Nonnull

--- a/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InvokableScriptsApiImpl.java
@@ -30,14 +30,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.influxdb.Cancellable;
-import com.influxdb.client.InvocableScriptsApi;
-import com.influxdb.client.InvocableScriptsQuery;
+import com.influxdb.client.InvokableScriptsApi;
+import com.influxdb.client.InvokableScriptsQuery;
 import com.influxdb.client.domain.Script;
 import com.influxdb.client.domain.ScriptCreateRequest;
 import com.influxdb.client.domain.ScriptInvocationParams;
 import com.influxdb.client.domain.ScriptUpdateRequest;
 import com.influxdb.client.domain.Scripts;
-import com.influxdb.client.service.InvocableScriptsService;
+import com.influxdb.client.service.InvokableScriptsService;
 import com.influxdb.internal.AbstractQueryApi;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
@@ -50,11 +50,11 @@ import retrofit2.Call;
 /**
  * @author Jakub Bednar (bednar@github) (03/21/2022 07:54)
  */
-final class InvocableScriptsApiImpl extends AbstractQueryApi implements InvocableScriptsApi {
+final class InvokableScriptsApiImpl extends AbstractQueryApi implements InvokableScriptsApi {
 
-    private final InvocableScriptsService service;
+    private final InvokableScriptsService service;
 
-    InvocableScriptsApiImpl(@Nonnull final InvocableScriptsService service) {
+    InvokableScriptsApiImpl(@Nonnull final InvokableScriptsService service) {
         super(new FluxCsvParser(FluxCsvParser.ResponseMetadataMode.ONLY_NAMES));
 
         Arguments.checkNotNull(service, "service");
@@ -85,12 +85,12 @@ final class InvocableScriptsApiImpl extends AbstractQueryApi implements Invocabl
     @Nonnull
     @Override
     public List<Script> findScripts() {
-        return findScripts(new InvocableScriptsQuery());
+        return findScripts(new InvokableScriptsQuery());
     }
 
     @Nonnull
     @Override
-    public List<Script> findScripts(@Nonnull final InvocableScriptsQuery query) {
+    public List<Script> findScripts(@Nonnull final InvokableScriptsQuery query) {
 
         Arguments.checkNotNull(query, "query");
 

--- a/client/src/test/java/com/influxdb/client/InvokableScriptsApiTest.java
+++ b/client/src/test/java/com/influxdb/client/InvokableScriptsApiTest.java
@@ -38,26 +38,26 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitPlatform.class)
-class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
+class InvokableScriptsApiTest extends AbstractInfluxDBClientTest {
 
     static final String SUCCESS_DATA = ",result,table,_start,_stop,_time,_value,_field,_measurement,host,value\n"
             + ",,0,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,10,free,mem,A,12.25\n"
             + ",,1,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,10,free,mem,A,15.55\n";
 
-    private InvocableScriptsApi invocableScriptsApi;
+    private InvokableScriptsApi invokableScriptsApi;
 
     @BeforeEach
     protected void setUp() {
         super.setUp();
 
-        invocableScriptsApi = influxDBClient.getInvocableScriptsApi();
+        invokableScriptsApi = influxDBClient.getInvokableScriptsApi();
     }
 
     @Test
     public void queryFluxTable() {
         mockServer.enqueue(createResponse(SUCCESS_DATA));
 
-        List<FluxTable> tables = invocableScriptsApi.invokeScript("script_id", new HashMap<>());
+        List<FluxTable> tables = invokableScriptsApi.invokeScript("script_id", new HashMap<>());
         Assertions.assertThat(tables).hasSize(2);
         Assertions.assertThat(tables.get(0).getRecords()).hasSize(1);
         Assertions.assertThat(tables.get(0).getRecords().get(0).getValues().get("value")).isEqualTo("12.25");
@@ -71,7 +71,7 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
 
         List<FluxRecord> records = new ArrayList<>();
         CountDownLatch recordsCountDown = new CountDownLatch(2);
-        invocableScriptsApi.invokeScript("script_id", new HashMap<>(), (cancellable, fluxRecord) -> {
+        invokableScriptsApi.invokeScript("script_id", new HashMap<>(), (cancellable, fluxRecord) -> {
             records.add(fluxRecord);
             recordsCountDown.countDown();
         });
@@ -87,7 +87,7 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
     public void queryMeasurements() {
         mockServer.enqueue(createResponse(SUCCESS_DATA));
 
-        List<InvocableScriptsPojo> pojos = invocableScriptsApi.invokeScript("script_id", new HashMap<>(), InvocableScriptsPojo.class);
+        List<InvokableScriptsPojo> pojos = invokableScriptsApi.invokeScript("script_id", new HashMap<>(), InvokableScriptsPojo.class);
         Assertions.assertThat(pojos).hasSize(2);
         Assertions.assertThat(pojos.get(0).value).isEqualTo("12.25");
         Assertions.assertThat(pojos.get(0).host).isEqualTo("A");
@@ -99,10 +99,10 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
     public void queryStreamMeasurements() {
         mockServer.enqueue(createResponse(SUCCESS_DATA));
 
-        List<InvocableScriptsPojo> pojos = new ArrayList<>();
+        List<InvokableScriptsPojo> pojos = new ArrayList<>();
         CountDownLatch measurementsCountDown = new CountDownLatch(2);
-        invocableScriptsApi.invokeScript("script_id", new HashMap<>(), InvocableScriptsPojo.class, (cancellable, invocableScriptsPojo) -> {
-            pojos.add(invocableScriptsPojo);
+        invokableScriptsApi.invokeScript("script_id", new HashMap<>(), InvokableScriptsPojo.class, (cancellable, invokableScriptsPojo) -> {
+            pojos.add(invokableScriptsPojo);
             measurementsCountDown.countDown();
         });
 
@@ -119,7 +119,7 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
     public void queryRaw() {
         mockServer.enqueue(createResponse(SUCCESS_DATA));
 
-        String response = invocableScriptsApi.invokeScriptRaw("script_id", new HashMap<>());
+        String response = invokableScriptsApi.invokeScriptRaw("script_id", new HashMap<>());
         Assertions.assertThat(response).isEqualToIgnoringNewLines(SUCCESS_DATA);
     }
 
@@ -129,7 +129,7 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
 
         List<String> lines = new ArrayList<>();
         CountDownLatch linesCountDown = new CountDownLatch(3);
-        invocableScriptsApi.invokeScriptRaw("script_id", new HashMap<>(), (cancellable, line) -> {
+        invokableScriptsApi.invokeScriptRaw("script_id", new HashMap<>(), (cancellable, line) -> {
             lines.add(line);
             linesCountDown.countDown();
         });
@@ -143,7 +143,7 @@ class InvocableScriptsApiTest extends AbstractInfluxDBClientTest {
     }
 
     @SuppressWarnings("NewClassNamingConvention")
-    public static class InvocableScriptsPojo {
+    public static class InvokableScriptsPojo {
 
         @Column(name = "host", tag = true)
         String host;

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This directory contains Java, Kotlin and Scala examples.
 - [ParameterizedQuery.java](src/main/java/example/ParameterizedQuery.java) - How to use Parameterized Queries
 
 ### Others
-- [InvocableScripts.java](src/main/java/example/InvocableScripts.java) - How to use Invocable scripts Cloud API to create custom endpoints that query data
+- [InvokableScripts.java](src/main/java/example/InvokableScripts.java) - How to use Invokable scripts Cloud API to create custom endpoints that query data
 - [InfluxDBEnterpriseExample.java](src/main/java/example/InfluxDBEnterpriseExample.java) - How to use `consistency` parameter for InfluxDB Enterprise
 
 ## Kotlin

--- a/examples/src/main/java/example/InvokableScripts.java
+++ b/examples/src/main/java/example/InvokableScripts.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
-import com.influxdb.client.InvocableScriptsApi;
+import com.influxdb.client.InvokableScriptsApi;
 import com.influxdb.client.domain.Script;
 import com.influxdb.client.domain.ScriptCreateRequest;
 import com.influxdb.client.domain.ScriptLanguage;
@@ -36,7 +36,7 @@ import com.influxdb.client.write.Point;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
 
-public class InvocableScripts {
+public class InvokableScripts {
 
     //
     // Define credentials
@@ -56,10 +56,10 @@ public class InvocableScripts {
             Point point2 = Point.measurement("my_measurement").addTag("location", "New York").addField("temperature", 24.3);
             client.getWriteApiBlocking().writePoints(bucket, org, Arrays.asList(point1, point2));
 
-            InvocableScriptsApi scriptsApi = client.getInvocableScriptsApi();
+            InvokableScriptsApi scriptsApi = client.getInvokableScriptsApi();
 
             //
-            // Create Invocable Script
+            // Create Invokable Script
             //
             System.out.println("------- Create -------\n");
             ScriptCreateRequest createRequest = new ScriptCreateRequest()
@@ -71,7 +71,7 @@ public class InvocableScripts {
             System.out.println(createdScript);
 
             //
-            // Update Invocable Script
+            // Update Invokable Script
             //
             System.out.println("------- Update -------\n");
             ScriptUpdateRequest updateRequest = new ScriptUpdateRequest().description("my updated description");


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/317

## Proposed Changes

Renamed `InvocableScripts` to `InvokableScripts`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
