### PR TITLE
fix: creating `Tasks` with `import` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 1. [#339](https://github.com/influxdata/influxdb-client-java/pull/339): Evaluation of connection string
+1. [#352](https://github.com/influxdata/influxdb-client-java/pull/352): Creating `Tasks` with `import` statements
 
 ## 6.0.0 [2022-04-19]
 

--- a/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
@@ -721,7 +721,11 @@ final class TasksApiImpl extends AbstractRestClient implements TasksApi {
             repetition += "cron: ";
             repetition += "\"" + cron + "\"";
         }
-        String fluxWithOptions = String.format("option task = {name: \"%s\", %s} \n %s", name, repetition, flux);
+
+        int fromBegin = flux.indexOf("from");
+        String fluxWithOptions = flux.substring(0, fromBegin)
+                + String.format("option task = {name: \"%s\", %s}\n\n", name, repetition)
+                + flux.substring(fromBegin);
 
         task.setFlux(fluxWithOptions);
 


### PR DESCRIPTION
Closes #351

## Proposed Changes

Fixed creating `Task` with import statement:

```java
String flux = "import \"experimental\"\n"
        + "\n"
        + "from(bucket: \"my-bucket\")\n"
        + "    |> range(start: experimental.addDuration(d: -1d, to: today()), stop: today())\n"
        + "    |> max()";

Task task = tasksApi.createTaskCron("my-task", flux, "10 0 * * * *", organization.getId());
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
