### PR TITLE
fix: enable OkHttp retries for connection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 6.2.0 [unreleased]
 
+## 6.1.1 [unreleased]
+
 1. [#353](https://github.com/influxdata/influxdb-client-java/pull/353): Supports `contains` filter [FluxDSL]
 
 ## 6.1.0 [2022-05-20]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 6.1.1 [unreleased]
 
-1. [#353](https://github.com/influxdata/influxdb-client-java/pull/353): Supports `contains` filter [FluxDSL]
+### Features
+1. [#354](https://github.com/influxdata/influxdb-client-java/pull/354): Supports `contains` filter [FluxDSL]
+
+### Bug Fixes
+1. [#359](https://github.com/influxdata/influxdb-client-java/pull/359): Enable `OkHttp` retries for connection failure
 
 ## 6.1.0 [2022-05-20]
 

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-core</artifactId>

--- a/client-kotlin/pom.xml
+++ b/client-kotlin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-legacy/pom.xml
+++ b/client-legacy/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.influxdb</groupId>
         <artifactId>influxdb-client</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-flux</artifactId>

--- a/client-osgi/pom.xml
+++ b/client-osgi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-osgi</artifactId>

--- a/client-reactive/pom.xml
+++ b/client-reactive/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
@@ -62,7 +62,7 @@ class QueryReactiveApiTest extends AbstractMockServerTest {
     @Test
     public void doNotPropagateErrorOnCanceledConsumer() throws InterruptedException {
 
-        mockServer.enqueue(createErrorResponse("Request Timeout", true, 408)
+        mockServer.enqueue(createErrorResponse("Conflict", true, 409)
                 .setBodyDelay(3, TimeUnit.SECONDS));
 
         QueryReactiveApi queryApi = influxDBClient.getQueryReactiveApi();

--- a/client-scala/cross/2.12/pom.xml
+++ b/client-scala/cross/2.12/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>influxdb-client</artifactId>
     <groupId>com.influxdb</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/client-test/pom.xml
+++ b/client-test/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-test</artifactId>

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-client-utils</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
@@ -94,8 +94,13 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
         this.gzipInterceptor = new GzipInterceptor();
 
         this.okHttpClient = options.getOkHttpClient()
-                // Connection errors are handled by RetryAttempt in AbstractWriteClient.
-                .retryOnConnectionFailure(false)
+                //
+                // We don't need to disable the `retryOnConnectionFailure`. The retry logic
+                // in the OkHttp is not in a collision with our "exponential backoff strategy"
+                // for writes. OkHttp logic uses the possibility of routing to another "routes"
+                // - e.g. network loopback or multiple proxies.
+                //
+                //.retryOnConnectionFailure(false)
                 .addInterceptor(new UserAgentInterceptor(clientType))
                 .addInterceptor(this.loggingInterceptor)
                 .addInterceptor(this.authenticateInterceptor)

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,12 +27,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <properties>
         <checkstyle.skip>true</checkstyle.skip>
-        <influxdb-client.version>6.2.0-SNAPSHOT</influxdb-client.version>
+        <influxdb-client.version>6.1.1-SNAPSHOT</influxdb-client.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flux-dsl/pom.xml
+++ b/flux-dsl/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>flux-dsl</artifactId>

--- a/karaf/karaf-assembly/pom.xml
+++ b/karaf/karaf-assembly/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-assembly</artifactId>

--- a/karaf/karaf-features/pom.xml
+++ b/karaf/karaf-features/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-features</artifactId>

--- a/karaf/karaf-kar/pom.xml
+++ b/karaf/karaf-kar/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-karaf</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf-kar</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>influxdb-karaf-features</artifactId>
-            <version>6.2.0-SNAPSHOT</version>
+            <version>6.1.1-SNAPSHOT</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>influxdb-karaf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.influxdb</groupId>
     <artifactId>influxdb-client</artifactId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -475,38 +475,38 @@
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-test</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-core</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-utils</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-java</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-reactive</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.influxdb</groupId>
                 <artifactId>influxdb-client-flux</artifactId>
-                <version>6.2.0-SNAPSHOT</version>
+                <version>6.1.1-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <artifactId>influxdb-client</artifactId>
         <groupId>com.influxdb</groupId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>influxdb-spring</artifactId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring Integration for InfluxDB 2.x</name>


### PR DESCRIPTION
## Proposed Changes

This PR enables OkHttp retries strategy for connection failures. 

 We don't need to disable the `retryOnConnectionFailure`. The retry logic in the OkHttp is not in a collision with our `exponential backoff strategy` for writes. OkHttp logic uses the possibility of routing to another "routes"  - e.g. network loopback or multiple proxies.

For more info see:

- https://github.com/square/okhttp/issues/5390
- https://github.com/ktorio/ktor/issues/1708#issuecomment-609988128

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
