### PR TITLE
fix: fixing double quote escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 1. [#359](https://github.com/influxdata/influxdb-client-java/pull/359): Enable `OkHttp` retries for connection failure
+1. [#360](https://github.com/influxdata/influxdb-client-java/pull/360): Fix double quote escape in flux-dsl
 
 ## 6.1.0 [2022-05-20]
 

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/FunctionsParameters.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/properties/FunctionsParameters.java
@@ -54,6 +54,10 @@ public final class FunctionsParameters {
 
     private Map<String, Property> properties = new LinkedHashMap<>();
 
+    public static String escapeDoubleQuotes(final String val) {
+        return val.replace("\"", "\\\"");
+    }
+
     private FunctionsParameters() {
     }
 
@@ -86,7 +90,7 @@ public final class FunctionsParameters {
             }
 
             serializedValue = collection.stream()
-                    .map(host -> "\"" + host + "\"")
+                    .map(host -> "\"" + escapeDoubleQuotes(host.toString()) + "\"")
                     .collect(Collectors.joining(", ", "[", "]"));
         }
 
@@ -97,7 +101,7 @@ public final class FunctionsParameters {
             Map map = (Map) serializedValue;
             //noinspection unchecked
             map.keySet().forEach(key -> {
-                joiner.add(String.format("%s: \"%s\"", key, map.get(key)));
+                joiner.add(String.format("%s: \"%s\"", key, escapeDoubleQuotes(map.get(key).toString())));
             });
 
             serializedValue = joiner;
@@ -337,7 +341,7 @@ public final class FunctionsParameters {
                 return null;
             }
 
-            return "\"" + value + "\"";
+            return "\"" + escapeDoubleQuotes(value) + "\"";
         }
     }
 

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
@@ -28,6 +28,8 @@ import javax.annotation.Nonnull;
 import com.influxdb.query.dsl.functions.properties.FunctionsParameters;
 import com.influxdb.utils.Arguments;
 
+import static com.influxdb.query.dsl.functions.properties.FunctionsParameters.escapeDoubleQuotes;
+
 /**
  * The column restrictions.
  *
@@ -166,8 +168,9 @@ public final class ColumnRestriction {
 
         @Override
         public String toString() {
-            return "contains(value: r[\"" + fieldName + "\"], set:["
-                    + Arrays.stream(set).collect(Collectors.joining("\", \"", "\"", "\"")) + "])";
+            return "contains(value: r[\"" + escapeDoubleQuotes(fieldName) + "\"], set:["
+                    + Arrays.stream(set).map(FunctionsParameters::escapeDoubleQuotes)
+                    .collect(Collectors.joining("\", \"", "\"", "\"")) + "])";
         }
     }
 
@@ -196,8 +199,5 @@ public final class ColumnRestriction {
 
             return "r[\"" + escapeDoubleQuotes(fieldName) + "\"] " + operator + " " + value;
         }
-    }
-    private static String escapeDoubleQuotes(final String val) {
-        return val.replace("\"", "\\\"");
     }
 }

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/restriction/ColumnRestriction.java
@@ -141,7 +141,7 @@ public final class ColumnRestriction {
 
         @Override
         public String toString() {
-            return "exists r[\"" + fieldName + "\"]";
+            return "exists r[\"" + escapeDoubleQuotes(fieldName) + "\"]";
         }
     }
 
@@ -189,12 +189,15 @@ public final class ColumnRestriction {
 
             String value;
             if (fieldValue instanceof String) {
-                value = "\"" + fieldValue + "\"";
+                value = "\"" + escapeDoubleQuotes((String) fieldValue) + "\"";
             } else {
                 value = FunctionsParameters.serializeValue(fieldValue);
             }
 
-            return "r[\"" + fieldName + "\"] " + operator + " " + value;
+            return "r[\"" + escapeDoubleQuotes(fieldName) + "\"] " + operator + " " + value;
         }
+    }
+    private static String escapeDoubleQuotes(final String val) {
+        return val.replace("\"", "\\\"");
     }
 }

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
@@ -95,4 +95,14 @@ class RestrictionsTest {
         restrictions = Restrictions.or(Restrictions.or());
         Assertions.assertThat(restrictions.toString()).isEqualTo("");
     }
+
+    @Test
+    void escapeStringValues() {
+        Restrictions restrictions = Restrictions.tag("my-tag").equal("escaped\"tag");
+        Assertions.assertThat(restrictions.toString()).isEqualTo("r[\"my-tag\"] == \"escaped\\\"tag\"");
+
+        restrictions = Restrictions.column("my\"column").exists();
+        Assertions.assertThat(restrictions.toString()).isEqualTo("exists r[\"my\\\"column\"]");
+    }
+
 }


### PR DESCRIPTION
## Proposed Changes

This PR fixes the escaping of double quotes in flux-dsl.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
