### PR TITLE
feat: add HTTP status code to detail message of InfluxException, add `GatewayTimeoutException` for `504`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 1. [#354](https://github.com/influxdata/influxdb-client-java/pull/354): Supports `contains` filter [FluxDSL]
+1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add HTTP status code to detail message of `InfluxException`
+1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add `GatewayTimeoutException` for HTTP status code 504
 
 ### Bug Fixes
 1. [#359](https://github.com/influxdata/influxdb-client-java/pull/359): Enable `OkHttp` retries for connection failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## 6.3.0 [unreleased]
 
+### Features
+1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add HTTP status code to detail message of `InfluxException`
+1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add `GatewayTimeoutException` for HTTP status code 504
+
 ## 6.2.0 [2022-06-24]
 
 ### Features
 1. [#354](https://github.com/influxdata/influxdb-client-java/pull/354): Supports `contains` filter [FluxDSL]
-1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add HTTP status code to detail message of `InfluxException`
-1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add `GatewayTimeoutException` for HTTP status code 504
 
 ### Bug Fixes
 1. [#359](https://github.com/influxdata/influxdb-client-java/pull/359): Enable `OkHttp` retries for connection failure

--- a/client-core/src/main/java/com/influxdb/exceptions/GatewayTimeoutException.java
+++ b/client-core/src/main/java/com/influxdb/exceptions/GatewayTimeoutException.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.exceptions;
+
+import org.jetbrains.annotations.Nullable;
+import retrofit2.Response;
+
+/**
+ * The exception is thrown if an HTTP 504 response code arrived - Gateway Timeout.
+ *
+ * @author Jakub Bednar (bednar@github) (06/23/2022 13:16)
+ */
+public class GatewayTimeoutException extends InfluxException {
+
+    public GatewayTimeoutException(@Nullable final Response<?> cause) {
+        super(cause);
+    }
+}

--- a/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
+++ b/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
@@ -89,7 +89,7 @@ public class InfluxException extends RuntimeException {
     }
 
     /**
-     * Gets the reference code unique to the error type. If the reference code is not present than return "0".
+     * Gets the reference code unique to the error type. If the reference code is not present then return "0".
      *
      * @return reference code unique to the error type
      */
@@ -109,7 +109,7 @@ public class InfluxException extends RuntimeException {
 
     /**
      * Gets the HTTP status code of the unsuccessful response.
-     * If the response is not present than return "0".
+     * If the response is not present then return "0".
      *
      * @return HTTP status code
      */
@@ -124,7 +124,7 @@ public class InfluxException extends RuntimeException {
 
     /**
      * Gets the HTTP headers from the unsuccessful response.
-     * If the response is not present than return empty {@code Map}.
+     * If the response is not present then return empty {@code Map}.
      *
      * @return HTTP headers
      */

--- a/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
+++ b/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
@@ -50,6 +50,7 @@ import retrofit2.Response;
 public class InfluxException extends RuntimeException {
 
     private static final Logger LOG = Logger.getLogger(InfluxException.class.getName());
+    private static final String HTTP_STATUS_CODE_MESSAGE = "HTTP status code: %d; Message: %s";
 
     private final Response<?> response;
     private final String message;
@@ -155,6 +156,7 @@ public class InfluxException extends RuntimeException {
     @Nullable
     private String messageFromResponse() {
         if (response != null) {
+            int code = response.code();
             try {
                 ResponseBody body = response.errorBody();
                 if (body != null) {
@@ -163,7 +165,7 @@ public class InfluxException extends RuntimeException {
                         errorBody = new Gson().fromJson(json, new TypeToken<Map<String, Object>>() {
                         }.getType());
                         if (errorBody.containsKey("message")) {
-                            return errorBody.get("message").toString();
+                            return String.format(HTTP_STATUS_CODE_MESSAGE, code, errorBody.get("message").toString());
                         }
                     }
                 }
@@ -177,7 +179,7 @@ public class InfluxException extends RuntimeException {
                     .orElse(null);
 
             if (value != null) {
-                return value;
+                return String.format(HTTP_STATUS_CODE_MESSAGE, code, value);
             }
         }
 

--- a/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
+++ b/client-core/src/main/java/com/influxdb/internal/AbstractRestClient.java
@@ -32,6 +32,7 @@ import com.influxdb.LogLevel;
 import com.influxdb.exceptions.BadGatewayException;
 import com.influxdb.exceptions.BadRequestException;
 import com.influxdb.exceptions.ForbiddenException;
+import com.influxdb.exceptions.GatewayTimeoutException;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.InternalServerErrorException;
 import com.influxdb.exceptions.MethodNotAllowedException;
@@ -138,6 +139,8 @@ public abstract class AbstractRestClient {
                 return new BadGatewayException(response);
             case 503:
                 return new ServiceUnavailableException(response);
+            case 504:
+                return new GatewayTimeoutException(response);
             default:
                 return new InfluxException(response);
         }

--- a/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
+++ b/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
@@ -78,7 +78,7 @@ class InfluxExceptionTest {
                 })
                 .isInstanceOf(InfluxException.class)
                 .hasCauseInstanceOf(HttpException.class)
-                .hasMessage("Wrong query");
+                .hasMessage("HTTP status code: 500; Message: Wrong query");
     }
 
     @Test
@@ -172,7 +172,7 @@ class InfluxExceptionTest {
                     Response<Object> response = errorResponse("not found", 404, 15, "{\"code\":\"not found\",\"message\":\"user not found\"}", "X-Platform-Error-Code");
                     throw new InfluxException(new HttpException(response));
                 })
-                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("user not found"));
+                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("HTTP status code: 404; Message: user not found"));
     }
 
     @Test
@@ -182,7 +182,7 @@ class InfluxExceptionTest {
                     Response<Object> response = errorResponse("not found", 404, 15, "{\"code\":\"not found\"}", "X-Platform-Error-Code");
                     throw new InfluxException(new HttpException(response));
                 })
-                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("not found"));
+                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("HTTP status code: 404; Message: not found"));
     }
 
     @Test
@@ -192,7 +192,7 @@ class InfluxExceptionTest {
                     Response<Object> response = errorResponse("not found", 404, 15, "not-json", "X-Platform-Error-Code");
                     throw new InfluxException(new HttpException(response));
                 })
-                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("not found"));
+                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("HTTP status code: 404; Message: not found"));
     }
 
     @Test
@@ -312,6 +312,17 @@ class InfluxExceptionTest {
                 .matches((Predicate<Throwable>) throwable -> ((InfluxException) throwable).status() == 0)
                 .matches((Predicate<Throwable>) throwable -> ((InfluxException) throwable).reference() == 0)
                 .matches((Predicate<Throwable>) throwable -> ((InfluxException) throwable).errorBody().isEmpty());
+    }
+
+    @Test
+    void messageContainsHttpErrorCode() {
+        Assertions
+                .assertThatThrownBy(() -> {
+                    Response<Object> response = errorResponse("Wrong query", 501, 15, "{\"error\": \"error-body\"}");
+                    throw new InfluxException(new HttpException(response));
+                })
+                .matches((Predicate<Throwable>) throwable -> throwable.getMessage().equals("HTTP status code: 501; Message: Wrong query"))
+                .matches((Predicate<Throwable>) throwable -> throwable.toString().equals("com.influxdb.exceptions.InfluxException: HTTP status code: 501; Message: Wrong query"));
     }
 
     @Nonnull

--- a/client-core/src/test/java/com/influxdb/internal/QueryAbstractApiTest.java
+++ b/client-core/src/test/java/com/influxdb/internal/QueryAbstractApiTest.java
@@ -172,7 +172,7 @@ class QueryAbstractApiTest extends AbstractMockServerTest {
         Assertions.assertThatThrownBy(() -> queryClient.query(createCall(), consumer, AbstractQueryApi.ERROR_CONSUMER, () -> {
         }, false))
                 .isInstanceOf(InfluxException.class)
-                .hasMessage("Flux query is not valid");
+                .hasMessage("HTTP status code: 500; Message: Flux query is not valid");
     }
 
     @Test
@@ -238,7 +238,7 @@ class QueryAbstractApiTest extends AbstractMockServerTest {
         Assertions.assertThatThrownBy(() -> queryClient.queryRaw(createCall(), consumer, AbstractQueryApi.ERROR_CONSUMER, () -> {
         }, false))
                 .isInstanceOf(InfluxException.class)
-                .hasMessage("Flux query is not valid");
+                .hasMessage("HTTP status code: 500; Message: Flux query is not valid");
     }
 
     @Test

--- a/client-core/src/test/java/com/influxdb/internal/RestClientTest.java
+++ b/client-core/src/test/java/com/influxdb/internal/RestClientTest.java
@@ -30,6 +30,7 @@ import com.influxdb.LogLevel;
 import com.influxdb.exceptions.BadGatewayException;
 import com.influxdb.exceptions.BadRequestException;
 import com.influxdb.exceptions.ForbiddenException;
+import com.influxdb.exceptions.GatewayTimeoutException;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.InternalServerErrorException;
 import com.influxdb.exceptions.MethodNotAllowedException;
@@ -114,6 +115,7 @@ class RestClientTest extends AbstractMockServerTest {
         Assertions.assertThatThrownBy(() -> errorResponse(501)).isInstanceOf(NotImplementedException.class);
         Assertions.assertThatThrownBy(() -> errorResponse(502)).isInstanceOf(BadGatewayException.class);
         Assertions.assertThatThrownBy(() -> errorResponse(503)).isInstanceOf(ServiceUnavailableException.class);
+        Assertions.assertThatThrownBy(() -> errorResponse(504)).isInstanceOf(GatewayTimeoutException.class);
         Assertions.assertThatThrownBy(() -> errorResponse(550)).isInstanceOf(InfluxException.class);
     }
 
@@ -202,7 +204,7 @@ class RestClientTest extends AbstractMockServerTest {
 
         Assertions.assertThatThrownBy(() -> restClient.execute(call))
                 .isInstanceOf(InfluxException.class)
-                .hasMessage("flower not found");
+                .hasMessage("HTTP status code: 500; Message: flower not found");
     }
     
     @Test

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/WriteKotlinApiTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/WriteKotlinApiTest.kt
@@ -183,7 +183,7 @@ class WriteKotlinApiTest : AbstractMockServerTest() {
                 runBlocking {
                     writeApi.writeRecord("h2o_feet,location=coyote_creek water_level=1.0 1", WritePrecision.S)
                 }
-            }.hasMessageStartingWith("token does not have sufficient permissions")
+            }.hasMessageStartingWith("HTTP status code: 401; Message: token does not have sufficient permissions")
             .isInstanceOf(UnauthorizedException::class.java)
     }
 

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryRawTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryRawTest.java
@@ -58,7 +58,7 @@ class FluxClientQueryRawTest extends AbstractFluxClientTest {
         mockServer.enqueue(createErrorResponse());
 
         Assertions.assertThatThrownBy(() -> fluxClient.queryRaw("from(bucket:\"telegraf\")"))
-                .hasMessage("Flux query is not valid")
+                .hasMessage("HTTP status code: 500; Message: Flux query is not valid")
                 .isInstanceOf(InfluxException.class);
     }
 

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryTest.java
@@ -90,7 +90,7 @@ class FluxClientQueryTest extends AbstractFluxClientTest {
 
         Assertions.assertThatThrownBy(() -> fluxClient.query("from(bucket:\"telegraf\")"))
                 .isInstanceOf(InfluxException.class)
-                .hasMessage("Flux query is not valid");
+                .hasMessage("HTTP status code: 500; Message: Flux query is not valid");
     }
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/ITFluxClient.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/ITFluxClient.java
@@ -182,7 +182,7 @@ class ITFluxClient extends AbstractITFluxClient {
 
         Assertions.assertThatThrownBy(() -> fluxClient.query("from(bucket:\"telegraf\")"))
                 .isInstanceOf(InfluxException.class)
-                .hasMessageStartingWith("error in building plan while starting program:")
+                .hasMessageStartingWith("HTTP status code: 500; Message: error in building plan while starting program:")
                 .hasMessageEndingWith("try bounding 'from' with a call to 'range'");
     }
 

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
@@ -313,7 +313,7 @@ class WriteReactiveApiTest extends AbstractMockServerTest {
                 .assertValueCount(0)
                 .assertError(throwable -> {
                     Assertions.assertThat(throwable).isInstanceOf(InfluxException.class);
-                    Assertions.assertThat(throwable).hasMessage("token is temporarily over quota");
+                    Assertions.assertThat(throwable).hasMessage("HTTP status code: 429; Message: token is temporarily over quota");
                     return true;
                 })
                 .assertNotComplete();

--- a/client-scala/src/test/scala/com/influxdb/client/scala/WriteScalaApiTest.scala
+++ b/client-scala/src/test/scala/com/influxdb/client/scala/WriteScalaApiTest.scala
@@ -111,7 +111,7 @@ class WriteScalaApiTest extends AnyFunSuite with Matchers with BeforeAndAfter wi
     val materialized = source.toMat(sink)(Keep.right)
 
     whenReady(materialized.run().failed) { exc => {
-      exc.getMessage should be("line protocol poorly formed and no points were written")
+      exc.getMessage should be("HTTP status code: 500; Message: line protocol poorly formed and no points were written")
       exc.getClass should be(classOf[InternalServerErrorException])
     }
     }

--- a/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/InfluxDBClientImpl.java
@@ -79,7 +79,6 @@ import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.UnprocessableEntityException;
 import com.influxdb.utils.Arguments;
 
-import org.jetbrains.annotations.NotNull;
 import retrofit2.Call;
 
 /**
@@ -242,7 +241,7 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
         return new DeleteApiImpl(retrofit.create(DeleteService.class));
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public InvokableScriptsApi getInvokableScriptsApi() {
         return new InvokableScriptsApiImpl(retrofit.create(InvokableScriptsService.class));

--- a/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
@@ -223,7 +223,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> authorizationsApi.findAuthorizationByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("authorization not found");
+                .hasMessage("HTTP status code: 404; Message: authorization not found");
     }
 
     @Test
@@ -321,7 +321,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> authorizationsApi.findAuthorizationByID(createdAuthorization.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("authorization not found");
+                .hasMessage("HTTP status code: 404; Message: authorization not found");
     }
 
     @Test
@@ -350,7 +350,7 @@ class ITAuthorizationsApi extends AbstractITClientTest {
         
         Assertions.assertThatThrownBy(() -> authorizationsApi.cloneAuthorization("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("authorization not found");
+                .hasMessage("HTTP status code: 404; Message: authorization not found");
     }
 
     @Nonnull

--- a/client/src/test/java/com/influxdb/client/ITBucketsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITBucketsApi.java
@@ -142,7 +142,7 @@ class ITBucketsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> bucketsApi.findBucketByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("bucket not found");
+                .hasMessage("HTTP status code: 404; Message: bucket not found");
     }
 
     @Test
@@ -237,7 +237,7 @@ class ITBucketsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> bucketsApi.findBucketByID(createBucket.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("bucket not found");
+                .hasMessage("HTTP status code: 404; Message: bucket not found");
     }
 
     @Test
@@ -408,6 +408,6 @@ class ITBucketsApi extends AbstractITClientTest {
     void cloneBucketNotFound() {
          Assertions.assertThatThrownBy(() -> bucketsApi.cloneBucket(generateName("cloned"), "020f755c3c082000"))
                  .isInstanceOf(NotFoundException.class)
-                 .hasMessage("bucket not found");
+                 .hasMessage("HTTP status code: 404; Message: bucket not found");
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITChecksApi.java
+++ b/client/src/test/java/com/influxdb/client/ITChecksApi.java
@@ -225,7 +225,7 @@ class ITChecksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> checksApi.updateCheck("020f755c3c082000", update))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("check not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: check not found for key \"020f755c3c082000\"");
     }
 
     @Test
@@ -247,7 +247,7 @@ class ITChecksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> checksApi.findCheckByID(found.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("check not found for key \"" + found.getId() + "\"");
+                .hasMessage("HTTP status code: 404; Message: check not found for key \"" + found.getId() + "\"");
     }
 
     @Test
@@ -255,7 +255,7 @@ class ITChecksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> checksApi.deleteCheck("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("check not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: check not found for key \"020f755c3c082000\"");
     }
 
     @Test
@@ -280,7 +280,7 @@ class ITChecksApi extends AbstractITClientTest {
     public void findCheckByIDNotFound() {
         Assertions.assertThatThrownBy(() -> checksApi.findCheckByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("check not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: check not found for key \"020f755c3c082000\"");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITDashboardsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITDashboardsApi.java
@@ -142,7 +142,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.findDashboardByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("dashboard not found");
+                .hasMessage("HTTP status code: 404; Message: dashboard not found");
     }
 
     @Test
@@ -351,7 +351,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.addCell(createCell, "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("dashboard not found");
+                .hasMessage("HTTP status code: 404; Message: dashboard not found");
     }
 
     @Test
@@ -462,7 +462,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.deleteCell("020f755c3c082000", dashboard.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("cell not found");
+                .hasMessage("HTTP status code: 404; Message: cell not found");
     }
 
     @Test
@@ -482,7 +482,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.deleteCell(cell.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("dashboard not found");
+                .hasMessage("HTTP status code: 404; Message: dashboard not found");
     }
 
     @Test
@@ -582,7 +582,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.addCellView(view, cell.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("dashboard not found");
+                .hasMessage("HTTP status code: 404; Message: dashboard not found");
 
         //TODO https://github.com/influxdata/influxdb/issues/13083
         // Assertions.assertThatThrownBy(() -> dashboardsApi.addCellView(view, "020f755c3c082000", dashboard.getId()))
@@ -607,7 +607,7 @@ class ITDashboardsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> dashboardsApi.getCellView(cell.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("dashboard not found");
+                .hasMessage("HTTP status code: 404; Message: dashboard not found");
 
         //TODO https://github.com/influxdata/influxdb/issues/13083
         // Assertions.assertThatThrownBy(() -> dashboardsApi.getCellView("ffffffffffffffff", dashboard.getId()))

--- a/client/src/test/java/com/influxdb/client/ITInfluxDBClient.java
+++ b/client/src/test/java/com/influxdb/client/ITInfluxDBClient.java
@@ -194,7 +194,7 @@ class ITInfluxDBClient extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> influxDBClient.onBoarding(onboarding))
                 .isInstanceOf(UnprocessableEntityException.class)
-                .hasMessage("onboarding has already been completed");
+                .hasMessage("HTTP status code: 422; Message: onboarding has already been completed");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITLabelsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITLabelsApi.java
@@ -107,7 +107,7 @@ class ITLabelsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> labelsApi.findLabelByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("label not found");
+                .hasMessage("HTTP status code: 404; Message: label not found");
     }
 
     @Test
@@ -153,7 +153,7 @@ class ITLabelsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> labelsApi.findLabelByID(createdLabel.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("label not found");
+                .hasMessage("HTTP status code: 404; Message: label not found");
     }
 
     @Test
@@ -212,6 +212,6 @@ class ITLabelsApi extends AbstractITClientTest {
     void cloneLabelNotFound() {
         Assertions.assertThatThrownBy(() -> labelsApi.cloneLabel(generateName("cloned"), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("label not found");
+                .hasMessage("HTTP status code: 404; Message: label not found");
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITNotificationEndpointsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITNotificationEndpointsApi.java
@@ -168,7 +168,7 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .createEndpoint(endpoint))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("slack endpoint URL must be provided");
+                .hasMessage("HTTP status code: 400; Message: slack endpoint URL must be provided");
     }
 
     @Test
@@ -339,7 +339,7 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi.updateEndpoint("020f755c3c082000", update))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
     }
 
     @Test
@@ -354,7 +354,7 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi.findNotificationEndpointByID(found.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"" + found.getId() + "\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"" + found.getId() + "\"");
     }
 
     @Test
@@ -362,7 +362,7 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi.deleteNotificationEndpoint("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
     }
 
     @Test
@@ -381,7 +381,7 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
     public void findNotificationEndpointByIDNotFound() {
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi.findNotificationEndpointByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
     }
 
     @Test
@@ -516,27 +516,27 @@ class ITNotificationEndpointsApi extends AbstractITClientTest {
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .cloneSlackEndpoint("not-found-cloned", "token", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .clonePagerDutyEndpoint("not-found-cloned", "token", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .cloneHTTPEndpoint("not-found-cloned", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .cloneHTTPEndpointBearer("not-found-cloned", "token", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
 
         Assertions.assertThatThrownBy(() -> notificationEndpointsApi
                 .cloneHTTPEndpointBasicAuth("not-found-cloned", "username", "password", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification endpoint not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: notification endpoint not found for key \"020f755c3c082000\"");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITNotificationRulesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITNotificationRulesApi.java
@@ -278,7 +278,7 @@ class ITNotificationRulesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationRulesApi.updateNotificationRule("020f755c3c082000", update))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification rule not found");
+                .hasMessage("HTTP status code: 404; Message: notification rule not found");
     }
 
     @Test
@@ -298,7 +298,7 @@ class ITNotificationRulesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationRulesApi.findNotificationRuleByID(created.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification rule not found");
+                .hasMessage("HTTP status code: 404; Message: notification rule not found");
     }
 
     @Test
@@ -306,7 +306,7 @@ class ITNotificationRulesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> notificationRulesApi.deleteNotificationRule("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification rule not found");
+                .hasMessage("HTTP status code: 404; Message: notification rule not found");
     }
 
     @Test
@@ -330,7 +330,7 @@ class ITNotificationRulesApi extends AbstractITClientTest {
     public void findRuleByIDNotFound() {
         Assertions.assertThatThrownBy(() -> notificationRulesApi.findNotificationRuleByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("notification rule not found");
+                .hasMessage("HTTP status code: 404; Message: notification rule not found");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITOrganizationsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITOrganizationsApi.java
@@ -124,7 +124,7 @@ class ITOrganizationsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> organizationsApi.findOrganizationByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("organization not found");
+                .hasMessage("HTTP status code: 404; Message: organization not found");
     }
 
     @Test
@@ -152,7 +152,7 @@ class ITOrganizationsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> organizationsApi.findOrganizationByID(createdOrganization.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("organization not found");
+                .hasMessage("HTTP status code: 404; Message: organization not found");
     }
 
     @Test
@@ -280,6 +280,6 @@ class ITOrganizationsApi extends AbstractITClientTest {
     void cloneOrganizationNotFound() {
         Assertions.assertThatThrownBy(() -> organizationsApi.cloneOrganization(generateName("cloned"), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("organization not found");
+                .hasMessage("HTTP status code: 404; Message: organization not found");
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITScraperTargetsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITScraperTargetsApi.java
@@ -142,7 +142,7 @@ class ITScraperTargetsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> scraperTargetsApi.findScraperTargetByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("scraper target is not found");
+                .hasMessage("HTTP status code: 404; Message: scraper target is not found");
     }
 
     @Test
@@ -160,7 +160,7 @@ class ITScraperTargetsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> scraperTargetsApi.findScraperTargetByID(createdScraper.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("scraper target is not found");
+                .hasMessage("HTTP status code: 404; Message: scraper target is not found");
     }
 
     @Test
@@ -290,6 +290,6 @@ class ITScraperTargetsApi extends AbstractITClientTest {
     void cloneScraperTargetNotFound() {
         Assertions.assertThatThrownBy(() -> scraperTargetsApi.cloneScraperTarget(generateName("cloned"), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("scraper target is not found");
+                .hasMessage("HTTP status code: 404; Message: scraper target is not found");
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITSourcesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITSourcesApi.java
@@ -126,7 +126,7 @@ class ITSourcesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> sourcesApi.findSourceByID(createdSource.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("source not found");
+                .hasMessage("HTTP status code: 404; Message: source not found");
 
     }
 
@@ -151,7 +151,7 @@ class ITSourcesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> sourcesApi.findSourceByID("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("source not found");
+                .hasMessage("HTTP status code: 404; Message: source not found");
     }
 
     @Test
@@ -182,7 +182,7 @@ class ITSourcesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> sourcesApi.findBucketsBySourceID("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("source not found");
+                .hasMessage("HTTP status code: 404; Message: source not found");
     }
 
     @Test
@@ -224,7 +224,7 @@ class ITSourcesApi extends AbstractITClientTest {
     void cloneSourceNotFound() {
         Assertions.assertThatThrownBy(() -> sourcesApi.cloneSource(generateName("cloned"), "da7aba5e5d81e550"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("source not found");
+                .hasMessage("HTTP status code: 404; Message: source not found");
     }
 
     @Nonnull

--- a/client/src/test/java/com/influxdb/client/ITTasksApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTasksApi.java
@@ -257,7 +257,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.findTaskByID("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find task: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find task: task not found");
     }
 
     @Test
@@ -332,7 +332,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.findTaskByID(createdTask.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find task: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find task: task not found");
     }
 
     @Test
@@ -466,7 +466,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.getRuns("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find runs: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find runs: task not found");
     }
 
     @Test
@@ -559,7 +559,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.getRun(task.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find run: run not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find run: run not found");
     }
 
     @Test
@@ -578,7 +578,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.runManually("020f755c3c082000", new RunManually()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to force run: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to force run: task not found");
     }
 
     @Test
@@ -611,7 +611,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.retryRun(task.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to retry run: run not found");
+                .hasMessage("HTTP status code: 404; Message: failed to retry run: run not found");
     }
 
     @Test
@@ -644,7 +644,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.getLogs("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find task logs: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find task logs: task not found");
     }
 
     @Test
@@ -674,7 +674,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.getRunLogs(task.getId(), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find task logs: run not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find task logs: run not found");
     }
 
     @Test
@@ -690,7 +690,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.cancelRun(runs.get(0)))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to cancel run: run not found");
+                .hasMessage("HTTP status code: 404; Message: failed to cancel run: run not found");
     }
 
     @Test
@@ -698,7 +698,7 @@ class ITTasksApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> tasksApi.cancelRun("020f755c3c082000", "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to cancel run: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to cancel run: task not found");
     }
 
     @Test
@@ -771,7 +771,7 @@ class ITTasksApi extends AbstractITClientTest {
     void cloneTaskNotFound() {
         Assertions.assertThatThrownBy(() -> tasksApi.cloneTask("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("failed to find task: task not found");
+                .hasMessage("HTTP status code: 404; Message: failed to find task: task not found");
     }
 
     @Nonnull

--- a/client/src/test/java/com/influxdb/client/ITTelegrafsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTelegrafsApi.java
@@ -160,7 +160,7 @@ class ITTelegrafsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> telegrafsApi.findTelegrafByID(createdConfig.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("telegraf configuration not found");
+                .hasMessage("HTTP status code: 404; Message: telegraf configuration not found");
     }
 
     @Test
@@ -168,7 +168,7 @@ class ITTelegrafsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> telegrafsApi.deleteTelegraf("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("telegraf configuration not found");
+                .hasMessage("HTTP status code: 404; Message: telegraf configuration not found");
     }
 
     @Test
@@ -193,7 +193,7 @@ class ITTelegrafsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> telegrafsApi.findTelegrafByID("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("telegraf configuration not found");
+                .hasMessage("HTTP status code: 404; Message: telegraf configuration not found");
     }
 
     @Test
@@ -247,7 +247,7 @@ class ITTelegrafsApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> telegrafsApi.getTOML("020f755c3d082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("telegraf configuration not found");
+                .hasMessage("HTTP status code: 404; Message: telegraf configuration not found");
     }
 
     @Test
@@ -397,7 +397,7 @@ class ITTelegrafsApi extends AbstractITClientTest {
     void cloneTelegrafConfigNotFound() {
         Assertions.assertThatThrownBy(() -> telegrafsApi.cloneTelegraf(generateName("cloned"), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("telegraf configuration not found");
+                .hasMessage("HTTP status code: 404; Message: telegraf configuration not found");
     }
 
     @Nonnull

--- a/client/src/test/java/com/influxdb/client/ITUsersApi.java
+++ b/client/src/test/java/com/influxdb/client/ITUsersApi.java
@@ -87,7 +87,7 @@ class ITUsersApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> usersApi.findUserByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("user not found");
+                .hasMessage("HTTP status code: 404; Message: user not found");
     }
 
     @Test
@@ -115,7 +115,7 @@ class ITUsersApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> usersApi.findUserByID(createdUser.getId()))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("user not found");
+                .hasMessage("HTTP status code: 404; Message: user not found");
     }
 
     @Test
@@ -147,7 +147,7 @@ class ITUsersApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> usersApi.me())
                 .isInstanceOf(UnauthorizedException.class)
-                .hasMessage("unauthorized access");
+                .hasMessage("HTTP status code: 401; Message: unauthorized access");
     }
 
     @Test
@@ -232,6 +232,6 @@ class ITUsersApi extends AbstractITClientTest {
     void cloneUserNotFound() {
         Assertions.assertThatThrownBy(() -> usersApi.cloneUser(generateName("cloned"), "020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("user not found");
+                .hasMessage("HTTP status code: 404; Message: user not found");
     }
 }

--- a/client/src/test/java/com/influxdb/client/ITVariablesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITVariablesApi.java
@@ -198,7 +198,7 @@ class ITVariablesApi extends AbstractITClientTest {
 
         Assertions.assertThatThrownBy(() -> variablesApi.findVariableByID("020f755c3c082000"))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage("variable not found for key \"020f755c3c082000\"");
+                .hasMessage("HTTP status code: 404; Message: variable not found for key \"020f755c3c082000\"");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
@@ -131,7 +131,7 @@ class ITWriteApiBlocking extends AbstractITWrite {
         WriteApiBlocking api = influxDBClient.getWriteApiBlocking();
 
         Assertions.assertThatThrownBy(() -> api.writeRecord(WritePrecision.NS, "h2o,location=coyote_creek"))
-                .hasMessageStartingWith("unable to parse 'h2o,location=coyote_creek': missing fields")
+                .hasMessageStartingWith("HTTP status code: 400; Message: unable to parse 'h2o,location=coyote_creek': missing fields")
                 .isInstanceOf(BadRequestException.class);
     }
 


### PR DESCRIPTION
## Proposed Changes

1. Added HTTP status code to detail message of the `InfluxException` => logged exception looks like: `HTTP status code: 501; Message: Wrong query"`
1. Added `GatewayTimeoutException` for HTTP status code 504

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)