### PR TITLE
feat: add possibility to customize the User-Agent HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add HTTP status code to detail message of `InfluxException`
 1. [#367](https://github.com/influxdata/influxdb-client-java/pull/367): Add `GatewayTimeoutException` for HTTP status code 504
+1. [#371](https://github.com/influxdata/influxdb-client-java/pull/371): Add possibility to customize the `User-Agent` HTTP header
 
 ### CI
 1. [#369](https://github.com/influxdata/influxdb-client-java/pull/369): Add JDK 18 to CI pipeline

--- a/client-kotlin/README.md
+++ b/client-kotlin/README.md
@@ -179,17 +179,18 @@ A client can be configured via configuration file. The configuration file has to
 
 The following options are supported:
 
-| Property name            | default    | description                                                |
-|--------------------------|------------|------------------------------------------------------------| 
-| influx2.url              | -          | the url to connect to InfluxDB                             |
-| influx2.org              | -          | default destination organization for writes and queries    |
-| influx2.bucket           | -          | default destination bucket for writes                      |
-| influx2.token            | -          | the token to use for the authorization                     |
-| influx2.logLevel         | NONE       | rest client verbosity level                                |
-| influx2.readTimeout      | 10000 ms   | read timeout                                               |
-| influx2.writeTimeout     | 10000 ms   | write timeout                                              |
-| influx2.connectTimeout   | 10000 ms   | socket timeout                                             |
-| influx2.precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name          | default    | description                                                |
+|------------------------|------------|------------------------------------------------------------| 
+| influx2.url            | -          | the url to connect to InfluxDB                             |
+| influx2.org            | -          | default destination organization for writes and queries    |
+| influx2.bucket         | -          | default destination bucket for writes                      |
+| influx2.token          | -          | the token to use for the authorization                     |
+| influx2.logLevel       | NONE       | rest client verbosity level                                |
+| influx2.readTimeout    | 10000 ms   | read timeout                                               |
+| influx2.writeTimeout   | 10000 ms   | write timeout                                              |
+| influx2.connectTimeout | 10000 ms   | socket timeout                                             |
+| influx2.precision      | NS         | default precision for unix timestamps in the line protocol |
+| influx2.clientType     | -          | to customize the User-Agent HTTP header                    |
 
 The `influx2.readTimeout`, `influx2.writeTimeout` and `influx2.connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 
@@ -223,16 +224,17 @@ val influxDBClient = InfluxDBClientKotlinFactory
 ```
 The following options are supported:
 
-| Property name    | default    | description                                                |
-|------------------|------------|------------------------------------------------------------| 
-| org              | -          | default destination organization for writes and queries    |
-| bucket           | -          | default destination bucket for writes                      |
-| token            | -          | the token to use for the authorization                     |
-| logLevel         | NONE       | rest client verbosity level                                |
-| readTimeout      | 10000 ms   | read timeout                                               |
-| writeTimeout     | 10000 ms   | write timeout                                              |
-| connectTimeout   | 10000 ms   | socket timeout                                             |
-| precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name    | default   | description                                                |
+|------------------|-----------|------------------------------------------------------------| 
+| org              | -         | default destination organization for writes and queries    |
+| bucket           | -         | default destination bucket for writes                      |
+| token            | -         | the token to use for the authorization                     |
+| logLevel         | NONE      | rest client verbosity level                                |
+| readTimeout      | 10000 ms  | read timeout                                               |
+| writeTimeout     | 10000 ms  | write timeout                                              |
+| connectTimeout   | 10000 ms  | socket timeout                                             |
+| precision        | NS        | default precision for unix timestamps in the line protocol |
+| clientType       | -         | to customize the User-Agent HTTP header                    |
 
 The `readTimeout`, `writeTimeout` and `connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -302,17 +302,18 @@ A client can be configured via configuration file. The configuration file has to
 
 The following options are supported:
 
-| Property name            | default    | description                                                |
-|--------------------------|------------|------------------------------------------------------------| 
-| influx2.url              | -          | the url to connect to InfluxDB                             |
-| influx2.org              | -          | default destination organization for writes and queries    |
-| influx2.bucket           | -          | default destination bucket for writes                      |
-| influx2.token            | -          | the token to use for the authorization                     |
-| influx2.logLevel         | NONE       | rest client verbosity level                                |
-| influx2.readTimeout      | 10000 ms   | read timeout                                               |
-| influx2.writeTimeout     | 10000 ms   | write timeout                                              |
-| influx2.connectTimeout   | 10000 ms   | socket timeout                                             |
-| influx2.precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name          | default   | description                                                |
+|------------------------|-----------|------------------------------------------------------------| 
+| influx2.url            | -         | the url to connect to InfluxDB                             |
+| influx2.org            | -         | default destination organization for writes and queries    |
+| influx2.bucket         | -         | default destination bucket for writes                      |
+| influx2.token          | -         | the token to use for the authorization                     |
+| influx2.logLevel       | NONE      | rest client verbosity level                                |
+| influx2.readTimeout    | 10000 ms  | read timeout                                               |
+| influx2.writeTimeout   | 10000 ms  | write timeout                                              |
+| influx2.connectTimeout | 10000 ms  | socket timeout                                             |
+| influx2.precision      | NS        | default precision for unix timestamps in the line protocol |
+| influx2.clientType     | -         | to customize the User-Agent HTTP header                    |
 
 The `influx2.readTimeout`, `influx2.writeTimeout` and `influx2.connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 
@@ -346,16 +347,17 @@ InfluxDBClientReactive influxDBClient = InfluxDBClientReactiveFactory
 ```
 The following options are supported:
 
-| Property name    | default    | description                                                |
-|------------------|------------|------------------------------------------------------------| 
-| org              | -          | default destination organization for writes and queries    |
-| bucket           | -          | default destination bucket for writes                      |
-| token            | -          | the token to use for the authorization                     |
-| logLevel         | NONE       | rest client verbosity level                                |
-| readTimeout      | 10000 ms   | read timeout                                               |
-| writeTimeout     | 10000 ms   | write timeout                                              |
-| connectTimeout   | 10000 ms   | socket timeout                                             |
-| precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name  | default    | description                                                |
+|----------------|------------|------------------------------------------------------------| 
+| org            | -          | default destination organization for writes and queries    |
+| bucket         | -          | default destination bucket for writes                      |
+| token          | -          | the token to use for the authorization                     |
+| logLevel       | NONE       | rest client verbosity level                                |
+| readTimeout    | 10000 ms   | read timeout                                               |
+| writeTimeout   | 10000 ms   | write timeout                                              |
+| connectTimeout | 10000 ms   | socket timeout                                             |
+| precision      | NS         | default precision for unix timestamps in the line protocol |
+| clientType     | -          | to customize the User-Agent HTTP header                    |
 
 The `readTimeout`, `writeTimeout` and `connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 

--- a/client-scala/README.md
+++ b/client-scala/README.md
@@ -130,6 +130,7 @@ The following options are supported:
 | influx2.writeTimeout   | 10000 ms | write timeout                                              |
 | influx2.connectTimeout | 10000 ms | socket timeout                                             |
 | influx2.precision      | NS       | default precision for unix timestamps in the line protocol |
+| influx2.clientType     | -        | to customize the User-Agent HTTP header                    |
 
 The `influx2.readTimeout`, `influx2.writeTimeout` and `influx2.connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 
@@ -163,16 +164,17 @@ val influxDBClient = InfluxDBClientScalaFactory
 ```
 The following options are supported:
 
-| Property name    | default    | description                                                |
-|------------------|------------|------------------------------------------------------------| 
-| org              | -          | default destination organization for writes and queries    |
-| bucket           | -          | default destination bucket for writes                      |
-| token            | -          | the token to use for the authorization                     |
-| logLevel         | NONE       | rest client verbosity level                                |
-| readTimeout      | 10000 ms   | read timeout                                               |
-| writeTimeout     | 10000 ms   | write timeout                                              |
-| connectTimeout   | 10000 ms   | socket timeout                                             |
-| precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name  | default  | description                                                |
+|----------------|----------|------------------------------------------------------------| 
+| org            | -        | default destination organization for writes and queries    |
+| bucket         | -        | default destination bucket for writes                      |
+| token          | -        | the token to use for the authorization                     |
+| logLevel       | NONE     | rest client verbosity level                                |
+| readTimeout    | 10000 ms | read timeout                                               |
+| writeTimeout   | 10000 ms | write timeout                                              |
+| connectTimeout | 10000 ms | socket timeout                                             |
+| precision      | NS       | default precision for unix timestamps in the line protocol |
+| clientType     | -        | to customize the User-Agent HTTP header                    |
 
 The `readTimeout`, `writeTimeout` and `connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 

--- a/client/README.md
+++ b/client/README.md
@@ -1039,17 +1039,18 @@ A client can be configured via configuration file. The configuration file has to
 
 The following options are supported:
 
-| Property name            | default    | description                                                |
-|--------------------------|------------|------------------------------------------------------------| 
-| influx2.url              | -          | the url to connect to InfluxDB                             |
-| influx2.org              | -          | default destination organization for writes and queries    |
-| influx2.bucket           | -          | default destination bucket for writes                      |
-| influx2.token            | -          | the token to use for the authorization                     |
-| influx2.logLevel         | NONE       | rest client verbosity level                                |
-| influx2.readTimeout      | 10000 ms   | read timeout                                               |
-| influx2.writeTimeout     | 10000 ms   | write timeout                                              |
-| influx2.connectTimeout   | 10000 ms   | socket timeout                                             |
-| influx2.precision        | NS         | default precision for unix timestamps in the line protocol |
+| Property name           | default    | description                                                |
+|-------------------------|------------|------------------------------------------------------------| 
+| influx2.url             | -          | the url to connect to InfluxDB                             |
+| influx2.org             | -          | default destination organization for writes and queries    |
+| influx2.bucket          | -          | default destination bucket for writes                      |
+| influx2.token           | -          | the token to use for the authorization                     |
+| influx2.logLevel        | NONE       | rest client verbosity level                                |
+| influx2.readTimeout     | 10000 ms   | read timeout                                               |
+| influx2.writeTimeout    | 10000 ms   | write timeout                                              |
+| influx2.connectTimeout  | 10000 ms   | socket timeout                                             |
+| influx2.precision       | NS         | default precision for unix timestamps in the line protocol |
+| influx2.clientType      | -          | to customize the User-Agent HTTP header                    |
 
 The `influx2.readTimeout`, `influx2.writeTimeout` and `influx2.connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 
@@ -1093,6 +1094,7 @@ The following options are supported:
 | writeTimeout     | 10000 ms   | write timeout                                              |
 | connectTimeout   | 10000 ms   | socket timeout                                             |
 | precision        | NS         | default precision for unix timestamps in the line protocol |
+| clientType       | -          | to customize the User-Agent HTTP header                    |
 
 The `readTimeout`, `writeTimeout` and `connectTimeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 

--- a/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
@@ -93,6 +93,7 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
         this.authenticateInterceptor = new AuthenticateInterceptor(options);
         this.gzipInterceptor = new GzipInterceptor();
 
+        String customClientType = options.getClientType() != null ? options.getClientType() : clientType;
         this.okHttpClient = options.getOkHttpClient()
                 //
                 // We don't need to disable the `retryOnConnectionFailure`. The retry logic
@@ -101,7 +102,7 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
                 // - e.g. network loopback or multiple proxies.
                 //
                 //.retryOnConnectionFailure(false)
-                .addInterceptor(new UserAgentInterceptor(clientType))
+                .addInterceptor(new UserAgentInterceptor(customClientType))
                 .addInterceptor(this.loggingInterceptor)
                 .addInterceptor(this.authenticateInterceptor)
                 .addInterceptor(this.gzipInterceptor)

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -142,4 +142,21 @@ class InfluxDBClientOptionsTest {
 
         Assertions.assertThat(options.getOkHttpClient().build().protocols()).containsExactly(Protocol.H2_PRIOR_KNOWLEDGE);
     }
+
+    @Test
+    public void customClientTypeFromConnectionString() {
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .url("http://localhost:9999?token=my-token&bucket=my-bucket&org=my-org&clientType=url-service")
+                .build();
+
+        Assertions.assertThat(options.getClientType()).isEqualTo("url-service");
+    }
+
+    @Test
+    public void customClientTypeFromProperties() {
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder().loadProperties().build();
+
+        Assertions.assertThat(options.getClientType()).isEqualTo("properties-service");
+    }
 }

--- a/client/src/test/resources/influx2.properties
+++ b/client/src/test/resources/influx2.properties
@@ -30,6 +30,7 @@ influx2.writeTimeout=10s
 influx2.connectTimeout=5s
 influx2.precision=US
 influx2.consistency=QUORUM
+influx2.clientType=properties-service
 
 influx2.tags.id = 132-987-655
 influx2.tags.customer =     California Miner


### PR DESCRIPTION
Closes #370 

## Proposed Changes

Added possibility to customise the `User-Agent` HTTP header:

```java
InfluxDBClientOptions options = InfluxDBClientOptions
                .builder()
                .url("http://localhost:8086")
                .clientType("awesome-service")
                .authenticateToken("my-token".toCharArray())
                .build();
```

=>

```txt
User-Agent: influxdb-client-awesome-service/6.3.0
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
