### PR TITLE
fix: redact the `Authorization` HTTP header from log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
    * Add TruncateTimeColumnFlux [FluxDSL]
    * Add ArrayFromFlux [FluxDSL]
    * Add UnionFlux [FluxDSL]
- 
+
+### Bug Fixes
+1. [#372](https://github.com/influxdata/influxdb-client-java/pull/372): Redact the `Authorization` HTTP header from log
+
 ## 6.3.0 [2022-06-30]
 
 ### Features

--- a/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractInfluxDBClient.java
@@ -89,6 +89,7 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
 
         this.options = options;
         this.loggingInterceptor = new HttpLoggingInterceptor();
+        this.loggingInterceptor.redactHeader("Authorization");
         setLogLevel(loggingInterceptor, options.getLogLevel());
         this.authenticateInterceptor = new AuthenticateInterceptor(options);
         this.gzipInterceptor = new GzipInterceptor();
@@ -103,8 +104,8 @@ public abstract class AbstractInfluxDBClient extends AbstractRestClient {
                 //
                 //.retryOnConnectionFailure(false)
                 .addInterceptor(new UserAgentInterceptor(customClientType))
-                .addInterceptor(this.loggingInterceptor)
                 .addInterceptor(this.authenticateInterceptor)
+                .addInterceptor(this.loggingInterceptor)
                 .addInterceptor(this.gzipInterceptor)
                 .build();
 


### PR DESCRIPTION
## Proposed Changes

Redacted `Authorization` HTTP header from log.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
