### PR TITLE
fix: append `task option` at the end of script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `percentile()` function renamed to `quantile()`.
 
 ### Bug Fixes
 1. [#390](https://github.com/influxdata/influxdb-client-java/pull/390): Rename `percentile()` function renamed to `quantile()` [FluxDSL]
+1. [#398](https://github.com/influxdata/influxdb-client-java/pull/398): Append `task option` at the end of script
 
 ### Dependencies
 Update dependencies:

--- a/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/TasksApiImpl.java
@@ -722,10 +722,7 @@ final class TasksApiImpl extends AbstractRestClient implements TasksApi {
             repetition += "\"" + cron + "\"";
         }
 
-        int fromBegin = flux.indexOf("from");
-        String fluxWithOptions = flux.substring(0, fromBegin)
-                + String.format("option task = {name: \"%s\", %s}\n\n", name, repetition)
-                + flux.substring(fromBegin);
+        String fluxWithOptions = String.format("%s\n\noption task = {name: \"%s\", %s}", flux, name, repetition);
 
         task.setFlux(fluxWithOptions);
 


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/issues/490

## Proposed Changes

Append `task option` at the end of script. It allows create task with following Flux:

```
procTotal = from(bucket: "example-bucket")
    |> range(start: -5m)
    |> filter(fn: (r) => r._measurement == "processes" and r._field == "total")

procTotal
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
