### PR TITLE
fix(docs): doclint for JDK 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
       - run:
           name: "Running tests"
           command: |
-            mvn -B -U clean install -Dmaven.javadoc.skip=true -Dmaven.dokka.skip=true -Dbuild.env=CI << parameters.junit-tests >>
+            mvn -B -U clean install -Dbuild.env=CI << parameters.junit-tests >>
       - save_cache:
           name: Saving Maven Cache
           key: *cache-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 6.6.0 [unreleased]
 
+### Documentation
+1. [#406](https://github.com/influxdata/influxdb-client-java/pull/406): Fix compatibility of the `doclint` between JDK 8 and JDK 18
+
 ## 6.5.0 [2022-08-29]
 
 ### Breaking Changes

--- a/client-osgi/src/main/java/com/influxdb/client/osgi/InfluxDBConnector.java
+++ b/client-osgi/src/main/java/com/influxdb/client/osgi/InfluxDBConnector.java
@@ -50,8 +50,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
  *     <li>InfluxDB V2 client is created (by username and password) otherwise.</li>
  * </ol>
  *
- * <p>The following connector properties are added to InfluxDB client too: <tt>organization</tt>, <tt>bucket</tt>,
- * <tt>database</tt>, <tt>url</tt> and <tt>alias</tt>.</p>
+ * <p>The following connector properties are added to InfluxDB client too: <code>organization</code>,
+ * <code>bucket</code>, <code>database</code>, <code>url</code> and <code>alias</code>.</p>
  */
 @Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = InfluxDBConnector.class)
 @Designate(ocd = InfluxDBConnector.Config.class)
@@ -77,7 +77,7 @@ public class InfluxDBConnector {
         String alias();
 
         /**
-         * InfluxDB URL, i.e. <tt>http://localhost:8086</tt>
+         * InfluxDB URL, i.e. <code>http://localhost:8086</code>
          */
         @AttributeDefinition(name = "InfluxDB URL")
         String url();

--- a/client-osgi/src/main/java/com/influxdb/client/osgi/LineProtocolWriter.java
+++ b/client-osgi/src/main/java/com/influxdb/client/osgi/LineProtocolWriter.java
@@ -53,8 +53,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
  * <ul>
  *     <li><i>record</i> ({@link String}): value must be a single line protocol record</li>
  *     <li><i>records</i> ({@link List}): value must be a list of line protocol records</li>
- *     <li><i>precision</i> ({@link String}, optional): write precision, values: <tt>s</tt>, <tt>ms</tt>, <tt>us</tt>,
- *         <tt>ns</tt>, default: <tt>ns</tt></li>
+ *     <li><i>precision</i> ({@link String}, optional): write precision, values: <code>s</code>, <code>ms</code>,
+ *         <code>us</code>, <code>ns</code>, default: <code>ns</code></li>
  *     <li><i>organization</i> ({@link String}, optional): used to override InfluxDB organization of
  *         {@link LineProtocolWriter} service (by event).</li>
  *     <li><i>bucket</i> ({@link String}, optional): used to override InfluxDB bucket of
@@ -114,9 +114,9 @@ public class LineProtocolWriter implements EventHandler {
         String[] event_topics() default {DEFAULT_EVENT_TOPIC};
 
         /**
-         * OSGi target filter for InfluxDB connection, i.e. <tt>(alias=test)</tt>. The following properties are
-         * copied from {@link InfluxDBConnector}: <tt>organization</tt>, <tt>bucket</tt>, <tt>database</tt>,
-         * <tt>url</tt>, <tt>alias</tt>.
+         * OSGi target filter for InfluxDB connection, i.e. <code>(alias=test)</code>. The following properties are
+         * copied from {@link InfluxDBConnector}: <code>organization</code>, <code>bucket</code>, <code>database</code>,
+         * <code>url</code>, <code>alias</code>.
          */
         @AttributeDefinition(required = false, name = "InfluxDB client target",
                 description = "OSGi target filter of InfluxDB client service")

--- a/client-osgi/src/main/java/com/influxdb/client/osgi/PointWriter.java
+++ b/client-osgi/src/main/java/com/influxdb/client/osgi/PointWriter.java
@@ -72,9 +72,10 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
  *
  * <p>One of <i>point</i> or <i>points</i> must be set.</p>
  *
- * <p>Measurement name is defined by OSGi event topic if {@link Map} type is used: measure name is fragment after the
- * last slash (<tt>/</tt>) character. For example: <b>weather</b> measure is written if event topic is
- * <tt>influxdb/point/weather</tt> (in this case OSGi event filter must be changed, i.e. <tt>influxdb/point/*</tt>).</p>
+ * <p>Measurement name is defined by OSGi event topic if {@link Map} type is used: measure name is fragment after
+ * the last slash (<code>/</code>) character. For example: <b>weather</b> measure is written
+ * if event topic is <code>influxdb/point/weather</code> (in this case OSGi event filter must be changed,
+ * i.e. <code>influxdb/point/*</code>).</p>
  *
  * <p>Structured data can be decorated with host name, host address or timestamp (by configuration).</p>
  */
@@ -148,9 +149,9 @@ public class PointWriter implements EventHandler {
         String[] event_topics() default {DEFAULT_EVENT_TOPIC};
 
         /**
-         * OSGi target filter for InfluxDB connection, i.e. <tt>(alias=test)</tt>. The following properties are
-         * copied from {@link InfluxDBConnector}: <tt>organization</tt>, <tt>bucket</tt>, <tt>database</tt>,
-         * <tt>url</tt>, <tt>alias</tt>.
+         * OSGi target filter for InfluxDB connection, i.e. <code>(alias=test)</code>. The following properties are
+         * copied from {@link InfluxDBConnector}: <code>organization</code>, <code>bucket</code>, <code>database</code>,
+         * <code>url</code>, <code>alias</code>.
          */
         @AttributeDefinition(required = false, name = "InfluxDB client target",
                 description = "OSGi target filter of InfluxDB client service")
@@ -179,7 +180,8 @@ public class PointWriter implements EventHandler {
         boolean timestamp_add() default false;
 
         /**
-         * Precision used if adding timestamp, values: <tt>s</tt>, <tt>ms</tt>, <tt>us</tt>, <tt>ns</tt>.
+         * Precision used if adding timestamp, values: <code>s</code>, <code>ms</code>, <code>us</code>,
+         * <code>ns</code>.
          */
         @AttributeDefinition(required = false, name = "Precision",
                 description = "Precision used if adding timestamp")

--- a/client/src/main/java/com/influxdb/client/InfluxQLQueryApi.java
+++ b/client/src/main/java/com/influxdb/client/InfluxQLQueryApi.java
@@ -64,8 +64,8 @@ public interface InfluxQLQueryApi {
      * Executes an InfluxQL query against the legacy endpoint.
      * The value extractor is called for each resulting column to convert the string value returned by query into a
      * custom type.
-     *
-     * <h3>Example</h3>
+     * <p>
+     * <b>Example:</b>
      * <pre>
      * InfluxQLQueryResult result = influxQLQueryApi.query(
      *             new InfluxQLQuery("SELECT FIRST(\"free\") FROM \"influxql\"", DATABASE_NAME)

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Expressions.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Expressions.java
@@ -37,8 +37,8 @@ import com.influxdb.utils.Arguments;
 
 /**
  * A container holding a list of {@link Expression}s.
- *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * VariableAssignment a = Flux.from("test1").asVariable("a");
  * VariableAssignment b = Flux.from("test2").asVariable("b");

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/Flux.java
@@ -98,7 +98,8 @@ import com.influxdb.utils.Arguments;
  * <br>
  * <a href="http://bit.ly/flux-spec">Flux Specification</a>
  *
- * <h3>The functions:</h3>
+ * <p>
+ * <b>The functions:</b>
  * <ul>
  * <li>{@link AggregateWindow}</li>
  * <li>{@link FromFlux}</li>
@@ -205,7 +206,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Applies an aggregate or selector function to fixed windows of time.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link AggregateWindow#withEvery(Long, ChronoUnit)}</li>
      * <li>{@link AggregateWindow#withEvery(String)}</li>
@@ -226,7 +228,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Applies an aggregate or selector function to fixed windows of time.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link AggregateWindow#withEvery(Long, ChronoUnit)}</li>
      * <li>{@link AggregateWindow#withEvery(String)}</li>
@@ -279,7 +282,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Join two time series together on time and the list of tags.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link JoinFlux#withTable(String, Flux)}</li>
      * <li>{@link JoinFlux#withOn(String)}</li>
@@ -327,7 +331,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * It will return a table containing only columns that are specified.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link KeepFlux#withColumns(String[])}</li>
      * <li>{@link KeepFlux#withFunction(String)}</li>
@@ -423,7 +428,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Covariance computes the covariance between two columns.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link CovarianceFlux#withColumns(String[])}</li>
      * <li>{@link CovarianceFlux#withColumns(Collection)}</li>
@@ -546,7 +552,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Computes a running sum for non null records in the table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link CumulativeSumFlux#withColumns(String[])}</li>
      * <li>{@link CumulativeSumFlux#withColumns(Collection)}</li>
@@ -587,7 +594,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Computes the time based difference between subsequent non null records.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DerivativeFlux#withUnit(Long, ChronoUnit)}</li>
      * <li>{@link DerivativeFlux#withNonNegative(boolean)}</li>
@@ -620,7 +628,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Difference computes the difference between subsequent non null records.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DifferenceFlux#withNonNegative(boolean)}</li>
      * <li>{@link DifferenceFlux#withColumns(String[])}</li>
@@ -697,7 +706,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Distinct produces the unique values for a given column.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DistinctFlux#withColumn(String)}</li>
      * <li>{@link DistinctFlux#withPropertyNamed(String)}</li>
@@ -726,7 +736,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Drop will exclude specified columns from a table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DropFlux#withColumns(String[])}</li>
      * <li>{@link DropFlux#withFunction(String)}</li>
@@ -779,7 +790,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Duplicate will duplicate a specified column in a table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DuplicateFlux#withAs(String)}</li>
      * <li>{@link DuplicateFlux#withColumn(String)} (String)}</li>
@@ -798,7 +810,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Duplicate will duplicate a specified column in a table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link DuplicateFlux#withAs(String)}</li>
      * <li>{@link DuplicateFlux#withColumn(String)} (String)}</li>
@@ -819,7 +832,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Replaces all null values in input tables with a non-null value.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link FillFlux#withUsePrevious(Boolean)}</li>
      * <li>{@link FillFlux#withColumn(String)}</li>
@@ -847,7 +861,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Returns the first result of the query.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link FilterFlux#withRestrictions(Restrictions)}</li>
      * <li>{@link FilterFlux#withPropertyNamed(String)}</li>
@@ -889,7 +904,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Groups results by a user-specified set of tags.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link GroupFlux#withBy(String[])}</li>
      * <li>{@link GroupFlux#withBy(Collection)}</li>
@@ -989,7 +1005,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * For each aggregate column, it outputs the area under the curve of non null records.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link IntegralFlux#withUnit(Long, ChronoUnit)}</li>
      * <li>{@link IntegralFlux#withPropertyNamed(String)}</li>
@@ -1024,7 +1041,8 @@ public abstract class Flux implements HasImports, Expression {
      * The `interpolate.linear` function inserts rows at regular intervals using linear interpolation to determine
      * values for inserted rows.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link InterpolateLinearFlux#withEvery(long, ChronoUnit)}</li>
      * <li>{@link InterpolateLinearFlux#withPropertyNamed(String)}</li>
@@ -1079,7 +1097,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Restricts the number of rows returned in the results.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link LimitFlux#withN(int)}</li>
      * <li>{@link LimitFlux#withPropertyNamed(String)}</li>
@@ -1123,7 +1142,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Applies a function to each row of the table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link MapFlux#withFunction(String)}</li>
      * <li>{@link MapFlux#withPropertyNamed(String)}</li>
@@ -1216,7 +1236,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Quantile is both an aggregate operation and a selector operation depending on selected options.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link QuantileFlux#withColumn(String)}</li>
      * <li>{@link QuantileFlux#withQuantile(Float)}</li>
@@ -1311,7 +1332,8 @@ public abstract class Flux implements HasImports, Expression {
      * Pivot collects values stored vertically (column-wise) in a table
      * and aligns them horizontally (row-wise) into logical sets.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link PivotFlux#withRowKey(String[])}</li>
      * <li>{@link PivotFlux#withRowKey(Collection)}</li>
@@ -1367,7 +1389,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Filters the results by time boundaries.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link RangeFlux#withStart(Instant)}</li>
      * <li>{@link RangeFlux#withStart(Long, ChronoUnit)}</li>
@@ -1472,7 +1495,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Reduce aggregates records in each table according to the reducer.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link ReduceFlux#withFunction(String)} </li>
      * <li>{@link ReduceFlux#withIdentity(String)}</li>
@@ -1498,7 +1522,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Rename will rename specified columns in a table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link RenameFlux#withColumns(Map)} </li>
      * <li>{@link RenameFlux#withFunction(String)}</li>
@@ -1540,7 +1565,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Sample values from a table.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link SampleFlux#withN(int)}</li>
      * <li>{@link SampleFlux#withPos(int)}</li>
@@ -1592,7 +1618,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Assigns a static value to each record.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link SetFlux#withKeyValue(String, String)}</li>
      * <li>{@link SetFlux#withPropertyNamed(String)}</li>
@@ -1622,7 +1649,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Shift add a fixed duration to time columns.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link TimeShiftFlux#withDuration(Long, ChronoUnit)}</li>
      * <li>{@link TimeShiftFlux#withColumns(String[])}</li>
@@ -1851,7 +1879,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Caps the number of records in output tables.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link TailFlux#withN(int)}</li>
      * <li>{@link TailFlux#withPropertyNamed(String)}</li>
@@ -1895,7 +1924,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * To operation takes data from a stream and writes it to a bucket.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link ToFlux#withBucket(String)}</li>
      * <li>{@link ToFlux#withBucketID(String)}</li>
@@ -2169,7 +2199,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Groups the results by a given time range.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link WindowFlux#withEvery(Long, ChronoUnit)}</li>
      * <li>{@link WindowFlux#withPeriod(Long, ChronoUnit)}</li>
@@ -2351,7 +2382,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Yield a query results to yielded results.
      *
-     * <h3>The parameters had to be defined by:</h3>
+     * <p>
+     * <b>The parameters had to be defined by:</b>
      * <ul>
      * <li>{@link YieldFlux#withName(String)}</li>
      * <li>{@link YieldFlux#withPropertyNamed(String)}</li>
@@ -2421,7 +2453,8 @@ public abstract class Flux implements HasImports, Expression {
     /**
      * Creates a piped function call.
      *
-     * <h3>Example Definition</h3>
+     * <p>
+     * <b>Example Definition</b>
      * <pre>
      * public static class MultByXFunction extends AbstractFunctionFlux&lt;MultByXFunction.MultByXFunctionCall&gt; {
      *
@@ -2447,7 +2480,8 @@ public abstract class Flux implements HasImports, Expression {
      *     }
      * }
      * </pre>
-     * <h3>Example Usage</h3>
+     * <p>
+     * <b>Example Usage</b>
      * <pre>
      * MultByXFunction multByX = new MultByXFunction();
      *

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/VariableAssignment.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/VariableAssignment.java
@@ -30,8 +30,8 @@ import com.influxdb.query.dsl.utils.ImportUtils;
 
 /**
  * Hold the variable name and expression of an assignment.
- *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * VariableAssignment a = Flux.from("test1").asVariable("a");
  * VariableAssignment b = Flux.from("test2").asVariable("b");

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFunctionCallFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFunctionCallFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.query.dsl.utils.ImportUtils;
 /**
  * Base class defining a function invocation.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *  public static class MyCustomFunctionCall extends AbstractFunctionCallFlux {
  *     public MyCustomFunctionCall(@Nonnull String name) {

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFunctionFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AbstractFunctionFlux.java
@@ -45,7 +45,8 @@ import static com.influxdb.query.dsl.functions.properties.FunctionsParameters.es
  * The function definition describes the implementation of a function.
  * A concrete call to this function can be created via the {@link #invoke()} method.
  *
- * <h3>Example Definition</h3>
+ * <p>
+ * <b>Example Definition</b>
  * <pre>
  * public static class MyCustomFunction extends AbstractFunctionFlux&lt;MyCustomFunction.MyCustomFunctionCall&gt; {
  *
@@ -71,7 +72,8 @@ import static com.influxdb.query.dsl.functions.properties.FunctionsParameters.es
  *     }
  * }
  * </pre>
- * <h3>Example Usage</h3>
+ * <p>
+ * <b>Example Usage</b>
  * <pre>
  * MyCustomFunction fun = new MyCustomFunction();
  *

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AggregateWindow.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/AggregateWindow.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Applies an aggregate or selector function (any function with a column parameter) to fixed windows of time.
  * <a href="http://bit.ly/flux-spec#aggregateWindow">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  *     <li><b>every</b> - The duration of windows. [duration]</li>
  *     <li><b>fn</b> - The aggregate function used in the operation. [function]</li>
@@ -46,7 +47,8 @@ import com.influxdb.utils.Arguments;
  *     Defaults to <i>true</i>. [boolean]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ColumnsFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ColumnsFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
  * The columns() function lists the column labels of input tables.
  * <a href="http://bit.ly/flux-spec#columns">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  *     <b>column</b> -
@@ -38,7 +39,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CountFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CountFlux.java
@@ -29,12 +29,14 @@ import com.influxdb.utils.Arguments;
 /**
  * Counts the number of results. <a href="http://bit.ly/flux-spec#count">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column to aggregate [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *      .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CovarianceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CovarianceFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Covariance is an aggregate operation. Covariance computes the covariance between two columns.
  * <a href="http://bit.ly/flux-spec#covariance">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>columns</b> - List of columns on which to compute the covariance.
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * <li><b>valueDst</b> - The column into which the result will be placed. Defaults to <i>_value`</i> [string].</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CumulativeSumFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/CumulativeSumFlux.java
@@ -32,12 +32,14 @@ import com.influxdb.utils.Arguments;
  * The output table schema will be the same as the input table.
  * <a href="http://bit.ly/flux-spec#cumulative-sum">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>columns</b> - a list of columns on which to operate [array of strings]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DerivativeFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DerivativeFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * Computes the time based difference between subsequent non null records.
  * <a href="http://bit.ly/flux-spec#derivative">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>unit</b> - The time duration to use for the result [duration]</li>
  * <li><b>nonNegative</b> - Indicates if the derivative is allowed to be negative [boolean].</li>
@@ -40,7 +41,8 @@ import com.influxdb.utils.Arguments;
  * <li><b>timeColumn</b> - The source column for the time values. Defaults to `_time` [string].</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DifferenceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DifferenceFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Difference computes the difference between subsequent non null records.
  * <a href="http://bit.ly/flux-spec#difference">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>nonNegative</b> - Indicates if the derivative is allowed to be negative.
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DistinctFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DistinctFlux.java
@@ -30,14 +30,16 @@ import com.influxdb.utils.Arguments;
  * Distinct produces the unique values for a given column.
  * <a href="http://bit.ly/flux-spec#distinct">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>column</b> - The column on which to track unique values [string]
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DropFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DropFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Drop will exclude specified columns from a table.
  * <a href="http://bit.ly/flux-spec#drop">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>columns</b> - The list of columns which should be excluded from the resulting table.
@@ -43,7 +44,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DuplicateFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/DuplicateFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
  * Duplicate will duplicate a specified column in a table.
  * <a href="http://bit.ly/flux-spec#duplicate">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>column</b> - The column to duplicate. [string]
@@ -40,7 +41,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ExpressionFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ExpressionFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
 /**
  * The custom Flux expression.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *     Flux.from("telegraf")
  *          .expression("map(fn: (r) =&gt; r._value * r._value)")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FillFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FillFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
  * Replaces all null values in input tables with a non-null value.
  * <a href="http://bit.ly/flux-spec#fill">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FilterFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FilterFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Filters the results using an expression.
  * <a href="http://bit.ly/flux-spec#filter">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>fn</b> - Function to when filtering the records. The function must accept a single parameter
@@ -40,7 +41,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *  Restrictions restriction = Restrictions.and(
  *          Restrictions.measurement().equal("mem"),

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FirstFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FirstFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Returns the first result of the query.
  * <a href="http://bit.ly/flux-spec#first">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FromFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/FromFlux.java
@@ -32,13 +32,15 @@ import com.influxdb.utils.Arguments;
  * From produces a stream of tables from the specified bucket.
  * <a href="http://bit.ly/flux-spec#from">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>bucket</b> - The name of the bucket to query [string]</li>
  * <li><b>hosts</b> - array of strings from(bucket:"telegraf", hosts:["host1", "host2"])</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux.from("telegraf");
  *

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/GroupFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/GroupFlux.java
@@ -31,13 +31,15 @@ import com.influxdb.utils.Arguments;
  * Groups results by a user-specified set of tags.
  * <a href="http://bit.ly/flux-spec#group">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>columns</b> - List of columns used to calculate the new group key. Default <i>[]</i> [array of strings]</li>
  * <li><b>mode</b> -  The grouping mode, can be one of <i>by</i> or <i>except</i>. The default is <i>by</i> [string].
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux.from("telegraf")
  *     .range(-30L, ChronoUnit.MINUTES)

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/IntegralFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/IntegralFlux.java
@@ -32,12 +32,14 @@ import com.influxdb.utils.Arguments;
  * The curve is defined as function where the domain is the record times and the range is the record values.
  * <a href="http://bit.ly/flux-spec#integral">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>unit</b> - Time duration to use when computing the integral [duration]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/InterpolateLinearFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/InterpolateLinearFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
 /**
  * Inserts rows at regular intervals using linear interpolation to determine values for inserted rows.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *         Flux flux = Flux
  *                 .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/JoinFlux.java
@@ -36,7 +36,8 @@ import com.influxdb.utils.Arguments;
  * Join two time series together on time and the list of <i>on</i> keys.
  * <a href="http://bit.ly/flux-spec#join">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>tables</b> - Map of tables to join. Currently only two tables are allowed. [map of tables]</li>
  * <li><b>on</b> - List of tag keys that when equal produces a result set. [array of strings]</li>
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * <b>method</b> - An optional parameter that specifies the type of join to be performed. </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux cpu = Flux.from("telegraf")
  *     .filter(Restrictions.and(Restrictions.measurement().equal("cpu"), Restrictions.field().equal("usage_user")))

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/KeepFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/KeepFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * Only columns in the group key that are also specified in keep will be kept in the resulting group key.
  * <a href="http://bit.ly/flux-spec#keep">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>columns</b> - The list of columns that should be included in the resulting table.
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LastFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Returns the last result of the query.
  * <a href="http://bit.ly/flux-spec#last">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column used to verify the existence of a value [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/LimitFlux.java
@@ -30,13 +30,15 @@ import com.influxdb.utils.Arguments;
  * Restricts the number of rows returned in the results.
  * <a href="http://bit.ly/flux-spec#limit">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>n</b> - The maximum number of records to output [int].</li>
  * <li><b>offset</b> - The number of records to skip per table [int]. Default to <i>0</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MapFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MapFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
  * Applies a function to each row of the table.
  * <a href="http://bit.ly/flux-spec#map">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>fn</b> - The function to apply to each row.
@@ -38,7 +39,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Restrictions restriction = Restrictions.and(
  *     Restrictions.measurement().equal("cpu"),

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MaxFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MaxFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Returns the max value within the results.
  * <a href="http://bit.ly/flux-spec#max">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column to use to calculate the maximum value [string]. Default is <i>_value</i>.
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MeanFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MeanFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Returns the mean of the within the results.
  * <a href="http://bit.ly/flux-spec#mean">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column to use to compute the mean [string]. Default to <i>_value</i>.
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MinFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/MinFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Returns the min value within the results.
  * <a href="http://bit.ly/flux-spec#min">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column to use to calculate the minimum value [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PivotFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/PivotFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * into logical sets.
  * <a href="http://bit.ly/flux-spec#pivot">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>rowKey</b> - List of columns used to uniquely identify a row for the output. [array of strings]</li>
  * <li><b>columnKey</b> -
@@ -41,7 +42,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux.from("telegraf")
  *     .pivot()

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/QuantileFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/QuantileFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * as a float.
  * <a href="http://bit.ly/flux-spec#quantile-aggregate">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  *     <li><b>column</b> - column to aggregate. Defaults to <i>_value</i>. [string]</li>
  *     <li><b>quantile</b> - value between 0 and 1 indicating the desired quantile. [float]</li>
@@ -43,7 +44,8 @@ import com.influxdb.utils.Arguments;
  *     [float]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RangeFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RangeFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * Filters the results by time boundaries.
  * <a href="http://bit.ly/flux-spec#range">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>start</b> - Specifies the oldest time to be included in the results [duration or timestamp]</li>
  * <li>
@@ -41,7 +42,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ReduceFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ReduceFlux.java
@@ -30,7 +30,8 @@ import com.influxdb.utils.Arguments;
  * Reduce aggregates records in each table according to the reducer.
  * <a href="http://bit.ly/flux-spec#reduce">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>fn</b> -
@@ -39,7 +40,8 @@ import com.influxdb.utils.Arguments;
  * <li><b>identity</b> - an initial value to use when creating a reducer ['a]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Restrictions restriction = Restrictions.and(
  *     Restrictions.measurement().equal("cpu"),

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RenameFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/RenameFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * the column name in the group key will be updated.
  * <a href="http://bit.ly/flux-spec#rename">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>columns</b> - The map of columns to rename and their corresponding new names. Cannot be used with <i>fn</i>.
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Map&lt;String, String&gt; map = new HashMap&lt;&gt;();
  * map.put("host", "server");

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SampleFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SampleFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Sample values from a table.
  * <a href="http://bit.ly/flux-spec#sample">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>n</b> - Sample every Nth element [int]</li>
  * <li>
@@ -38,7 +39,8 @@ import com.influxdb.query.dsl.Flux;
  * </li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux.from("telegraf")
  *     .filter(and(measurement().equal("cpu"), field().equal("usage_system")))

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SetFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SetFlux.java
@@ -30,13 +30,15 @@ import com.influxdb.utils.Arguments;
  * Assigns a static value to each record.
  * <a href="http://bit.ly/flux-spec#set">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>key</b> - Label for the column to set [string].</li>
  * <li><b>value</b> - Value for the column to set [string]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SkewFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SkewFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Skew of the results.
  * <a href="http://bit.ly/flux-spec#skew">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column on which to operate [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SortFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SortFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * Sorts the results by the specified columns Default sort is ascending.
  * <a href="http://bit.ly/flux-spec#sort">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li>
  * <b>columns</b> - List of columns used to sort; precedence from left to right.
@@ -40,7 +41,8 @@ import com.influxdb.utils.Arguments;
  * <li><b>desc</b> - Sort results descending. Default false [bool]</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SpreadFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SpreadFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Difference between min and max values.
  * <a href="http://bit.ly/flux-spec#spread">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column on which to operate [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/StddevFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/StddevFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Standard Deviation of the results.
  * <a href="http://bit.ly/flux-spec#stddev">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column on which to operate [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SumFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/SumFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Sum of the results.
  * <a href="http://bit.ly/flux-spec#sum">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>column</b> - The column on which to operate [string]. Default to <i>_value</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TailFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TailFlux.java
@@ -30,13 +30,15 @@ import com.influxdb.utils.Arguments;
  * Tail caps the number of records in output tables to a fixed size <i>n</i>.
  * <a href="http://bit.ly/flux-spec#tail">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>n</b> - The maximum number of records to output [int].</li>
  * <li><b>offset</b> - The number of records to skip per table [int]. Default to <i>0</i>.</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TimeShiftFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TimeShiftFlux.java
@@ -32,14 +32,16 @@ import com.influxdb.utils.Arguments;
  * Shift add a fixed duration to time columns.
  * <a href="http://bit.ly/flux-spec#timeshift">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>duration</b> - The amount to add to each time value [duration]</li>
  * <li><b>columns</b> - The list of all columns that should be shifted.
  * Defaults `["_start", "_stop", "_time"]` [array of strings].</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToBoolFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToBoolFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a bool.
  * <a href="http://bit.ly/flux-spec#tobool">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToDurationFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToDurationFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a duration.
  * <a href="http://bit.ly/flux-spec#toduration">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFloatFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFloatFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a float.
  * <a href="http://bit.ly/flux-spec#tofloat">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToFlux.java
@@ -31,7 +31,8 @@ import com.influxdb.utils.Arguments;
  * The To operation takes data from a stream and writes it to a bucket.
  * <a href="http://bit.ly/flux-spec#to">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  *     <li><b>bucket</b> - The bucket to which data will be written. [string]</li>
  *     <li><b>bucketID</b> - The bucket to which data will be written. [string]</li>
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  *     <li><b>fieldFn</b> - Function that takes a record from the input table and returns an object.</li>
  * </ul>
  *
- * <h3>Examples</h3>
+ * <p>
+ * <b>Examples</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToIntFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToIntFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a int.
  * <a href="http://bit.ly/flux-spec#toint">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToStringFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToStringFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a string.
  * <a href="http://bit.ly/flux-spec#tostring">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *  Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToTimeFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToTimeFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a time.
  * <a href="http://bit.ly/flux-spec#totime">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  *  Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToUIntFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/ToUIntFlux.java
@@ -29,7 +29,8 @@ import com.influxdb.query.dsl.Flux;
  * Convert a value to a duration.
  * <a href="http://bit.ly/flux-spec#toduration">See SPEC</a>.
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TruncateTimeColumnFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/TruncateTimeColumnFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
 /**
  * Truncates all input time values in the _time to a specified unit..
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>unit</b> - Unit of time to truncate to. [unit].</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/WindowFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/WindowFlux.java
@@ -32,7 +32,8 @@ import com.influxdb.utils.Arguments;
  * Groups the results by a given time range.
  * <a href="http://bit.ly/flux-spec#window">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>every</b> - Duration of time between windows. Defaults to <i>period's</i> value. [duration]
  * <li><b>period</b> - Duration of the windowed partition. Defaults to <i>every's</i> value. [duration]
@@ -44,7 +45,8 @@ import com.influxdb.utils.Arguments;
  * <li><b>stopColumn</b> - Name of the column containing the window stop time. Defaults to <i>_stop</i>. [string]
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")

--- a/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/YieldFlux.java
+++ b/flux-dsl/src/main/java/com/influxdb/query/dsl/functions/YieldFlux.java
@@ -30,12 +30,14 @@ import com.influxdb.utils.Arguments;
  * Yield a query results to yielded results.
  * <a href="http://bit.ly/flux-spec#yield">See SPEC</a>.
  *
- * <h3>Options</h3>
+ * <p>
+ * <b>Options</b>
  * <ul>
  * <li><b>name</b> - The unique name to give to yielded results [string].</li>
  * </ul>
  *
- * <h3>Example</h3>
+ * <p>
+ * <b>Example</b>
  * <pre>
  * Flux flux = Flux
  *     .from("telegraf")


### PR DESCRIPTION
Closes #405 

## Proposed Changes

1. Fixed compatibility of the `doclint` between JDK 8 and JDK 18
1. Enabled generating javadoc in CI

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
