### PR TITLE
fix: mapping `Number` types to POJO query output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#419](https://github.com/influxdata/influxdb-client-java/pull/419): Add possibility to get time from `Point` data structure
 
+### Bug Fixes
+1. [#414](https://github.com/influxdata/influxdb-client-java/pull/414): Mapping `Number` types to POJO query output
+
 ### Documentation
 1. [#406](https://github.com/influxdata/influxdb-client-java/pull/406): Fix compatibility of the `doclint` between JDK 8 and JDK 18
 

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
@@ -141,6 +141,14 @@ public class FluxResultMapper {
                 field.set(object, toIntValue(value));
                 return;
             }
+            if (float.class.isAssignableFrom(fieldType) || Float.class.isAssignableFrom(fieldType)) {
+                field.set(object, toFloatValue(value));
+                return;
+            }
+            if (short.class.isAssignableFrom(fieldType) || Short.class.isAssignableFrom(fieldType)) {
+                field.set(object, toShortValue(value));
+                return;
+            }
             if (boolean.class.isAssignableFrom(fieldType)) {
                 field.setBoolean(object, Boolean.valueOf(String.valueOf(value)));
                 return;
@@ -193,6 +201,24 @@ public class FluxResultMapper {
         return ((Number) value).intValue();
     }
 
+    private float toFloatValue(final Object value) {
+
+        if (float.class.isAssignableFrom(value.getClass()) || Float.class.isAssignableFrom(value.getClass())) {
+            return (float) value;
+        }
+
+        return ((Number) value).floatValue();
+    }
+
+    private short toShortValue(final Object value) {
+
+        if (short.class.isAssignableFrom(value.getClass()) || Short.class.isAssignableFrom(value.getClass())) {
+            return (short) value;
+        }
+
+        return ((Number) value).shortValue();
+    }
+
     private BigDecimal toBigDecimalValue(final Object value) {
         if (String.class.isAssignableFrom(value.getClass())) {
             return new BigDecimal((String) value);
@@ -208,6 +234,14 @@ public class FluxResultMapper {
 
         if (long.class.isAssignableFrom(value.getClass()) || Long.class.isAssignableFrom(value.getClass())) {
             return BigDecimal.valueOf((long) value);
+        }
+
+        if (float.class.isAssignableFrom(value.getClass()) || Float.class.isAssignableFrom(value.getClass())) {
+            return BigDecimal.valueOf((float) value);
+        }
+
+        if (short.class.isAssignableFrom(value.getClass()) || Short.class.isAssignableFrom(value.getClass())) {
+            return BigDecimal.valueOf((short) value);
         }
 
         String message = String.format("Cannot cast %s [%s] to %s.",

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxResultMapper.java
@@ -129,16 +129,16 @@ public class FluxResultMapper {
             }
 
             //convert primitives
-            if (double.class.isAssignableFrom(fieldType)) {
-                field.setDouble(object, toDoubleValue(value));
+            if (double.class.isAssignableFrom(fieldType) || Double.class.isAssignableFrom(fieldType)) {
+                field.set(object, toDoubleValue(value));
                 return;
             }
-            if (long.class.isAssignableFrom(fieldType)) {
-                field.setLong(object, toLongValue(value));
+            if (long.class.isAssignableFrom(fieldType) || Long.class.isAssignableFrom(fieldType)) {
+                field.set(object, toLongValue(value));
                 return;
             }
-            if (int.class.isAssignableFrom(fieldType)) {
-                field.setInt(object, toIntValue(value));
+            if (int.class.isAssignableFrom(fieldType) || Integer.class.isAssignableFrom(fieldType)) {
+                field.set(object, toIntValue(value));
                 return;
             }
             if (boolean.class.isAssignableFrom(fieldType)) {
@@ -172,7 +172,7 @@ public class FluxResultMapper {
             return (double) value;
         }
 
-        return (Double) value;
+        return ((Number) value).doubleValue();
     }
 
     private long toLongValue(final Object value) {
@@ -181,7 +181,7 @@ public class FluxResultMapper {
             return (long) value;
         }
 
-        return ((Double) value).longValue();
+        return ((Number) value).longValue();
     }
 
     private int toIntValue(final Object value) {
@@ -190,7 +190,7 @@ public class FluxResultMapper {
             return (int) value;
         }
 
-        return ((Double) value).intValue();
+        return ((Number) value).intValue();
     }
 
     private BigDecimal toBigDecimalValue(final Object value) {

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -122,26 +122,72 @@ class FluxResultMapperTest {
         record.getValues().put("fieldLong", 55);
         record.getValues().put("fieldDouble", 55);
         record.getValues().put("fieldInt", 55);
+        record.getValues().put("fieldFloat", 55);
+        record.getValues().put("fieldShort", 55);
+        record.getValues().put("fieldBigDecimal", 55);
         NumberFields bean = mapper.toPOJO(record, NumberFields.class);
         Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
         Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
         Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+        Assertions.assertThat(bean.fieldFloat).isEqualTo(55F);
+        Assertions.assertThat(bean.fieldShort).isEqualTo((short) 55);
+        Assertions.assertThat(bean.fieldBigDecimal).isEqualByComparingTo(BigDecimal.valueOf(55));
 
         record.getValues().put("fieldLong", 55.0);
         record.getValues().put("fieldDouble", 55.0);
         record.getValues().put("fieldInt", 55.0);
+        record.getValues().put("fieldFloat", 55.0);
+        record.getValues().put("fieldShort", 55.0);
+        record.getValues().put("fieldBigDecimal", 55.0);
         bean = mapper.toPOJO(record, NumberFields.class);
         Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
         Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
         Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+        Assertions.assertThat(bean.fieldFloat).isEqualTo(55F);
+        Assertions.assertThat(bean.fieldShort).isEqualTo((short) 55);
+        Assertions.assertThat(bean.fieldBigDecimal).isEqualByComparingTo(BigDecimal.valueOf(55));
 
         record.getValues().put("fieldLong", 55L);
         record.getValues().put("fieldDouble", 55L);
         record.getValues().put("fieldInt", 55L);
+        record.getValues().put("fieldFloat", 55L);
+        record.getValues().put("fieldShort", 55L);
+        record.getValues().put("fieldBigDecimal", 55L);
         bean = mapper.toPOJO(record, NumberFields.class);
         Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
         Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
         Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+        Assertions.assertThat(bean.fieldFloat).isEqualTo(55F);
+        Assertions.assertThat(bean.fieldShort).isEqualTo((short) 55);
+        Assertions.assertThat(bean.fieldBigDecimal).isEqualByComparingTo(BigDecimal.valueOf(55));
+
+        record.getValues().put("fieldLong", 55F);
+        record.getValues().put("fieldDouble", 55F);
+        record.getValues().put("fieldInt", 55F);
+        record.getValues().put("fieldFloat", 55F);
+        record.getValues().put("fieldShort", 55f);
+        record.getValues().put("fieldBigDecimal", 55f);
+        bean = mapper.toPOJO(record, NumberFields.class);
+        Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
+        Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
+        Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+        Assertions.assertThat(bean.fieldFloat).isEqualTo(55F);
+        Assertions.assertThat(bean.fieldShort).isEqualTo((short) 55);
+        Assertions.assertThat(bean.fieldBigDecimal).isEqualByComparingTo(BigDecimal.valueOf(55));
+
+        record.getValues().put("fieldLong", (short) 55);
+        record.getValues().put("fieldDouble", (short) 55);
+        record.getValues().put("fieldInt", (short) 55);
+        record.getValues().put("fieldFloat", (short) 55);
+        record.getValues().put("fieldShort", (short) 55);
+        record.getValues().put("fieldBigDecimal", (short) 55);
+        bean = mapper.toPOJO(record, NumberFields.class);
+        Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
+        Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
+        Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+        Assertions.assertThat(bean.fieldFloat).isEqualTo(55F);
+        Assertions.assertThat(bean.fieldShort).isEqualTo((short) 55);
+        Assertions.assertThat(bean.fieldBigDecimal).isEqualByComparingTo(BigDecimal.valueOf(55));
     }
 
     public static class BigDecimalBean {
@@ -204,5 +250,13 @@ class FluxResultMapperTest {
         private Double fieldDouble;
         @Column
         private Integer fieldInt;
+        @Column
+        private Float fieldFloat;
+        
+        @Column
+        private Short fieldShort;
+
+        @Column
+        private BigDecimal fieldBigDecimal;
     }
 }

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -203,6 +203,6 @@ class FluxResultMapperTest {
         @Column
         private Double fieldDouble;
         @Column
-        private Double fieldInt;
+        private Integer fieldInt;
     }
 }

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -252,10 +252,8 @@ class FluxResultMapperTest {
         private Integer fieldInt;
         @Column
         private Float fieldFloat;
-        
         @Column
         private Short fieldShort;
-
         @Column
         private BigDecimal fieldBigDecimal;
     }

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -114,6 +114,36 @@ class FluxResultMapperTest {
         Assertions.assertThat(bean.value).isEqualByComparingTo(new BigDecimal(20));
     }
 
+    @Test
+    public void numberConversion() {
+
+        FluxRecord record = new FluxRecord(0);
+
+        record.getValues().put("fieldLong", 55);
+        record.getValues().put("fieldDouble", 55);
+        record.getValues().put("fieldInt", 55);
+        NumberFields bean = mapper.toPOJO(record, NumberFields.class);
+        Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
+        Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
+        Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+
+        record.getValues().put("fieldLong", 55.0);
+        record.getValues().put("fieldDouble", 55.0);
+        record.getValues().put("fieldInt", 55.0);
+        bean = mapper.toPOJO(record, NumberFields.class);
+        Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
+        Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
+        Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+
+        record.getValues().put("fieldLong", 55L);
+        record.getValues().put("fieldDouble", 55L);
+        record.getValues().put("fieldInt", 55L);
+        bean = mapper.toPOJO(record, NumberFields.class);
+        Assertions.assertThat(bean.fieldLong).isEqualTo(55L);
+        Assertions.assertThat(bean.fieldDouble).isEqualTo(55.0);
+        Assertions.assertThat(bean.fieldInt).isEqualTo(55);
+    }
+
     public static class BigDecimalBean {
         @Column(name = "value1")
         BigDecimal value1;
@@ -165,5 +195,14 @@ class FluxResultMapperTest {
 
         @Column(name = "value")
         BigDecimal value;
+    }
+
+    public static class NumberFields {
+        @Column
+        private Long fieldLong;
+        @Column
+        private Double fieldDouble;
+        @Column
+        private Double fieldInt;
     }
 }


### PR DESCRIPTION
Closes #410

## Proposed Changes

Fixed mapping aggregated results (changed type) from InfluxDB.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
