### PR TITLE
chore(test): remove deprecated `junit-platform-runner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Update dependencies:
 #### Test:
   - [#408](https://github.com/influxdata/influxdb-client-java/pull/408): `logback-classic` to `1.3.0`
   - [#417](https://github.com/influxdata/influxdb-client-java/pull/417): `mockito` to `4.8.0`
+               
+Remove dependencies:
+#### Test:
+  - [#418](https://github.com/influxdata/influxdb-client-java/pull/418): `junit-platform-runner`
 
 ## 6.5.0 [2022-08-29]
 

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -172,10 +172,6 @@
             <artifactId>mockwebserver</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.squareup.okhttp3</groupId>
                     <artifactId>okhttp</artifactId>
                 </exclusion>
@@ -190,12 +186,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
+++ b/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
@@ -34,15 +34,12 @@ import okhttp3.Request;
 import okhttp3.ResponseBody;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.HttpException;
 import retrofit2.Response;
 
 /**
  * @author Jakub Bednar (bednar@github) (02/08/2018 08:58)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxExceptionTest {
 
     @Test

--- a/client-core/src/test/java/com/influxdb/internal/ITUserAgentInterceptor.java
+++ b/client-core/src/test/java/com/influxdb/internal/ITUserAgentInterceptor.java
@@ -33,13 +33,10 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (02/03/2020 10:18)
  */
-@RunWith(JUnitPlatform.class)
 class ITUserAgentInterceptor extends AbstractMockServerTest {
 
     private OkHttpClient client;

--- a/client-core/src/test/java/com/influxdb/internal/QueryAbstractApiTest.java
+++ b/client-core/src/test/java/com/influxdb/internal/QueryAbstractApiTest.java
@@ -27,12 +27,12 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 
-import com.google.gson.JsonParser;
 import com.influxdb.Cancellable;
 import com.influxdb.exceptions.InfluxException;
 import com.influxdb.query.internal.FluxCsvParser;
 import com.influxdb.test.AbstractMockServerTest;
 
+import com.google.gson.JsonParser;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -41,8 +41,6 @@ import okio.Buffer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -53,7 +51,6 @@ import retrofit2.http.Streaming;
 /**
  * @author Jakub Bednar (bednar@github) (17/10/2018 09:44)
  */
-@RunWith(JUnitPlatform.class)
 class QueryAbstractApiTest extends AbstractMockServerTest {
 
     private AbstractQueryApi queryClient;

--- a/client-core/src/test/java/com/influxdb/internal/RestClientTest.java
+++ b/client-core/src/test/java/com/influxdb/internal/RestClientTest.java
@@ -58,8 +58,6 @@ import okio.Buffer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -70,7 +68,6 @@ import retrofit2.http.Path;
 /**
  * @author Jakub Bednar (bednar@github) (04/10/2018 07:57)
  */
-@RunWith(JUnitPlatform.class)
 class RestClientTest extends AbstractMockServerTest {
 
     private AbstractRestClient restClient;

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -44,15 +44,12 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Jakub Bednar (bednar@github) (16/07/2018 12:26)
  */
-@RunWith(JUnitPlatform.class)
 class FluxCsvParserTest {
 
     private static final Logger LOG = Logger.getLogger(FluxCsvParserTest.class.getName());

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxResultMapperTest.java
@@ -30,13 +30,10 @@ import com.influxdb.query.FluxRecord;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (01/02/2019 09:01)
  */
-@RunWith(JUnitPlatform.class)
 class FluxResultMapperTest {
 
     private FluxResultMapper mapper;

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxStructureSerializationTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxStructureSerializationTest.java
@@ -35,10 +35,7 @@ import com.influxdb.query.FluxRecord;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class FluxStructureSerializationTest {
 
     @Test

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITInfluxDBClientKotlin.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITInfluxDBClientKotlin.kt
@@ -26,14 +26,11 @@ import com.influxdb.client.domain.HealthCheck
 import com.influxdb.exceptions.InfluxException
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 
 
 /**
  * @author Jakub Bednar (bednar@github) (30/10/2018 09:19)
  */
-@RunWith(JUnitPlatform::class)
 internal class ITInfluxDBClientKotlin : AbstractITInfluxDBClientKotlin() {
 
     @Test

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/ITQueryKotlinApi.kt
@@ -46,8 +46,6 @@ import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 import java.net.ConnectException
 import java.time.Instant
 import java.util.*
@@ -55,7 +53,6 @@ import java.util.*
 /**
  * @author Jakub Bednar (bednar@github) (31/10/2018 07:16)
  */
-@RunWith(JUnitPlatform::class)
 internal class ITQueryKotlinApi : AbstractITInfluxDBClientKotlin() {
 
     private lateinit var bucket: Bucket

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinFactoryTest.kt
@@ -29,14 +29,11 @@ import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 import retrofit2.Retrofit
 
 /**
  * @author Jakub Bednar (bednar@github) (30/10/2018 08:32)
  */
-@RunWith(JUnitPlatform::class)
 class InfluxDBClientKotlinFactoryTest : AbstractTest() {
 
     @Test

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/InfluxDBClientKotlinTest.kt
@@ -26,14 +26,11 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
 
 /**
  * @author Jakub Bednar (09/06/2020 07:11)
  */
-@RunWith(JUnitPlatform::class)
 class InfluxDBClientKotlinTest : AbstractMockServerTest() {
 
     private lateinit var client: InfluxDBClientKotlin

--- a/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/WriteKotlinApiTest.kt
+++ b/client-kotlin/src/test/kotlin/com/influxdb/client/kotlin/WriteKotlinApiTest.kt
@@ -29,7 +29,6 @@ import com.influxdb.exceptions.UnauthorizedException
 import com.influxdb.test.AbstractMockServerTest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.RecordedRequest
@@ -37,15 +36,12 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 /**
  * @author Jakub Bednar (20/04/2021 13:58)
  */
-@RunWith(JUnitPlatform::class)
 class WriteKotlinApiTest : AbstractMockServerTest() {
 
     private lateinit var client: InfluxDBClientKotlin

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientFactoryTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientFactoryTest.java
@@ -23,13 +23,10 @@ package com.influxdb.client.flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (31/07/2018 13:12)
  */
-@RunWith(JUnitPlatform.class)
 class FluxClientFactoryTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientPingTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientPingTest.java
@@ -26,13 +26,10 @@ import java.io.IOException;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (31/07/2018 09:19)
  */
-@RunWith(JUnitPlatform.class)
 class FluxClientPingTest extends AbstractFluxClientTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryRawTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryRawTest.java
@@ -33,13 +33,10 @@ import com.influxdb.exceptions.InfluxException;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (03/08/2018 12:14)
  */
-@RunWith(JUnitPlatform.class)
 class FluxClientQueryRawTest extends AbstractFluxClientTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientQueryTest.java
@@ -34,13 +34,10 @@ import com.influxdb.query.FluxTable;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (31/07/2018 07:05)
  */
-@RunWith(JUnitPlatform.class)
 class FluxClientQueryTest extends AbstractFluxClientTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientVersionTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxClientVersionTest.java
@@ -28,13 +28,10 @@ import com.influxdb.exceptions.InfluxException;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (03/10/2018 15:08)
  */
-@RunWith(JUnitPlatform.class)
 class FluxClientVersionTest extends AbstractFluxClientTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/FluxConnectionOptionsTest.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/FluxConnectionOptionsTest.java
@@ -27,13 +27,10 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 09:09)
  */
-@RunWith(JUnitPlatform.class)
 class FluxConnectionOptionsTest {
 
     @Test

--- a/client-legacy/src/test/java/com/influxdb/client/flux/ITFluxClient.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/ITFluxClient.java
@@ -38,13 +38,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (31/07/2018 09:30)
  */
-@RunWith(JUnitPlatform.class)
 class ITFluxClient extends AbstractITFluxClient {
 
     private static final Logger LOG = Logger.getLogger(ITFluxClient.class.getName());

--- a/client-legacy/src/test/java/com/influxdb/client/flux/TestConnectionString.java
+++ b/client-legacy/src/test/java/com/influxdb/client/flux/TestConnectionString.java
@@ -26,10 +26,7 @@ import com.influxdb.LogLevel;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class TestConnectionString extends AbstractITFluxClient {
     @Test
     void connectionStringTest() {

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/ITConnectionTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/ITConnectionTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-
 public class ITConnectionTest extends InfluxDBConnectorTest {
 
     @Test

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/ITConnectionTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/ITConnectionTest.java
@@ -21,15 +21,12 @@
  */
 package com.influxdb.client.osgi;
 
-import com.influxdb.client.domain.HealthCheck;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(JUnitPlatform.class)
+
 public class ITConnectionTest extends InfluxDBConnectorTest {
 
     @Test

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/InfluxDBConnectorTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/InfluxDBConnectorTest.java
@@ -21,22 +21,21 @@
  */
 package com.influxdb.client.osgi;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+
 import com.influxdb.client.InfluxDBClient;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
-
-import java.util.Dictionary;
-import java.util.Hashtable;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +44,6 @@ import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 public class InfluxDBConnectorTest {
 

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/LineProtocolWriterTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/LineProtocolWriterTest.java
@@ -21,20 +21,20 @@
  */
 package com.influxdb.client.osgi;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.WriteApi;
 import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -54,7 +54,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 public class LineProtocolWriterTest {
 

--- a/client-osgi/src/test/java/com/influxdb/client/osgi/PointWriterTest.java
+++ b/client-osgi/src/test/java/com/influxdb/client/osgi/PointWriterTest.java
@@ -21,17 +21,29 @@
  */
 package com.influxdb.client.osgi;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
 import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.WriteApi;
 import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -39,20 +51,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventConstants;
 
-import java.time.*;
-import java.util.*;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 public class PointWriterTest {
 

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITInfluxDBReactiveClient.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITInfluxDBReactiveClient.java
@@ -27,14 +27,11 @@ import com.influxdb.client.domain.HealthCheck;
 import io.reactivex.rxjava3.core.Single;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
 
 /**
  * @author Jakub Bednar (bednar@github) (20/11/2018 08:06)
  */
-@RunWith(JUnitPlatform.class)
 class ITInfluxDBReactiveClient extends AbstractITInfluxDBClientTest {
 
     @Test

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/ITWriteQueryReactiveApi.java
@@ -41,23 +41,18 @@ import com.influxdb.client.write.Point;
 import com.influxdb.exceptions.BadRequestException;
 import com.influxdb.query.FluxRecord;
 
-
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/11/2018 06:59)
  */
-@RunWith(JUnitPlatform.class)
 class ITWriteQueryReactiveApi extends AbstractITInfluxDBClientTest {
 
     private WriteReactiveApi writeClient;

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/InfluxDBClientReactiveFactoryTest.java
@@ -29,14 +29,11 @@ import com.influxdb.test.AbstractTest;
 import okhttp3.OkHttpClient;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.Retrofit;
 
 /**
  * @author Jakub Bednar (bednar@github) (20/11/2018 07:21)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDBClientReactiveFactoryTest extends AbstractTest {
 
     @Test

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/QueryReactiveApiTest.java
@@ -36,13 +36,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (03/16/2022 08:28)
  */
-@RunWith(JUnitPlatform.class)
 class QueryReactiveApiTest extends AbstractMockServerTest {
 
     private InfluxDBClientReactive influxDBClient;

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteOptionsReactiveTest.java
@@ -24,13 +24,10 @@ package com.influxdb.client.reactive;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (05/08/2021 9:23)
  */
-@RunWith(JUnitPlatform.class)
 class WriteOptionsReactiveTest {
     @Test
     void configure() {

--- a/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
+++ b/client-reactive/src/test/java/com/influxdb/client/reactive/WriteReactiveApiTest.java
@@ -45,14 +45,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
 
 /**
  * @author Jakub Bednar (02/08/2021 12:28)
  */
-@RunWith(JUnitPlatform.class)
 class WriteReactiveApiTest extends AbstractMockServerTest {
 
     private TestScheduler testScheduler;

--- a/client-test/pom.xml
+++ b/client-test/pom.xml
@@ -107,10 +107,6 @@
             <artifactId>mockwebserver</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.squareup.okhttp3</groupId>
                     <artifactId>okhttp</artifactId>
                 </exclusion>
@@ -135,11 +131,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
         </dependency>
 
         <dependency>

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -97,12 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/client-utils/src/test/java/com/influxdb/utils/ArgumentsDurationTest.java
+++ b/client-utils/src/test/java/com/influxdb/utils/ArgumentsDurationTest.java
@@ -23,14 +23,11 @@ package com.influxdb.utils;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (20/08/2018 12:31)
  */
 @SuppressWarnings("ConstantConditions")
-@RunWith(JUnitPlatform.class)
 class ArgumentsDurationTest {
 
     @Test

--- a/client-utils/src/test/java/com/influxdb/utils/ArgumentsTest.java
+++ b/client-utils/src/test/java/com/influxdb/utils/ArgumentsTest.java
@@ -25,14 +25,11 @@ import java.time.temporal.ChronoUnit;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (01/08/2018 15:29)
  */
 @SuppressWarnings("ConstantConditions")
-@RunWith(JUnitPlatform.class)
 class ArgumentsTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/FindOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/FindOptionsTest.java
@@ -23,13 +23,10 @@ package com.influxdb.client;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (18/03/2019 11:53)
  */
-@RunWith(JUnitPlatform.class)
 class FindOptionsTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/GeneratedCodeTest.java
+++ b/client/src/test/java/com/influxdb/client/GeneratedCodeTest.java
@@ -25,13 +25,10 @@ import com.influxdb.client.domain.File;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (26/08/2021 6:24)
  */
-@RunWith(JUnitPlatform.class)
 class GeneratedCodeTest {
     @Test
     void adapterCanBeInstantiateWithoutParameters() {

--- a/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITAuthorizationsApi.java
@@ -39,13 +39,10 @@ import com.influxdb.exceptions.NotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (17/09/2018 12:02)
  */
-@RunWith(JUnitPlatform.class)
 class ITAuthorizationsApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITAuthorizationsApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/ITBackpressure.java
+++ b/client/src/test/java/com/influxdb/client/ITBackpressure.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 /**
  * @author Jakub Bednar (24/01/2020 09:40)
  */
-
 @EnabledIfSystemProperty(named = "clientBackpressure", matches = "true")
 class ITBackpressure extends AbstractITWrite {
 

--- a/client/src/test/java/com/influxdb/client/ITBackpressure.java
+++ b/client/src/test/java/com/influxdb/client/ITBackpressure.java
@@ -53,13 +53,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (24/01/2020 09:40)
  */
-@RunWith(JUnitPlatform.class)
+
 @EnabledIfSystemProperty(named = "clientBackpressure", matches = "true")
 class ITBackpressure extends AbstractITWrite {
 

--- a/client/src/test/java/com/influxdb/client/ITBenchmarkTest.java
+++ b/client/src/test/java/com/influxdb/client/ITBenchmarkTest.java
@@ -28,18 +28,16 @@ import java.time.Instant;
 import com.influxdb.client.benchmark.BenchmarkOptions;
 import com.influxdb.client.benchmark.ClientBenchmark;
 import com.influxdb.client.domain.Bucket;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * Client benchmark test
  */
-@RunWith(JUnitPlatform.class)
 class ITBenchmarkTest extends AbstractITClientTest {
 
     private BucketsApi bucketsApi;

--- a/client/src/test/java/com/influxdb/client/ITBucketsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITBucketsApi.java
@@ -42,13 +42,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (13/09/2018 10:49)
  */
-@RunWith(JUnitPlatform.class)
 class ITBucketsApi extends AbstractITClientTest {
 
     private Organization organization;

--- a/client/src/test/java/com/influxdb/client/ITChecksApi.java
+++ b/client/src/test/java/com/influxdb/client/ITChecksApi.java
@@ -48,13 +48,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (18/09/2019 08:30)
  */
-@RunWith(JUnitPlatform.class)
 class ITChecksApi extends AbstractITClientTest {
 
     private ChecksApi checksApi;

--- a/client/src/test/java/com/influxdb/client/ITDashboardsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITDashboardsApi.java
@@ -45,13 +45,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (01/04/2019 10:58)
  */
-@RunWith(JUnitPlatform.class)
 class ITDashboardsApi extends AbstractITClientTest {
 
     private DashboardsApi dashboardsApi;

--- a/client/src/test/java/com/influxdb/client/ITDeleteApi.java
+++ b/client/src/test/java/com/influxdb/client/ITDeleteApi.java
@@ -39,13 +39,10 @@ import com.influxdb.query.FluxTable;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Pavlina Rolincova (rolincova@github) (30/10/2019).
  */
-@RunWith(JUnitPlatform.class)
 class ITDeleteApi extends AbstractITClientTest {
 
     private DeleteApi deleteApi;

--- a/client/src/test/java/com/influxdb/client/ITInfluxDBClient.java
+++ b/client/src/test/java/com/influxdb/client/ITInfluxDBClient.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
-import com.influxdb.LogLevel;
 import com.influxdb.client.domain.HealthCheck;
 import com.influxdb.client.domain.OnboardingRequest;
 import com.influxdb.client.domain.OnboardingResponse;
@@ -41,13 +40,10 @@ import com.influxdb.query.FluxTable;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (20/11/2018 07:37)
  */
-@RunWith(JUnitPlatform.class)
 class ITInfluxDBClient extends AbstractITClientTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITInfluxQLQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITInfluxQLQueryApi.java
@@ -37,14 +37,11 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.InstanceOfAssertFactories.BIG_DECIMAL;
 import static org.assertj.core.api.InstanceOfAssertFactories.INSTANT;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
-@RunWith(JUnitPlatform.class)
 class ITInfluxQLQueryApi extends AbstractITClientTest {
 
 	private static final String DATABASE_NAME = "my-database";

--- a/client/src/test/java/com/influxdb/client/ITLabelsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITLabelsApi.java
@@ -33,13 +33,10 @@ import com.influxdb.exceptions.NotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (28/01/2019 10:52)
  */
-@RunWith(JUnitPlatform.class)
 class ITLabelsApi extends AbstractITClientTest {
 
     private LabelsApi labelsApi;

--- a/client/src/test/java/com/influxdb/client/ITMonitoringAlerting.java
+++ b/client/src/test/java/com/influxdb/client/ITMonitoringAlerting.java
@@ -45,13 +45,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (25/09/2019 09:41)
  */
-@RunWith(JUnitPlatform.class)
 class ITMonitoringAlerting extends AbstractITClientTest {
 
     private MockServerExtension mockServerExtension;

--- a/client/src/test/java/com/influxdb/client/ITNotificationEndpointsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITNotificationEndpointsApi.java
@@ -44,13 +44,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (10/09/2019 08:50)
  */
-@RunWith(JUnitPlatform.class)
 class ITNotificationEndpointsApi extends AbstractITClientTest {
 
     private NotificationEndpointsApi notificationEndpointsApi;

--- a/client/src/test/java/com/influxdb/client/ITNotificationRulesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITNotificationRulesApi.java
@@ -54,13 +54,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (24/09/2019 09:34)
  */
-@RunWith(JUnitPlatform.class)
 class ITNotificationRulesApi extends AbstractITClientTest {
 
     private NotificationRulesApi notificationRulesApi;

--- a/client/src/test/java/com/influxdb/client/ITOrganizationsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITOrganizationsApi.java
@@ -41,13 +41,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (12/09/2018 09:51)
  */
-@RunWith(JUnitPlatform.class)
 class ITOrganizationsApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITOrganizationsApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/ITQueryService.java
+++ b/client/src/test/java/com/influxdb/client/ITQueryService.java
@@ -43,13 +43,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (08/04/2019 09:41)
  */
-@RunWith(JUnitPlatform.class)
 class ITQueryService extends AbstractITClientTest {
 
     private QueryService queryService;

--- a/client/src/test/java/com/influxdb/client/ITScraperTargetsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITScraperTargetsApi.java
@@ -38,13 +38,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/01/2019 08:23)
  */
-@RunWith(JUnitPlatform.class)
 class ITScraperTargetsApi extends AbstractITClientTest {
 
     private ScraperTargetsApi scraperTargetsApi;

--- a/client/src/test/java/com/influxdb/client/ITSourcesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITSourcesApi.java
@@ -36,13 +36,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (18/09/2018 09:42)
  */
-@RunWith(JUnitPlatform.class)
 class ITSourcesApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITSourcesApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/ITTasksApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTasksApi.java
@@ -52,13 +52,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (05/09/2018 15:54)
  */
-@RunWith(JUnitPlatform.class)
 class ITTasksApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITTasksApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/ITTelegrafsApi.java
+++ b/client/src/test/java/com/influxdb/client/ITTelegrafsApi.java
@@ -43,13 +43,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (28/02/2019 10:31)
  */
-@RunWith(JUnitPlatform.class)
 class ITTelegrafsApi extends AbstractITClientTest {
 
     private TelegrafsApi telegrafsApi;

--- a/client/src/test/java/com/influxdb/client/ITUsersApi.java
+++ b/client/src/test/java/com/influxdb/client/ITUsersApi.java
@@ -34,13 +34,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (11/09/2018 11:26)
  */
-@RunWith(JUnitPlatform.class)
 class ITUsersApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITUsersApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/ITVariablesApi.java
+++ b/client/src/test/java/com/influxdb/client/ITVariablesApi.java
@@ -40,13 +40,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (27/03/2019 09:46)
  */
-@RunWith(JUnitPlatform.class)
 class ITVariablesApi extends AbstractITClientTest {
 
     private VariablesApi variablesApi;

--- a/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteApiBlocking.java
@@ -34,13 +34,10 @@ import com.influxdb.query.FluxTable;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (16/07/2019 07:13)
  */
-@RunWith(JUnitPlatform.class)
 class ITWriteApiBlocking extends AbstractITWrite {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITWriteQueryApi.java
@@ -49,13 +49,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/09/2018 13:39)
  */
-@RunWith(JUnitPlatform.class)
 class ITWriteQueryApi extends AbstractITClientTest {
 
     private static final Logger LOG = Logger.getLogger(ITWriteQueryApi.class.getName());

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientFactoryTest.java
@@ -32,14 +32,11 @@ import com.influxdb.test.AbstractTest;
 import okhttp3.OkHttpClient;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.Retrofit;
 
 /**
  * @author Jakub Bednar (bednar@github) (05/09/2018 10:59)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDBClientFactoryTest extends AbstractTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientOptionsTest.java
@@ -30,13 +30,10 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (05/09/2018 10:38)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDBClientOptionsTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
+++ b/client/src/test/java/com/influxdb/client/InfluxDBClientTest.java
@@ -49,13 +49,10 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (05/09/2018 14:00)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDBClientTest extends AbstractInfluxDBClientTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/InvokableScriptsApiTest.java
+++ b/client/src/test/java/com/influxdb/client/InvokableScriptsApiTest.java
@@ -34,10 +34,7 @@ import com.influxdb.query.FluxTable;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class InvokableScriptsApiTest extends AbstractInfluxDBClientTest {
 
     static final String SUCCESS_DATA = ",result,table,_start,_stop,_time,_value,_field,_measurement,host,value\n"

--- a/client/src/test/java/com/influxdb/client/QueryApiTest.java
+++ b/client/src/test/java/com/influxdb/client/QueryApiTest.java
@@ -26,22 +26,20 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.gson.Gson;
 import com.influxdb.client.domain.Dialect;
 import com.influxdb.client.domain.Query;
-import static com.influxdb.client.internal.AbstractInfluxDBClient.DEFAULT_DIALECT;
 import com.influxdb.client.internal.AbstractInfluxDBClientTest;
 
+import com.google.gson.Gson;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
+
+import static com.influxdb.client.internal.AbstractInfluxDBClient.DEFAULT_DIALECT;
 
 /**
  * @author Jakub Bednar (bednar@github) (07/05/2019 09:17)
  */
-@RunWith(JUnitPlatform.class)
 class QueryApiTest extends AbstractInfluxDBClientTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/WriteApiBlockingTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiBlockingTest.java
@@ -33,13 +33,10 @@ import com.influxdb.client.write.WriteParameters;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (12/11/2020 10:25)
  */
-@RunWith(JUnitPlatform.class)
 class WriteApiBlockingTest extends AbstractInfluxDBClientTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -54,13 +54,10 @@ import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (21/09/2018 11:36)
  */
-@RunWith(JUnitPlatform.class)
 class WriteApiTest extends AbstractInfluxDBClientTest {
 
     private WriteApi writeApi;

--- a/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteOptionsTest.java
@@ -25,13 +25,10 @@ import io.reactivex.rxjava3.core.BackpressureOverflowStrategy;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (21/09/2018 10:35)
  */
-@RunWith(JUnitPlatform.class)
 class WriteOptionsTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/AuthenticateInterceptorTest.java
@@ -37,13 +37,10 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (12/10/2018 12:50)
  */
-@RunWith(JUnitPlatform.class)
 class AuthenticateInterceptorTest extends AbstractMockServerTest {
 
     private String influxDB_URL;

--- a/client/src/test/java/com/influxdb/client/internal/GzipInterceptorTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/GzipInterceptorTest.java
@@ -36,13 +36,10 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (15/10/2018 11:27)
  */
-@RunWith(JUnitPlatform.class)
 class GzipInterceptorTest extends AbstractMockServerTest {
 
     private String url;

--- a/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
@@ -31,13 +31,10 @@ import com.influxdb.client.write.Point;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (15/10/2018 13:36)
  */
-@RunWith(JUnitPlatform.class)
 class MeasurementMapperTest {
 
     private MeasurementMapper mapper;

--- a/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/RetryAttemptTest.java
@@ -39,15 +39,12 @@ import okhttp3.ResponseBody;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit2.HttpException;
 import retrofit2.Response;
 
 /**
  * @author Jakub Bednar (29/09/2020 11:21)
  */
-@RunWith(JUnitPlatform.class)
 class RetryAttemptTest {
     
     private final WriteOptions DEFAULT = WriteOptions.builder().build();

--- a/client/src/test/java/com/influxdb/client/internal/WaitToConditionTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/WaitToConditionTest.java
@@ -31,13 +31,10 @@ import com.influxdb.client.MockLogHandler;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (28/01/2020 14:47)
  */
-@RunWith(JUnitPlatform.class)
 class WaitToConditionTest {
     
     @Test

--- a/client/src/test/java/com/influxdb/client/internal/flowable/BackpressureBatchesBufferStrategyTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/flowable/BackpressureBatchesBufferStrategyTest.java
@@ -13,15 +13,12 @@ import io.reactivex.rxjava3.subscribers.DefaultSubscriber;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static io.reactivex.rxjava3.core.BackpressureOverflowStrategy.DROP_OLDEST;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2022 07:54)
  */
-@RunWith(JUnitPlatform.class)
 class BackpressureBatchesBufferStrategyTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/internal/flowable/FlowableBufferTimedFlushableTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/flowable/FlowableBufferTimedFlushableTest.java
@@ -13,13 +13,10 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2022 07:40)
  */
-@RunWith(JUnitPlatform.class)
 class FlowableBufferTimedFlushableTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/write/PointSettingsTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointSettingsTest.java
@@ -26,13 +26,10 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (28/06/2019 09:35)
  */
-@RunWith(JUnitPlatform.class)
 class PointSettingsTest {
 
     private PointSettings defaults;

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -30,13 +30,10 @@ import com.influxdb.client.domain.WritePrecision;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (11/10/2018 12:57)
  */
-@RunWith(JUnitPlatform.class)
 class PointTest {
 
     @Test

--- a/client/src/test/java/com/influxdb/client/write/WriteParametersTest.java
+++ b/client/src/test/java/com/influxdb/client/write/WriteParametersTest.java
@@ -28,10 +28,7 @@ import com.influxdb.client.domain.WritePrecision;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class WriteParametersTest {
 
     private InfluxDBClientOptions.Builder optionsBuilder;

--- a/flux-dsl/src/test/java/com/example/flux/CustomFunction.java
+++ b/flux-dsl/src/test/java/com/example/flux/CustomFunction.java
@@ -29,13 +29,10 @@ import com.influxdb.utils.Arguments;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (02/07/2018 13:55)
  */
-@RunWith(JUnitPlatform.class)
 class CustomFunction {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/AbstractFunctionFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/AbstractFunctionFluxTest.java
@@ -27,12 +27,10 @@ import javax.annotation.Nonnull;
 import com.influxdb.query.dsl.functions.AbstractFunctionCallFlux;
 import com.influxdb.query.dsl.functions.AbstractFunctionFlux;
 import com.influxdb.query.dsl.functions.FreestyleExpression;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class AbstractFunctionFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/FluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/FluxTest.java
@@ -25,13 +25,10 @@ import java.time.temporal.ChronoUnit;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/06/2018 10:27)
  */
-@RunWith(JUnitPlatform.class)
 class FluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/AggregateWindowTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/AggregateWindowTest.java
@@ -24,15 +24,13 @@ package com.influxdb.query.dsl.functions;
 import java.time.temporal.ChronoUnit;
 
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (13/05/2020 15:07)
  */
-@RunWith(JUnitPlatform.class)
 class AggregateWindowTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ArrayFromFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ArrayFromFluxTest.java
@@ -25,12 +25,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class ArrayFromFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ColumnsFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ColumnsFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (19/04/2022 09:49)
  */
-@RunWith(JUnitPlatform.class)
 class ColumnsFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CountFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CountFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/06/2018 12:04)
  */
-@RunWith(JUnitPlatform.class)
 class CountFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CovarianceFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CovarianceFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (17/07/2018 13:51)
  */
-@RunWith(JUnitPlatform.class)
 class CovarianceFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CumulativeSumFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/CumulativeSumFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (10/10/2018 07:45)
  */
-@RunWith(JUnitPlatform.class)
 class CumulativeSumFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DerivativeFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DerivativeFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (03/07/2018 15:05)
  */
-@RunWith(JUnitPlatform.class)
 class DerivativeFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DifferenceFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DifferenceFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (17/07/2018 12:57)
  */
-@RunWith(JUnitPlatform.class)
 class DifferenceFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DistinctFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DistinctFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (17/07/2018 12:15)
  */
-@RunWith(JUnitPlatform.class)
 class DistinctFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DropFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DropFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (02/08/2018 11:09)
  */
-@RunWith(JUnitPlatform.class)
 class DropFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DuplicateFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/DuplicateFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (09/10/2018 13:27)
  */
-@RunWith(JUnitPlatform.class)
 class DuplicateFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ExpressionFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ExpressionFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (27/06/2018 11:30)
  */
-@RunWith(JUnitPlatform.class)
 class ExpressionFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FillFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FillFluxTest.java
@@ -24,15 +24,13 @@ package com.influxdb.query.dsl.functions;
 import java.time.Instant;
 
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (09/10/2018 13:27)
  */
-@RunWith(JUnitPlatform.class)
 class FillFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FilterFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FilterFluxTest.java
@@ -30,13 +30,10 @@ import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (28/06/2018 11:46)
  */
-@RunWith(JUnitPlatform.class)
 class FilterFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FirstFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FirstFluxTest.java
@@ -21,19 +21,14 @@
  */
 package com.influxdb.query.dsl.functions;
 
-import java.util.HashMap;
-
 import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 09:40)
  */
-@RunWith(JUnitPlatform.class)
 class FirstFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FromFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/FromFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (22/06/2018 12:04)
  */
-@RunWith(JUnitPlatform.class)
 class FromFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/GroupFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/GroupFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 15:16)
  */
-@RunWith(JUnitPlatform.class)
 class GroupFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/IntegralFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/IntegralFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (03/07/2018 12:48)
  */
-@RunWith(JUnitPlatform.class)
 class IntegralFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/InterpolateLinearTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/InterpolateLinearTest.java
@@ -24,12 +24,10 @@ package com.influxdb.query.dsl.functions;
 import java.time.temporal.ChronoUnit;
 
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class InterpolateLinearTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/JoinFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/JoinFluxTest.java
@@ -31,13 +31,10 @@ import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (19/07/2018 12:59)
  */
-@RunWith(JUnitPlatform.class)
 class JoinFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/KeepFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/KeepFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (02/08/2018 11:43)
  */
-@RunWith(JUnitPlatform.class)
 class KeepFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LastFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LastFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 09:47)
  */
-@RunWith(JUnitPlatform.class)
 class LastFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LimitFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/LimitFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 11:55)
  */
-@RunWith(JUnitPlatform.class)
 class LimitFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MapFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MapFluxTest.java
@@ -30,13 +30,10 @@ import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (17/07/2018 07:58)
  */
-@RunWith(JUnitPlatform.class)
 class MapFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MaxFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MaxFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 09:52)
  */
-@RunWith(JUnitPlatform.class)
 class MaxFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MeanFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MeanFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 09:58)
  */
-@RunWith(JUnitPlatform.class)
 class MeanFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MinFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/MinFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 10:03)
  */
-@RunWith(JUnitPlatform.class)
 class MinFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/PivotFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/PivotFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (10/10/2018 06:59)
  */
-@RunWith(JUnitPlatform.class)
 class PivotFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/QuantileFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/QuantileFluxTest.java
@@ -21,19 +21,14 @@
  */
 package com.influxdb.query.dsl.functions;
 
-import java.util.Arrays;
-
 import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (10/10/2018 12:38)
  */
-@RunWith(JUnitPlatform.class)
 class QuantileFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/RangeFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/RangeFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 07:23)
  */
-@RunWith(JUnitPlatform.class)
 class RangeFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ReduceFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ReduceFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (24/02/2020 13:26)
  */
-@RunWith(JUnitPlatform.class)
 class ReduceFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/RenameFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/RenameFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (02/08/2018 12:01)
  */
-@RunWith(JUnitPlatform.class)
 class RenameFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SampleFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SampleFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2018 07:37)
  */
-@RunWith(JUnitPlatform.class)
 class SampleFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SetFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SetFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2018 09:32)
  */
-@RunWith(JUnitPlatform.class)
 class SetFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SkewFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SkewFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 10:08)
  */
-@RunWith(JUnitPlatform.class)
 class SkewFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SortFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SortFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 13:54)
  */
-@RunWith(JUnitPlatform.class)
 class SortFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SpreadFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SpreadFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 10:13)
  */
-@RunWith(JUnitPlatform.class)
 class SpreadFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/StddevFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/StddevFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 10:18)
  */
-@RunWith(JUnitPlatform.class)
 class StddevFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SumFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/SumFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 10:22)
  */
-@RunWith(JUnitPlatform.class)
 class SumFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TailFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TailFluxTest.java
@@ -27,13 +27,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (14/12/2020 10:24)
  */
-@RunWith(JUnitPlatform.class)
 class TailFluxTest
 {
 	@Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TimeShiftFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TimeShiftFluxTest.java
@@ -29,13 +29,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2018 10:46)
  */
-@RunWith(JUnitPlatform.class)
 class TimeShiftFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToBoolFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToBoolFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 16:01)
  */
-@RunWith(JUnitPlatform.class)
 class ToBoolFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToDurationFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToDurationFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 06:30)
  */
-@RunWith(JUnitPlatform.class)
 class ToDurationFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFloatFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFloatFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 16:09)
  */
-@RunWith(JUnitPlatform.class)
 class ToFloatFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToFluxTest.java
@@ -28,13 +28,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (10/10/2018 09:35)
  */
-@RunWith(JUnitPlatform.class)
 class ToFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToIntFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToIntFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (25/06/2018 16:09)
  */
-@RunWith(JUnitPlatform.class)
 class ToIntFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToStringFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToStringFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 06:35)
  */
-@RunWith(JUnitPlatform.class)
 class ToStringFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToTimeFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToTimeFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 06:39)
  */
-@RunWith(JUnitPlatform.class)
 class ToTimeFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToUIntFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/ToUIntFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (26/06/2018 06:43)
  */
-@RunWith(JUnitPlatform.class)
 class ToUIntFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TruncateTimeColumnTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/TruncateTimeColumnTest.java
@@ -24,13 +24,11 @@ package com.influxdb.query.dsl.functions;
 import java.time.temporal.ChronoUnit;
 
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 
-@RunWith(JUnitPlatform.class)
 class TruncateTimeColumnTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/UnionFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/UnionFluxTest.java
@@ -23,15 +23,13 @@ package com.influxdb.query.dsl.functions;
 
 import com.influxdb.query.dsl.Expressions;
 import com.influxdb.query.dsl.Flux;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2018 10:03)
  */
-@RunWith(JUnitPlatform.class)
 class UnionFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/WindowFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/WindowFluxTest.java
@@ -30,13 +30,10 @@ import com.influxdb.query.dsl.functions.properties.TimeInterval;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (27/06/2018 12:42)
  */
-@RunWith(JUnitPlatform.class)
 class WindowFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/YieldFluxTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/YieldFluxTest.java
@@ -25,13 +25,10 @@ import com.influxdb.query.dsl.Flux;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (29/06/2018 10:03)
  */
-@RunWith(JUnitPlatform.class)
 class YieldFluxTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/properties/TimeIntervalTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/properties/TimeIntervalTest.java
@@ -25,13 +25,10 @@ import java.time.temporal.ChronoUnit;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author Jakub Bednar (bednar@github) (09/10/2018 12:24)
  */
-@RunWith(JUnitPlatform.class)
 class TimeIntervalTest {
 
     @Test

--- a/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
+++ b/flux-dsl/src/test/java/com/influxdb/query/dsl/functions/restriction/RestrictionsTest.java
@@ -21,19 +21,17 @@
  */
 package com.influxdb.query.dsl.functions.restriction;
 
-import com.influxdb.query.dsl.Flux;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.influxdb.query.dsl.Flux;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jakub Bednar (bednar@github) (09/10/2018 10:33)
  */
-@RunWith(JUnitPlatform.class)
 class RestrictionsTest {
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -637,12 +637,6 @@
                 <version>${junit-jupiter.version}</version>
             </dependency>
 
-<!--            <dependency>-->
-<!--                <groupId>org.junit.platform</groupId>-->
-<!--                <artifactId>junit-platform-runner</artifactId>-->
-<!--                <version>1.9.0</version>-->
-<!--            </dependency>-->
-
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${plugin.surefire.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>${junit-jupiter.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>
@@ -268,6 +275,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>${junit-jupiter.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>
@@ -623,11 +637,11 @@
                 <version>${junit-jupiter.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-runner</artifactId>
-                <version>1.9.0</version>
-            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>org.junit.platform</groupId>-->
+<!--                <artifactId>junit-platform-runner</artifactId>-->
+<!--                <version>1.9.0</version>-->
+<!--            </dependency>-->
 
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -154,12 +154,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/spring/src/test/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfigurationTest.java
+++ b/spring/src/test/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfigurationTest.java
@@ -24,8 +24,6 @@ package com.influxdb.spring.health;
 import com.influxdb.client.InfluxDBClient;
 
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -40,7 +38,6 @@ import static org.mockito.Mockito.mock;
  *
  * @author Jakub Bednar (bednar@github) (07/05/2019 14:59)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDB2HealthIndicatorAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactiveTest.java
+++ b/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationReactiveTest.java
@@ -26,8 +26,6 @@ import com.influxdb.client.reactive.InfluxDBClientReactive;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -36,7 +34,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
  *
  * @author Jakub Bednar (bednar@github) (07/05/2019 12:59)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDB2AutoConfigurationReactiveTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationTest.java
+++ b/spring/src/test/java/com/influxdb/spring/influx/InfluxDB2AutoConfigurationTest.java
@@ -31,8 +31,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -46,7 +44,6 @@ import retrofit2.Retrofit;
  *
  * @author Jakub Bednar (bednar@github) (07/05/2019 12:59)
  */
-@RunWith(JUnitPlatform.class)
 class InfluxDB2AutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()


### PR DESCRIPTION
Closes #327

## Proposed Changes

This PR removes dependency to deprecated `junit-platform-runner` package.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
