### PR TITLE
chore(deps): update scala to 2.13.9, remove scala coverage report plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Update dependencies:
 
 #### Build:
   - [#434](https://github.com/influxdata/influxdb-client-java/pull/434): `kotlin` to `1.7.20`
+  - [#436](https://github.com/influxdata/influxdb-client-java/pull/436): `scala-library` to `2.13.9`
 
 ## 6.6.0 [2022-09-29]
 

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -72,8 +72,7 @@
   </scm>
 
   <properties>
-    <scoverage-maven-plugin.version>1.4.11</scoverage-maven-plugin.version>
-    <scala.version>2.13.8</scala.version>
+    <scala.version>2.13.9</scala.version>
     <akka.version>2.6.20</akka.version>
   </properties>
 
@@ -131,25 +130,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.scoverage</groupId>
-        <artifactId>scoverage-maven-plugin</artifactId>
-        <version>${scoverage-maven-plugin.version}</version>
-        <configuration>
-          <scalaVersion>${scala.version}</scalaVersion>
-          <!-- other parameters -->
-        </configuration>
-        <executions>
-          <execution>
-            <id>report</id>
-            <phase>test</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
@@ -174,18 +154,6 @@
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
         <version>${plugin.scala.version}</version>
-      </plugin>
-      <plugin>
-        <groupId>org.scoverage</groupId>
-        <artifactId>scoverage-maven-plugin</artifactId>
-        <version>${scoverage-maven-plugin.version}</version>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>report</report>
-            </reports>
-          </reportSet>
-        </reportSets>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Closes #433
Closes #435

## Proposed Changes

1. Updated scala to `2.13.9`
2. Removed `scoverage-maven-plugin` because is no longer supported for Scala `2.13.9` - for more info see #433

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
