### PR TITLE
chore(docs): simplify publishing GitHub pages by Docker

### DIFF
--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -52,7 +52,7 @@ cp -Rf  --verbose "${SCRIPT_PATH}"/../target/staging/* "${HOME}"/gh-pages
 echo
 echo "Copy CircleCI"
 echo
-mkdir "${HOME}"/gh-pages/.circleci/ || true
+mkdir -p "${HOME}"/gh-pages/.circleci/
 cp "${SCRIPT_PATH}"/../.circleci/config.yml "${HOME}"/gh-pages/.circleci/config.yml
 
 echo


### PR DESCRIPTION
## Proposed Changes

Simplify publishing GitHub pages by Docker to be platform independent.


This PR also change the **Deploy Maven site** from [**ReleaseCycleSettings.md**](https://github.com/bonitoo-io/influxdata/blob/main/influxdb-clients/ReleaseCycleSettings.md#3-deploy-maven-site) to:

```console
mvn site site:stage -DskipTests

docker run -it --rm \
       -v "${PWD}":/code \
       -v ~/.ssh:/root/.ssh \
       -v ~/.gitconfig:/root/.gitconfig \
       -w /code \
       bitnami/git /code/scripts/publish-site.sh
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
