### PR TITLE
feat: add FluxRecord.getRow() with response data stored in List

### DIFF
--- a/client-core/src/main/java/com/influxdb/query/FluxRecord.java
+++ b/client-core/src/main/java/com/influxdb/query/FluxRecord.java
@@ -23,10 +23,7 @@ package com.influxdb.query;
 
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.StringJoiner;
+import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -49,6 +46,8 @@ public final class FluxRecord implements Serializable {
      * The record's values.
      */
     private LinkedHashMap<String, Object> values = new LinkedHashMap<>();
+
+    private List<Object> row = new ArrayList<>();
 
     public FluxRecord(@Nonnull final Integer table) {
 
@@ -119,6 +118,14 @@ public final class FluxRecord implements Serializable {
     @Nonnull
     public Map<String, Object> getValues() {
         return values;
+    }
+
+    /**
+     * @return record's columns
+     */
+    @Nonnull
+    public List<Object> getRow() {
+        return row;
     }
 
     /**

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -27,11 +27,7 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -276,7 +272,11 @@ public class FluxCsvParser {
 
             String strValue = csvRecord.get(fluxColumn.getIndex() + 1);
 
-            record.getValues().put(columnName, toValue(strValue, fluxColumn));
+            Object value = toValue(strValue, fluxColumn);
+
+            record.getValues().put(columnName, value);
+
+            record.getRow().add(value);
         }
         return record;
     }
@@ -397,6 +397,15 @@ public class FluxCsvParser {
 
             String columnName = columnNames.get(i);
             fluxColumn.setLabel(columnName);
+        }
+
+        HashSet<Object> seen=new HashSet<>();
+        columnNames.removeIf(seen::add);
+
+        if (!columnNames.isEmpty()){
+            System.out.printf("The response contains columns with duplicated names: %s)%n", columnNames);
+            System.out.println("You should use the \"FluxRecord.getRow()\"to access your data instead of " +
+                    "\"FluxRecord.getValues()\".");
         }
     }
 

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -655,6 +655,25 @@ class FluxCsvParserTest {
         Assertions.assertThat(tables.get(0).getRecords().get(11).getValueByKey("le")).isEqualTo(Double.NEGATIVE_INFINITY);
     }
 
+    @Test
+    public void parseDuplicateColumnNames() throws IOException {
+        String data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double\n" +
+                "#group,false,false,true,true,false,true,true,false\n" +
+                "#default,_result,,,,,,,\n" +
+                " ,result,table,_start,_stop,_time,_measurement,location,result\n" +
+                ",,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3\n" +
+                ",,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3\n" +
+                ",,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3\n";
+
+        List<FluxTable> tables = parseFluxResponse(data);
+        Assertions.assertThat(tables).hasSize(1);
+        Assertions.assertThat(tables.get(0).getRecords()).hasSize(3);
+        Assertions.assertThat(tables.get(0).getColumns()).hasSize(8);
+        Assertions.assertThat(tables.get(0).getRecords().get(0).getValues().size()).isEqualTo(7);
+        Assertions.assertThat(tables.get(0).getRecords().get(0).getRow().size()).isEqualTo(8);
+        Assertions.assertThat(tables.get(0).getRecords().get(0).getRow().get(7)).isEqualTo(25.3);
+    }
+
     @Nonnull
     private List<FluxTable> parseFluxResponse(@Nonnull final String data) throws IOException {
 

--- a/examples/src/main/java/example/RecordRowExample.java
+++ b/examples/src/main/java/example/RecordRowExample.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package example;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.QueryApi;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+
+import java.util.List;
+
+public class RecordRowExample {
+
+    public static void main(final String[] args) throws Exception {
+
+        final char[] token = "my-token".toCharArray();
+        final String org = "my-org";
+        final String bucket = "my-bucket";
+
+        InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:9999", token, org, bucket);
+
+        //
+        // Prepare Data
+        //
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+        for (int i = 1; i <= 5; i++)
+            writeApi.writeRecord(WritePrecision.NS, String.format("point,table=my-table result=%d", i));
+
+        //
+        // Query data
+        //
+        String fluxQuery = String.format("from(bucket: \"%s\")\n", bucket)
+                + " |> range(start: -1m)"
+                + " |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))"
+                + " |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+
+        QueryApi queryApi = influxDBClient.getQueryApi();
+
+        //
+        // Query data
+        //
+        List<FluxTable> tables = queryApi.query(fluxQuery);
+        System.out.println("--------------------------------- FluxRecord.getValues() --------------------------------");
+        for (FluxTable fluxTable : tables) {
+            List<FluxRecord> records = fluxTable.getRecords();
+            for (FluxRecord fluxRecord : records) {
+                System.out.println(fluxRecord.getValues());
+            }
+        }
+
+        System.out.println("---------------------------------- FluxRecord.getRow() ----------------------------------");
+        for (FluxTable fluxTable : tables) {
+            List<FluxRecord> records = fluxTable.getRecords();
+            for (FluxRecord fluxRecord : records) {
+                System.out.println(fluxRecord.getRow());
+            }
+        }
+
+        influxDBClient.close();
+    }
+}


### PR DESCRIPTION
Closes #

## Proposed Changes

Adding possibility of accessing response data in List FluxRecord.getRow().

In case of using pivot on data, where field contains labels that occur by default in the annotated CSV (f.e. "result" or "table"), could be duplicated column names in response. In that case FluxRecord.getValues() (Map), which can hold only unique keys, doesn't show complete data. This edge case is solved by using FluxRecord.getRow() (List).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `mvn test` completes successfully
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
