### PR TITLE
feat(authorization): add possibility to use *Request object in wrapped API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#439](https://github.com/influxdata/influxdb-client-java/pull/439): Add `FluxRecord.getRow()` which stores response data in a list
+1. [#457](https://github.com/influxdata/influxdb-client-java/pull/457): Add possibility to use `AuthorizationPostRequest` and `AuthorizationUpdateRequest` in `AuthorizationApi`
 
 ### Dependencies
 

--- a/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
+++ b/client/src/main/java/com/influxdb/client/AuthorizationsApi.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import com.influxdb.client.domain.Authorization;
+import com.influxdb.client.domain.AuthorizationPostRequest;
+import com.influxdb.client.domain.AuthorizationUpdateRequest;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.domain.Permission;
 import com.influxdb.client.domain.User;
@@ -71,6 +73,21 @@ public interface AuthorizationsApi {
                                       @Nonnull final List<Permission> permissions);
 
     /**
+     * Create an authorization.
+     *
+     * <p>
+     * Use this method to create an authorization, which generates an API token with permissions to `read` or `write`
+     * to a specific resource or `type` of resource. The response contains the new authorization
+     * with the generated API token.
+     * </p>
+     *
+     * @param request The authorization to create.
+     * @return Newly created authorization
+     */
+    @Nonnull
+    Authorization createAuthorization(@Nonnull final AuthorizationPostRequest request);
+
+    /**
      * Updates the status of the authorization. Useful for setting an authorization to inactive or active.
      *
      * @param authorization the authorization with updated status
@@ -78,6 +95,17 @@ public interface AuthorizationsApi {
      */
     @Nonnull
     Authorization updateAuthorization(@Nonnull final Authorization authorization);
+
+    /**
+     * Update an authorization to be active or inactive.
+     *
+     * @param authorizationID The ID of the authorization to update.
+     * @param request         Authorization to update
+     * @return The active or inactive authorization
+     */
+    @Nonnull
+    Authorization updateAuthorization(@Nonnull final String authorizationID,
+                                      @Nonnull final AuthorizationUpdateRequest request);
 
     /**
      * Delete an authorization.

--- a/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
+++ b/client/src/main/java/com/influxdb/client/internal/AuthorizationsApiImpl.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import com.influxdb.client.AuthorizationsApi;
 import com.influxdb.client.domain.Authorization;
 import com.influxdb.client.domain.AuthorizationPostRequest;
+import com.influxdb.client.domain.AuthorizationUpdateRequest;
 import com.influxdb.client.domain.Authorizations;
 import com.influxdb.client.domain.Organization;
 import com.influxdb.client.domain.Permission;
@@ -96,6 +97,15 @@ final class AuthorizationsApiImpl extends AbstractRestClient implements Authoriz
                 .permissions(authorization.getPermissions())
                 .description(authorization.getDescription());
 
+        return createAuthorization(request);
+    }
+
+    @Override
+    @Nonnull
+    public Authorization createAuthorization(@Nonnull final AuthorizationPostRequest request) {
+
+        Arguments.checkNotNull(request, "AuthorizationPostRequest is required");
+
         Call<Authorization> call = service.postAuthorizations(request, null);
 
         return execute(call);
@@ -160,8 +170,18 @@ final class AuthorizationsApiImpl extends AbstractRestClient implements Authoriz
 
         Arguments.checkNotNull(authorization, "Authorization is required");
 
-        Call<Authorization> authorizationCall = service
-                .patchAuthorizationsID(authorization.getId(), authorization, null);
+        return updateAuthorization(authorization.getId(), authorization);
+    }
+
+    @Override
+    @Nonnull
+    public Authorization updateAuthorization(@Nonnull final String authorizationID,
+                                             @Nonnull final AuthorizationUpdateRequest request) {
+
+        Arguments.checkNonEmpty(authorizationID, "authorizationID");
+        Arguments.checkNotNull(authorizationID, "AuthorizationUpdateRequest");
+
+        Call<Authorization> authorizationCall = service.patchAuthorizationsID(authorizationID, request, null);
 
         return execute(authorizationCall);
     }


### PR DESCRIPTION
Closes #453

## Proposed Changes

This PR add possibility to use `AuthorizationPostRequest` and `AuthorizationUpdateRequest` in wrapped API - `AuthorizationApi`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
