### PR TITLE
fix: Fix support for InfluxDB 1.8.x in InfluxQLQueryAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 1. [#439](https://github.com/influxdata/influxdb-client-java/pull/439): Add `FluxRecord.getRow()` which stores response data in a list
 1. [#457](https://github.com/influxdata/influxdb-client-java/pull/457): Add possibility to use `AuthorizationPostRequest` and `AuthorizationUpdateRequest` in `AuthorizationApi`
 
+### Bug Fixes
+1. [#459](https://github.com/influxdata/influxdb-client-java/pull/459): Fix support for InfluxDB 1.8.x in InfluxQLQueryAPI
+
 ### Dependencies
 
 1. [#446](https://github.com/influxdata/influxdb-client-java/pull/446): Remove `gson-fire`

--- a/client/src/generated/java/com/influxdb/client/service/InfluxQLQueryService.java
+++ b/client/src/generated/java/com/influxdb/client/service/InfluxQLQueryService.java
@@ -15,10 +15,11 @@ public interface InfluxQLQueryService {
      * @param zapTraceSpan    OpenTracing span context (optional)
      * @return response in csv format
      */
-    @Headers({"Accept:application/csv", "Content-Type:application/vnd.influxql"})
+    @Headers({"Accept:application/csv", "Content-Type:application/x-www-form-urlencoded"})
+    @FormUrlEncoded
     @POST("query")
     Call<ResponseBody> query(
-            @Body String query,
+            @Field("q") String query,
             @Nonnull @Query("db") String db,
             @Query("rp") String retentionPolicy,
             @Query("epoch") String epoch,

--- a/client/src/test/java/com/influxdb/client/ITInfluxQLQueryApi.java
+++ b/client/src/test/java/com/influxdb/client/ITInfluxQLQueryApi.java
@@ -133,6 +133,29 @@ class ITInfluxQLQueryApi extends AbstractITClientTest {
 				});
 	}
 
+	@Test
+	void testInfluxDB18() {
+		// create database
+		String db = "testing_database";
+		influxDBQuery("CREATE DATABASE " + db, db);
+
+		// connect to InfluxDB 1.8
+		influxDBClient.close();
+		influxDBClient = InfluxDBClientFactory.createV1(getInfluxDbUrl(), "username", "password".toCharArray(),
+				db, "autogen");
+		influxQLQueryApi = influxDBClient.getInfluxQLQueryApi();
+
+		// test query to InfluxDB 1.8
+		InfluxQLQueryResult result = influxQLQueryApi.query(new InfluxQLQuery("SHOW DATABASES", db));
+		assertSingleSeriesRecords(result)
+				.map(record -> record.getValueByKey("name"))
+				.contains(db);
+
+
+		// drop database
+		influxDBQuery("DROP DATABASE " + db, db);
+	}
+
 	private ListAssert<InfluxQLQueryResult.Series.Record> assertSingleSeriesRecords(InfluxQLQueryResult result) {
 		return Assertions.assertThat(result)
 				.extracting(InfluxQLQueryResult::getResults, list(InfluxQLQueryResult.Result.class))


### PR DESCRIPTION
## Proposed Changes

Switches to sending InfluxQL queries as a urlencoded form-body to ensure compatibility with 1.8.x's InfluxQL implementation.

See (#458)

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
