### PR TITLE
chore(ci): check dependency licenses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,23 @@ jobs:
           name: "Check dependency rules"
           command: mvn enforcer:enforce -Drules=banDuplicatePomDependencyVersions,dependencyConvergence
 
+  check-licenses:
+    parameters:
+      maven-image:
+        type: string
+        default: *default-maven-image
+    docker:
+      - image: << parameters.maven-image >>
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restoring Maven Cache
+          keys:
+            - maven-cache_v3-<< parameters.maven-image >>-
+      - run:
+          name: "Check dependency licenses"
+          command: mvn license:check -Dlicense.dependencies.enforce=true
+
   check-generate-site:
     parameters:
       maven-image:
@@ -232,6 +249,7 @@ workflows:
     jobs:
       - check-dependencies
       - check-generate-site
+      - check-licenses
       - tests-java:
           name: jdk-8
       - tests-java:
@@ -256,6 +274,7 @@ workflows:
           requires:
             - check-dependencies
             - check-generate-site
+            - check-licenses
             - jdk-8
             - jdk-11
             - jdk-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 ### Bug Fixes
 1. [#459](https://github.com/influxdata/influxdb-client-java/pull/459): Fix support for InfluxDB 1.8.x in InfluxQLQueryAPI
 
-### Dependencies
+### CI
+1. [#460](https://github.com/influxdata/influxdb-client-java/pull/460): Check dependency licenses
 
+### Dependencies
 1. [#446](https://github.com/influxdata/influxdb-client-java/pull/446): Remove `gson-fire`
 
 Update dependencies:

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,48 @@
                     <properties>
                         <organizationName>${project.organization.name}</organizationName>
                     </properties>
+                    <dependencyPolicies>
+                        <dependencyPolicy>
+                            <type>LICENSE_NAME</type>
+                            <rule>APPROVE</rule>
+                            <value>The MIT License (MIT)</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_NAME</type>
+                            <rule>APPROVE</rule>
+                            <value>The MIT License</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_NAME</type>
+                            <rule>APPROVE</rule>
+                            <value>Apache-2.0</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_URL</type>
+                            <rule>APPROVE</rule>
+                            <value>http://www.apache.org/licenses/LICENSE-2.0.txt</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_URL</type>
+                            <rule>APPROVE</rule>
+                            <value>https://www.apache.org/licenses/LICENSE-2.0.txt</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_URL</type>
+                            <rule>APPROVE</rule>
+                            <value>https://www.apache.org/licenses/LICENSE-2.0</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_URL</type>
+                            <rule>APPROVE</rule>
+                            <value>http://opensource.org/licenses/BSD-3-Clause</value>
+                        </dependencyPolicy>
+                        <dependencyPolicy>
+                            <type>LICENSE_URL</type>
+                            <rule>APPROVE</rule>
+                            <value>https://www.eclipse.org/legal/epl-v20.html</value>
+                        </dependencyPolicy>
+                    </dependencyPolicies>
                 </configuration>
                 <executions>
                     <execution>
@@ -375,7 +417,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.1</version>
+                    <version>4.2.rc2</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
## Proposed Changes

This PR add new step to CircleCI build: `check-licenses`:

![image](https://user-images.githubusercontent.com/455137/198000790-2a3bd131-e2bb-45c8-b934-95caf0fc4657.png)

The `check-licenses` uses [license-maven-plugin](https://github.com/mathieucarbou/license-maven-plugin/blob/5cdc5cbc40f320f88e0891ba67db5727eefc3b3f/docs/index.md#dependency-enforcement) to verify that all dependencies has allowed licence: https://github.com/influxdata/influxdb-client-java/blob/a126aeb0521505349c65fa7c9bd720cdf943fdcc/pom.xml#L243


If there a dependency (`akka:2.7.0`) which has not allowed license then the build fail with following error:

![image](https://user-images.githubusercontent.com/455137/198001654-31df1832-bf13-4c61-8f49-4d85bd0fb6a7.png)



## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
