### PR TITLE
refactor(spring): move auto-configuration registration to `AutoConfiguration.imports` as is recommended from Spring Boot 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 6.8.0 [unreleased]
 
+### Bug Fixes
+1. [#470](https://github.com/influxdata/influxdb-client-java/pull/470): Move auto-configuration registration to `AutoConfiguration.imports` [spring]
+
 ### Dependencies
 
 Update dependencies:

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                         **/*nightly*/**, **/.m2/**, LICENSE, **/*.md, **/PLACEHOLDER, **/.influxdb/**, **/generated/**,
                         **/openapi-generator/**, **/swagger.yml, **/*.json, **/spring.factories, **/PULL_REQUEST_TEMPLATE,
                         release.properties/, **/pom.xml.releaseBackup, **/pom.xml.tag, **/semantic.yml, **/test.txt, **/*.csv,
-                        codecov.yml, **/flowable/*.java
+                        codecov.yml, **/flowable/*.java, **/spring/*.imports
                     </excludes>
                     <properties>
                         <organizationName>${project.organization.name}</organizationName>

--- a/spring/src/main/resources/META-INF/spring.factories
+++ b/spring/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.influxdb.spring.health.InfluxDB2HealthIndicatorAutoConfiguration,\
-com.influxdb.spring.influx.InfluxDB2AutoConfiguration,\
-com.influxdb.spring.influx.InfluxDB2AutoConfigurationReactive

--- a/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.influxdb.spring.health.InfluxDB2HealthIndicatorAutoConfiguration
+com.influxdb.spring.influx.InfluxDB2AutoConfiguration
+com.influxdb.spring.influx.InfluxDB2AutoConfigurationReactive


### PR DESCRIPTION
Closes #468

Use `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` for registration of auto-configuration.

## Proposed Changes

    Auto-configuration Registration

    If you have created your own auto-configurations, you should move the registration from spring.factories 
    under the org.springframework.boot.autoconfigure.EnableAutoConfiguration key to a new file named 
    META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports. Rather than a single
    comma-separate list, each line contains the fully qualified name of an auto-configuration class. 
    See [the included auto-configurations](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports) 
    for an example.


https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
