### PR TITLE
fix: do not hard-code content-encoding on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 1. [#470](https://github.com/influxdata/influxdb-client-java/pull/470): Move auto-configuration registration to `AutoConfiguration.imports` [spring]
 1. [#483](https://github.com/influxdata/influxdb-client-java/pull/483): Fix of potential NPE for `WriteParameters#hashCode`
+1. [#521](https://github.com/influxdata/influxdb-client-java/issues/521): Ensure write data is actually gzip'ed when enabled
 
 ### CI
 1. [#484](https://github.com/influxdata/influxdb-client-java/pull/4884): Add JDK 19 to CI pipeline

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteBlockingClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteBlockingClient.java
@@ -84,7 +84,7 @@ public abstract class AbstractWriteBlockingClient extends AbstractRestClient {
                 new Object[]{organization, bucket, precision});
 
         Call<Void> voidCall = service.postWrite(organization, bucket, lineProtocol, null,
-                "identity", "text/plain; charset=utf-8", null,
+                null, "text/plain; charset=utf-8", null,
                 "application/json", null, precision, consistency);
 
         execute(voidCall);

--- a/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/com/influxdb/client/internal/AbstractWriteClient.java
@@ -443,7 +443,6 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
 
         @Override
         public Maybe<Notification<Response>> apply(final BatchWriteItem batchWrite) {
-
             String content = batchWrite.data.toLineProtocol();
 
             if (content == null || content.isEmpty()) {
@@ -457,7 +456,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient implements 
             WriteConsistency consistency = batchWrite.writeParameters.consistencySafe(options);
 
             Single<Response<Void>> postWriteRx = service
-                    .postWriteRx(organization, bucket, content, null, "identity", "text/plain; charset=utf-8",
+                    .postWriteRx(organization, bucket, content, null, null, "text/plain; charset=utf-8",
                             null, "application/json", null, precision, consistency);
 
 


### PR DESCRIPTION
Because the content-encoding was always getting set, we were never gzip encoding data. The content-encoding should only be set by the gzip class and only when we gzip data.

fixes: #521
