### PR TITLE
feat: add support of pojo's value which type is object

### DIFF
--- a/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
+++ b/client/src/main/java/com/influxdb/client/internal/MeasurementMapper.java
@@ -74,16 +74,19 @@ public final class MeasurementMapper {
             }
 
             Class<?> fieldType = field.getType();
+            // value type can be different from field type
+            // value won't be null at this point
+            Class<?> valueType = value.getClass();
             if (column.tag()) {
                 point.addTag(name, value.toString());
             } else if (column.timestamp()) {
                 Instant instant = (Instant) value;
                 point.time(instant, precision);
-            } else if (isNumber(fieldType)) {
+            } else if (isNumber(valueType)) {
                 point.addField(name, (Number) value);
-            } else if (Boolean.class.isAssignableFrom(fieldType) || boolean.class.isAssignableFrom(fieldType)) {
+            } else if (Boolean.class.isAssignableFrom(valueType) || boolean.class.isAssignableFrom(fieldType)) {
                 point.addField(name, (Boolean) value);
-            } else if (String.class.isAssignableFrom(fieldType)) {
+            } else if (String.class.isAssignableFrom(valueType)) {
                 point.addField(name, (String) value);
             } else {
                 point.addField(name, value.toString());

--- a/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
+++ b/client/src/test/java/com/influxdb/client/internal/MeasurementMapperTest.java
@@ -147,6 +147,100 @@ class MeasurementMapperTest {
         Assertions.assertThat(lineProtocol).isEqualTo("primitives bool1=true,bool2=true,double1=123.12,double2=123.12,float1=10.5,float2=10.5,integer1=50i,integer2=50i,long1=123456789i,long2=123456789i");
     }
 
+    @Test
+    void pojoMeasurementWithObjectValue() {
+        PojoMeasurementWithObjectValue pojo;
+        String lineProtocol;
+
+        // integer
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = 5;
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=5i");
+
+        // Integer
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = Integer.valueOf(5);
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=5i");
+
+        // long
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = 5L;
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=5i");
+
+        // Long
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = Long.valueOf(5L);
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=5i");
+
+        // double
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = 0.25;
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=0.25");
+
+        // Double
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = Double.valueOf(0.25);
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=0.25");
+
+        // float
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = 0.25f;
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=0.25");
+
+        // Float
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = Float.valueOf(0.25f);
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=0.25");
+
+        // boolean
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = true;
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=true");
+
+        // Boolean
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = Boolean.valueOf(true);
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=true");
+
+        // String
+        pojo = new PojoMeasurementWithObjectValue();
+        pojo.tag = "a";
+        pojo.value = "test";
+        pojo.customField = "mem";
+        lineProtocol = mapper.toPoint(pojo, WritePrecision.S).toLineProtocol();
+        Assertions.assertThat(lineProtocol).isEqualTo("mem,tag=a value=\"test\"");
+    }
+
     @Measurement(name = "pojo")
     private static class Pojo {
 
@@ -218,5 +312,16 @@ class MeasurementMapperTest {
         private Long long1;
         @Column
         private long long2;
+    }
+
+    public static class PojoMeasurementWithObjectValue {
+        @Column(measurement = true)
+        String customField;
+
+        @Column(name = "tag", tag = true)
+        private String tag;
+
+        @Column(name = "value")
+        private Object value;
     }
 }


### PR DESCRIPTION
Closes #

## Proposed Changes

add support of pojo's value which type is object

an example:
```java
public class PojoWithObjectValue {
    @Column(measurement = true)
    String customField;

    @Column(name = "tag", tag = true)
    private String tag;

    // The value's type is object, the value's actual type can be Number, boolean, or String, etc.
    @Column(name = "value")
    private Object value;
}
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
