### PR TITLE
fix: deploy by CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,8 +259,8 @@ workflows:
           name: jdk-17
           maven-image: "cimg/openjdk:17.0"
       - tests-java:
-          name: jdk-19
-          maven-image: "cimg/openjdk:19.0"
+          name: jdk-20
+          maven-image: "cimg/openjdk:20.0"
       - tests-java:
           name: jdk-8-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
@@ -278,7 +278,7 @@ workflows:
             - jdk-8
             - jdk-11
             - jdk-17
-            - jdk-19
+            - jdk-20
             - jdk-8-nightly
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
       - run:
           name: Deploying Snapshot
           command: |
-            mvn -s scripts/deploy-settings.xml -DskipTests=true clean package deploy
+            mvn -s scripts/deploy-settings.xml -DskipTests=true clean deploy
       - save_cache:
           name: Saving Maven Cache
           key: *cache-key-deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 1. [#584](https://github.com/influxdata/influxdb-client-java/pull/584): InfluxQL tags support
 
+### CI
+1. [#593](https://github.com/influxdata/influxdb-client-java/pull/593): Add JDK 20 to CI pipeline
+
 ### Dependencies
 
 Update dependencies:


### PR DESCRIPTION
## Proposed Changes

1. Fixed deploying artefacts to snapshot repository by CI:
    ![image](https://github.com/influxdata/influxdb-client-java/assets/455137/5f1c0a93-d7e2-4c52-9c69-8612585b3ea1)
1. Added JDK 20 to CI pipeline:
    ![image](https://github.com/influxdata/influxdb-client-java/assets/455137/b8d1229e-3680-4fff-a173-2642e93b28de)



## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
