### PR TITLE
fix: Issue/644

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             - maven-cache_v3-<< parameters.maven-image >>-
       - run:
           name: "Check generate site"
-          command: mvn clean site site:stage -DskipTests
+          command: mvn clean install site site:stage -DskipTests
 
   deploy-snapshot:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 6.11.0 [unreleased]
 
+### Bug Fixes
+1. [#648](https://github.com/influxdata/influxdb-client-java/pull/648): With csv parsing, return empty string when `stringValue` and `defaultValue` are both an empty string.
+
 ### Dependencies
 
 Update dependencies:

--- a/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
+++ b/client-core/src/main/java/com/influxdb/query/internal/FluxCsvParser.java
@@ -303,18 +303,20 @@ public class FluxCsvParser {
     private Object toValue(@Nullable final String strValue, final @Nonnull FluxColumn column) {
 
         Arguments.checkNotNull(column, "column");
+        String dataType = column.getDataType();
 
         // Default value
         if (strValue == null || strValue.isEmpty()) {
             String defaultValue = column.getDefaultValue();
             if (defaultValue == null || defaultValue.isEmpty()) {
+                if ("string".equals(dataType)) {
+                    return defaultValue;
+                }
                 return null;
             }
-
             return toValue(defaultValue, column);
         }
 
-        String dataType = column.getDataType();
         switch (dataType) {
             case "boolean":
                 return Boolean.valueOf(strValue);

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -705,6 +705,7 @@ class FluxCsvParserTest {
         Assertions.assertThat(tables.get(0).getRecords().get(0).getValueByKey("owner")).isEqualTo("influxdata");
         Assertions.assertThat(tables.get(0).getRecords().get(1).getValueByKey("owner")).isEqualTo("nana");
         Assertions.assertThat(tables.get(0).getRecords().get(2).getValueByKey("owner")).isEqualTo("nana");
+        
     }
 
     @Test

--- a/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
+++ b/client-core/src/test/java/com/influxdb/query/internal/FluxCsvParserTest.java
@@ -705,7 +705,6 @@ class FluxCsvParserTest {
         Assertions.assertThat(tables.get(0).getRecords().get(0).getValueByKey("owner")).isEqualTo("influxdata");
         Assertions.assertThat(tables.get(0).getRecords().get(1).getValueByKey("owner")).isEqualTo("nana");
         Assertions.assertThat(tables.get(0).getRecords().get(2).getValueByKey("owner")).isEqualTo("nana");
-        
     }
 
     @Test


### PR DESCRIPTION
Closes #644

## Proposed Changes

When FluxCSVParser parses a value, and the stringValue is empty and the default value for the column is empty, now checks whether the data type for the column is "string" and if this is the case returns the empty default value instead of null.

Note that headerless csv tables will still return null and that null will be returned if the default value is null. 

Two tests are added to FluxCsvParserTest.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
