### PR TITLE
feat: upgrade Spring to v6, SpringBoot to v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
     parameters:
       maven-image:
         type: string
-        default: &default-maven-image "cimg/openjdk:8.0"
+        default: &default-maven-image "cimg/openjdk:17.0"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -251,18 +251,16 @@ workflows:
       - check-generate-site
       - check-licenses
       - tests-java:
-          name: jdk-8
-      - tests-java:
-          name: jdk-11
-          maven-image: "cimg/openjdk:11.0"
-      - tests-java:
           name: jdk-17
           maven-image: "cimg/openjdk:17.0"
       - tests-java:
           name: jdk-20
           maven-image: "cimg/openjdk:20.0"
       - tests-java:
-          name: jdk-8-nightly
+          name: jdk-21
+          maven-image: "cimg/openjdk:21.0"
+      - tests-java:
+          name: jdk-17-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-java:
           name: client-backpressure
@@ -275,11 +273,10 @@ workflows:
             - check-dependencies
             - check-generate-site
             - check-licenses
-            - jdk-8
-            - jdk-11
             - jdk-17
             - jdk-20
-            - jdk-8-nightly
+            - jdk-21
+            - jdk-17-nightly
           filters:
             branches:
               only: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 7.0.0 [unreleased]
 
+:warning: This client version discontinues support for JDK 8 and 11. The minimum supported JDK version is now JDK 17.
+
 :warning: This client version discontinues support for Akka Streams and introduces support for Pekko Streams instead. Apache Pekko is a fork of [Akka](https://github.com/akka/akka) 2.6.x, created after the Akka project adopted the Business Source License, which is not compatible with open-source usage.
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Features
 1. [#661](https://github.com/influxdata/influxdb-client-java/pull/661): Replaced Akka Streams with Pekko Streams in the Scala client.
-
+1. [#673](https://github.com/influxdata/influxdb-client-java/pull/673): Upgrade SpringBoot to v3 and Spring to v6
+1. [#673](https://github.com/influxdata/influxdb-client-java/pull/673): Disable support for old JDKs (< 17)
 
 ### Dependencies
 
@@ -18,6 +19,10 @@ Update dependencies:
  - [#667](https://github.com/influxdata/influxdb-client-java/pull/667): `rxjava` to `3.1.8`
  - [#669](https://github.com/influxdata/influxdb-client-java/pull/669): `commons-lang3` to `3.14.0`
  - [#670](https://github.com/influxdata/influxdb-client-java/pull/670): `micrometer-registry-influx` to `1.12.1`
+ - [#673](https://github.com/influxdata/influxdb-client-java/pull/673): `spring-boot` to `3.2.2`
+ - [#673](https://github.com/influxdata/influxdb-client-java/pull/673): `spring` to `6.1.3`
+ - [#673](https://github.com/influxdata/influxdb-client-java/pull/673): `scala-library` to `2.13.11`
+ - [#673](https://github.com/influxdata/influxdb-client-java/pull/673): `okhttp` to `4.12.0`
 
 #### Maven:
  - [#671](https://github.com/influxdata/influxdb-client-java/pull/671): `maven-javadoc-plugin` to `3.6.3`

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ public class FluxExample {
 
 ## Build Requirements
 
-* Java 1.8+ (tested with jdk8)
+* Java 17+ (tested with JDK 17)
 * Maven 3.0+ (tested with maven 3.5.0)
 * Docker daemon running
 * The latest InfluxDB 2.x and InfluxDB 1.X docker instances, which can be started using the `./scripts/influxdb-restart.sh` script

--- a/README.md
+++ b/README.md
@@ -394,10 +394,10 @@ public class FluxExample {
 ## Build Requirements
 
 * Java 17+ (tested with JDK 17)
+    * :warning: If you want to use older version of JDK, you have to use the 6.x version of the client.
 * Maven 3.0+ (tested with maven 3.5.0)
 * Docker daemon running
 * The latest InfluxDB 2.x and InfluxDB 1.X docker instances, which can be started using the `./scripts/influxdb-restart.sh` script
-
 
 Once these are in place you can build influxdb-client-java with all tests with:
 

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -98,16 +98,6 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -107,10 +107,6 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib-common</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/client-kotlin/pom.xml
+++ b/client-kotlin/pom.xml
@@ -86,7 +86,7 @@
                 <version>${kotlin.version}</version>
                 <configuration>
                     <nowarn>true</nowarn>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>17</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
+++ b/client-reactive/src/main/java/com/influxdb/client/reactive/internal/QueryReactiveApiImpl.java
@@ -44,7 +44,6 @@ import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.ObservableEmitter;
-import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
 
 /**
@@ -355,7 +354,7 @@ final class QueryReactiveApiImpl extends AbstractQueryApi implements QueryReacti
             .map(q -> new Query().query(q).dialect(dialect)), dialect, org);
     }
 
-    @NotNull
+    @Nonnull
     private Consumer<Throwable> onError(final ObservableEmitter<?> subscriber) {
         return throwable -> {
             if (!subscriber.isDisposed()) {

--- a/client-scala/cross/2.13/pom.xml
+++ b/client-scala/cross/2.13/pom.xml
@@ -72,7 +72,7 @@
   </scm>
 
   <properties>
-    <scala.version>2.13.9</scala.version>
+    <scala.version>2.13.11</scala.version>
   </properties>
 
   <build>

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -1013,13 +1013,8 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
         String userAgent = recordedRequest.getHeader("User-Agent");
 
         String currentVersion = influxDBClient.getClass().getPackage().getImplementationVersion();
-
-        // not all test situations will get correct version from manifest at this point
-        String expectVersion = currentVersion == null
-          ? "unknown"
-          : currentVersion.substring(0, currentVersion.indexOf(".") + 1);
-
-        Assertions.assertThat(userAgent).startsWith(String.format("influxdb-client-java/%s", expectVersion));
+        
+        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/7.");
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -1012,7 +1012,14 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         String userAgent = recordedRequest.getHeader("User-Agent");
 
-        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/7.");
+        String currentVersion = influxDBClient.getClass().getPackage().getImplementationVersion();
+
+        // not all test situations will get correct version from manifest at this point
+        String expectVersion = currentVersion == null
+          ? "unknown"
+          : currentVersion.substring(0, currentVersion.indexOf(".") + 1);
+
+        Assertions.assertThat(userAgent).startsWith(String.format("influxdb-client-java/%s", expectVersion));
     }
 
     @Test

--- a/client/src/test/java/com/influxdb/client/WriteApiTest.java
+++ b/client/src/test/java/com/influxdb/client/WriteApiTest.java
@@ -46,6 +46,7 @@ import com.influxdb.exceptions.InfluxException;
 import com.influxdb.exceptions.RequestEntityTooLargeException;
 import com.influxdb.exceptions.UnauthorizedException;
 
+import com.influxdb.internal.UserAgentInterceptor;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -1012,9 +1013,15 @@ class WriteApiTest extends AbstractInfluxDBClientTest {
 
         String userAgent = recordedRequest.getHeader("User-Agent");
 
-        String currentVersion = influxDBClient.getClass().getPackage().getImplementationVersion();
-        
-        Assertions.assertThat(userAgent).startsWith("influxdb-client-java/7.");
+        String currentVersion = UserAgentInterceptor.class.getPackage().getImplementationVersion();
+
+        // not all test situations will get correct version from manifest at this point
+        String expectVersion = currentVersion == null
+          ? "unknown"
+          : currentVersion.substring(0, currentVersion.indexOf(".") + 1);
+
+        Assertions.assertThat(userAgent).startsWith(String.format("influxdb-client-java/%s", expectVersion));
+
     }
 
     @Test

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,7 +46,7 @@
                 <version>${kotlin.version}</version>
                 <configuration>
                     <nowarn>true</nowarn>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>17</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/karaf/karaf-assembly/pom.xml
+++ b/karaf/karaf-assembly/pom.xml
@@ -50,7 +50,7 @@
                     <execution>
                         <id>default-assembly</id>
                         <configuration>
-                            <javase>1.8</javase>
+                            <javase>17</javase>
                             <framework>framework</framework>
                             <bootFeatures>
                                 <feature>instance</feature>

--- a/karaf/karaf-features/pom.xml
+++ b/karaf/karaf-features/pom.xml
@@ -56,7 +56,7 @@
                     <execution>
                         <id>default-verify</id>
                         <configuration>
-                            <javase>1.8</javase>
+                            <javase>17</javase>
                             <distribution>org.apache.karaf.features:framework</distribution>
                             <descriptors>
                                 <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <dependency.retrofit.version>2.9.0</dependency.retrofit.version>
-        <dependency.okhttp3.version>4.11.0</dependency.okhttp3.version>
+        <dependency.okhttp3.version>4.12.0</dependency.okhttp3.version>
         <dependency.com.squareup.okio>3.7.0</dependency.com.squareup.okio>
         <dependency.gson.version>2.10.1</dependency.gson.version>
         <dependency.io.reactivex.rxjava3>3.1.8</dependency.io.reactivex.rxjava3>
@@ -138,7 +138,7 @@
     <build>
 
         <plugins>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -171,8 +171,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <release>17</release>
+                    <target>17</target>
                 </configuration>
             </plugin>
 
@@ -413,7 +414,7 @@
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
@@ -739,7 +740,7 @@
                 <artifactId>kotlinx-coroutines-core-jvm</artifactId>
                 <version>${kotlin-coroutines.version}</version>
             </dependency>
-            
+
         </dependencies>
     </dependencyManagement>
 

--- a/spring/README.md
+++ b/spring/README.md
@@ -10,10 +10,9 @@
 
 ## Spring Boot Compatibility
 
-:warning: The client version `6.4.0` upgrades the `OkHttp` library to version `4.10.0`. The version `3.12.x` is no longer supported - [okhttp#requirements](https://github.com/square/okhttp#requirements).
+:warning: The client version `7.0.0` upgrades the `OkHttp` library to version `4.12.0`. The version `3.x.x` is no longer supported - [okhttp#requirements](https://github.com/square/okhttp#requirements).
 
-The `spring-boot` supports the `OkHttp:4.10.0` from the version `3.0.0-M4` - [spring-boot/OkHttp 4.10,0](https://github.com/spring-projects/spring-boot/commit/6cb1a958a5d43a2fffb7e7635e3be9c0ee15f3b1).
-For the older version of `spring-boot` you have to configure Spring Boot's `okhttp3.version` property:
+The `spring-boot` supports the `OkHttp:4.12.0`. For the older version of `spring-boot` you have to configure Spring Boot's `okhttp3.version` property:
 
 ```xml
 <properties>
@@ -43,7 +42,7 @@ influx:
     connectTimeout: 5s # Connection timeout for OkHttpClient. (Default: 10s)
 ```
 
-:warning: If you are using a version of Spring Boot prior to 2.7, auto-configuration will not take effect. 
+:warning: If you are using a version of **Spring Boot prior to 2.7 with 6.x version of the client**, auto-configuration will not take effect. 
 You need to add the `@ComponentScan` annotation to your Spring Boot startup class and include com.influxdb.spring.influx in the basePackages.
 For example:
 ```java
@@ -62,7 +61,7 @@ If you want to configure the `InfluxDBClientReactive` client, you need to includ
 
 ## Actuator for InfluxDB2 micrometer registry
 
-To enable export metrics to **InfluxDB 2.x** you need to include `micrometer-core` on your classpath. 
+To enable export metrics to **InfluxDB 2.x** you need to include `micrometer-registry-influx` on your classpath. 
 (Due to package conflicts, the `spring-boot-actuator` may have relied on an earlier version of the `micrometer-core`. Therefore, it is necessary to specify a higher version here.)
 
 The default configuration can be override via properties:
@@ -81,24 +80,23 @@ management.metrics.export.influx:
     num-threads: 2 # Number of threads to use with the metrics publishing scheduler. (Default: 2)
     batch-size: 10000 # Number of measurements per request to use for this backend. If more measurements are found, then multiple requests will be made. (Default: 10000)
 ```
-
 Maven dependency:
 
 ```xml
 <dependency>
     <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-core</artifactId>
-    <version>1.11.2</version>
+    <artifactId>micrometer-registry-influx</artifactId>
+    <version>1.12.2</version>
 </dependency>
 ```
 
 or when using with Gradle:
 ```groovy
 dependencies {
-    implementation "io.micrometer:micrometer-core:1.11.2"
+    implementation "io.micrometer:micrometer-registry-influx:1.7.0"
 }
-``` 
-
+```
+ 
 ## Actuator for InfluxDB2 health
 
 The `/health` endpoint can monitor an **InfluxDB 2.x** server.

--- a/spring/README.md
+++ b/spring/README.md
@@ -93,7 +93,7 @@ Maven dependency:
 or when using with Gradle:
 ```groovy
 dependencies {
-    implementation "io.micrometer:micrometer-registry-influx:1.7.0"
+    implementation "io.micrometer:micrometer-registry-influx:1.12.2"
 }
 ```
  

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -73,8 +73,8 @@
 
     <properties>
         <micrometer.version>1.12.1</micrometer.version>
-        <spring-boot.version>2.7.17</spring-boot.version>
-        <spring.version>5.3.26</spring.version>
+        <spring-boot.version>3.2.2</spring-boot.version>
+        <spring.version>6.1.3</spring.version>
     </properties>
 
     <build>
@@ -158,7 +158,7 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/spring/src/main/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfiguration.java
+++ b/spring/src/main/java/com/influxdb/spring/health/InfluxDB2HealthIndicatorAutoConfiguration.java
@@ -50,6 +50,10 @@ import org.springframework.context.annotation.Configuration;
 public class InfluxDB2HealthIndicatorAutoConfiguration
         extends CompositeHealthContributorConfiguration<InfluxDB2HealthIndicator, InfluxDBClient> {
 
+    public InfluxDB2HealthIndicatorAutoConfiguration() {
+        super(InfluxDB2HealthIndicator::new);
+    }
+
     @Bean
     @ConditionalOnMissingBean(name = { "influxDB2HealthIndicator", "influxDB2HealthContributor" })
     public HealthContributor influxDbHealthContributor(final Map<String, InfluxDBClient> influxDBClients) {


### PR DESCRIPTION
Closes #649

## Proposed Changes

Migrate `influxdb-spring` from Spring Boot v2 to v3, Spring to v6.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
