### PR TITLE
docs: Add instructions for using Spring Boot prior to version 2.7

### DIFF
--- a/spring/README.md
+++ b/spring/README.md
@@ -44,11 +44,11 @@ influx:
 ```
 
 :warning: If you are using a version of Spring Boot prior to 2.7, auto-configuration will not take effect. 
-You need to add the @ComponentScan annotation to your Spring Boot startup class and include com.influxdb.spring.influx in the basePackages.
+You need to add the `@ComponentScan` annotation to your Spring Boot startup class and include com.influxdb.spring.influx in the basePackages.
 For example:
 ```java
 @SpringBootApplication
-@ComponentScan(basePackages = {"xxx", "com.influxdb.spring.influx"})
+@ComponentScan(basePackages = {"xyz", "com.influxdb.spring.influx"})
 public class Application {
     public static void main(String[] args) {
         ApplicationContext applicationContext = SpringApplication.run(Application.class, args);

--- a/spring/README.md
+++ b/spring/README.md
@@ -43,11 +43,27 @@ influx:
     connectTimeout: 5s # Connection timeout for OkHttpClient. (Default: 10s)
 ```
 
+:warning: If you are using a version of Spring Boot prior to 2.7, auto-configuration will not take effect. 
+You need to add the @ComponentScan annotation to your Spring Boot startup class and include com.influxdb.spring.influx in the basePackages.
+For example:
+```java
+@SpringBootApplication
+@ComponentScan(basePackages = {"xxx", "com.influxdb.spring.influx"})
+public class Application {
+    public static void main(String[] args) {
+        ApplicationContext applicationContext = SpringApplication.run(Application.class, args);
+    }
+}
+```
+The reason for this is that Spring Boot 2.7 has changed the way that auto-configuration and management context classes are discovered. see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes
+
+
 If you want to configure the `InfluxDBClientReactive` client, you need to include `influxdb-client-reactive` on your classpath instead of `influxdb-client-java`.
 
 ## Actuator for InfluxDB2 micrometer registry
 
-To enable export metrics to **InfluxDB 2.x** you need to include `micrometer-registry-influx` on your classpath.
+To enable export metrics to **InfluxDB 2.x** you need to include `micrometer-core` on your classpath. 
+(Due to package conflicts, the `spring-boot-actuator` may have relied on an earlier version of the `micrometer-core`. Therefore, it is necessary to specify a higher version here.)
 
 The default configuration can be override via properties:
 
@@ -65,23 +81,24 @@ management.metrics.export.influx:
     num-threads: 2 # Number of threads to use with the metrics publishing scheduler. (Default: 2)
     batch-size: 10000 # Number of measurements per request to use for this backend. If more measurements are found, then multiple requests will be made. (Default: 10000)
 ```
+
 Maven dependency:
 
 ```xml
 <dependency>
     <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-registry-influx</artifactId>
-    <version>1.7.0</version>
+    <artifactId>micrometer-core</artifactId>
+    <version>1.11.2</version>
 </dependency>
 ```
 
 or when using with Gradle:
 ```groovy
 dependencies {
-    implementation "io.micrometer:micrometer-registry-influx:1.7.0"
+    implementation "io.micrometer:micrometer-core:1.11.2"
 }
-```
- 
+``` 
+
 ## Actuator for InfluxDB2 health
 
 The `/health` endpoint can monitor an **InfluxDB 2.x** server.


### PR DESCRIPTION
Closes #

## Proposed Changes

1. When I introduced the influxdb-spring dependency into my Spring Boot 2.3 project, auto-configuration did not take effect, requiring additional code to be added. As a result, I updated the readme to provide instructions.

2. In the Maven repository influxdb-spring, the dependency for micrometer-registry-influx has already been added. Consequently, developers using influxdb-spring no longer need to manually import the micrometer-registry-influx dependency.  Due to package conflicts, the `spring-boot-actuator` may have relied on an earlier version of the `micrometer-core`. Therefore, it is necessary to specify a higher version here.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
