### PR TITLE
add escaping for backslashes, fixes #718

### DIFF
--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -442,6 +442,9 @@ public final class Point {
     private void escapeKey(@Nonnull final StringBuilder sb, @Nonnull final String key, final boolean escapeEqual) {
         for (int i = 0; i < key.length(); i++) {
             switch (key.charAt(i)) {
+                case '\\':
+                    sb.append("\\\\");
+                    continue;
                 case '\n':
                     sb.append("\\n");
                     continue;

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -183,6 +183,16 @@ class PointTest {
     }
 
     @Test
+    void tagEscape() {
+        Point point = Point.measurement("h2o")
+                .addTag("location", "\\")
+                .addTag("zone", "europe")
+                .addField("level", "dummy value");
+
+        Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2o,location=\\\\,zone=europe level=\"dummy value\"");
+    }
+
+    @Test
     void time() {
 
         Point point = Point.measurement("h2o")


### PR DESCRIPTION
Closes #718 

## Proposed Changes

Backslashes should also be escaped.
This is generally optional in InfluxDB, but in special cases such as the end of a tag value, it might become crucial

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
