### PR TITLE
feat: better expose HTTP Error header information in error handling on write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features 
 
+- [#745](https://github.com/influxdata/influxdb-client-java/pull/745): New example `WriteHttpExceptionHandled.java` showing how to make use of `InfluxException.headers()` when HTTP Errors are returned from server.  Also, now writes selected headers to client log.
 - [#719](https://github.com/influxdata/influxdb-client-java/issues/719): `InfluxQLQueryService` header changes.
    - `Accept` header can now be defined when making `InfluxQLQuery` calls. Supoorted MIME types:
       - `application/csv`

--- a/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
+++ b/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
@@ -156,17 +156,6 @@ public class InfluxException extends RuntimeException {
     @Nullable
     private String messageFromResponse() {
         if (response != null) {
-            String selectHeaders = Stream.of("trace-id",
-                "trace-sampled",
-                "X-Influxdb-Build",
-                "X-Influxdb-Request-ID",
-                "X-Influxdb-Version")
-              .filter(name -> response.headers().get(name) != null)
-              .reduce("", (message, name) -> message.concat(String.format("%s: %s\n",
-                name, response.headers().get(name))));
-
-            LOG.warning(String.format("Received HTTP Error %d with selected headers:\n%s",
-              response.code(), selectHeaders));
             int code = response.code();
             try {
                 ResponseBody body = response.errorBody();

--- a/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
+++ b/client-core/src/main/java/com/influxdb/exceptions/InfluxException.java
@@ -156,6 +156,17 @@ public class InfluxException extends RuntimeException {
     @Nullable
     private String messageFromResponse() {
         if (response != null) {
+            String selectHeaders = Stream.of("trace-id",
+                "trace-sampled",
+                "X-Influxdb-Build",
+                "X-Influxdb-Request-ID",
+                "X-Influxdb-Version")
+              .filter(name -> response.headers().get(name) != null)
+              .reduce("", (message, name) -> message.concat(String.format("%s: %s\n",
+                name, response.headers().get(name))));
+
+            LOG.warning(String.format("Received HTTP Error %d with selected headers:\n%s",
+              response.code(), selectHeaders));
             int code = response.code();
             try {
                 ResponseBody body = response.errorBody();

--- a/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
+++ b/client-core/src/test/java/com/influxdb/exceptions/InfluxExceptionTest.java
@@ -33,10 +33,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import retrofit2.HttpException;
 import retrofit2.Response;
 

--- a/client/src/main/java/com/influxdb/client/write/events/WriteErrorEvent.java
+++ b/client/src/main/java/com/influxdb/client/write/events/WriteErrorEvent.java
@@ -57,7 +57,6 @@ public final class WriteErrorEvent extends AbstractWriteEvent {
 
     @Override
     public void logEvent() {
-        //LOG.log(Level.SEVERE, "The error occurred during writing of data", throwable);
         if (throwable instanceof InfluxException ie) {
           String selectHeaders = Stream.of("trace-id",
                 "trace-sampled",

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ This directory contains Java, Kotlin and Scala examples.
 - [InfluxDBEnterpriseExample.java](src/main/java/example/InfluxDBEnterpriseExample.java) - How to use `consistency` parameter for InfluxDB Enterprise
 - [RecordRowExample.java](src/main/java/example/RecordRowExample.java) - How to use `FluxRecord.getRow()` (List) instead of `FluxRecord.getValues()` (Map),
   in case of duplicity column names
+- [WriteHttpExceptionHandled](src/main/java/example/WriteHttpExceptionHandled.java) - How to work with HTTP Exceptions for debugging and recovery.
 
 ## Kotlin
 

--- a/examples/src/main/java/example/WriteHttpExceptionHandled.java
+++ b/examples/src/main/java/example/WriteHttpExceptionHandled.java
@@ -98,7 +98,6 @@ public class WriteHttpExceptionHandled {
 
   private static void logInfluxException(@Nonnull InfluxException e) {
     StringBuilder sBuilder = new StringBuilder().append("Handling InfluxException:\n");
-    //Log.info("Message: " + e.getMessage());
     sBuilder.append("      ").append(e.getMessage());
     String headers = e.headers()
       .keySet()

--- a/examples/src/main/java/example/WriteHttpExceptionHandled.java
+++ b/examples/src/main/java/example/WriteHttpExceptionHandled.java
@@ -1,0 +1,92 @@
+package example;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.WriteApi;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.exceptions.InfluxException;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class WriteHttpExceptionHandled {
+
+  static Logger Log = Logger.getLogger(WriteHttpExceptionHandled.class.getName());
+
+  public static String resolveProperty(final String property, final String fallback) {
+    return System.getProperty(property, System.getenv(property)) == null
+      ? fallback : System.getProperty(property, System.getenv(property));
+  }
+
+  private static final String influxUrl = resolveProperty("INFLUX_URL", "http://localhost:8086");
+  private static final char[] token = resolveProperty("INFLUX_TOKEN","my-token").toCharArray();
+  private static final String org = resolveProperty("INFLUX_ORG","my-org");
+  private static final String bucket = resolveProperty("INFLUX_DATABASE","my-bucket");
+
+  public static void main(String[] args) {
+
+    InfluxDBClient influxDBClient = InfluxDBClientFactory.create(influxUrl, token, org, bucket);
+
+    Log.info("\nWriting invalid records to InfluxDB reactively - check log SEVERE messages.\n");
+    WriteApi writeApi = influxDBClient.makeWriteApi();
+
+    // the following call will cause an HTTP 400 error, which will
+    // include selected HTTP response headers in the error log
+    writeApi.writeRecords(WritePrecision.MS, List.of("invalid", "clumsy", "broken", "unusable"));
+    writeApi.close();
+
+    Log.info("\nWriting invalid records to InfluxDB blocking - can handle caught InfluxException.\n");
+    WriteApiBlocking writeApiBlocking = influxDBClient.getWriteApiBlocking();
+    try {
+      writeApiBlocking.writeRecord(WritePrecision.MS, "asdf");
+    } catch (InfluxException e) {
+      logInfluxException(e);
+    }
+
+    // Note when writing batches with one bad record:
+    //    Cloud v3.x - The bad record is ignored.
+    //    OSS   v2.x - returns exception
+    Log.info("Writing Batch with 1 bad record.");
+    Instant now = Instant.now();
+
+    List<String> lpData = List.of(
+      String.format("temperature,location=north value=60.0 %d", now.toEpochMilli()),
+      String.format("temperature,location=south value=65.0 %d", now.minus(1, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=north value=59.8 %d", now.minus(2, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=south value=64.8 %d", now.minus(3, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=north value=59.7 %d", now.minus(4, ChronoUnit.SECONDS).toEpochMilli()),
+      "asdf",
+      String.format("temperature,location=north value=59.9 %d", now.minus(6, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=south value=64.9 %d", now.minus(7, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=north value=60.1 %d", now.minus(8, ChronoUnit.SECONDS).toEpochMilli()),
+      String.format("temperature,location=south value=65.1 %d", now.minus(9, ChronoUnit.SECONDS).toEpochMilli())
+    );
+
+    try {
+      writeApiBlocking.writeRecords(WritePrecision.MS, lpData);
+    } catch (InfluxException e) {
+      logInfluxException(e);
+    }
+
+    Log.info("Done");
+  }
+
+  private static void logInfluxException(@Nonnull InfluxException e) {
+    StringBuilder sBuilder = new StringBuilder().append("Handling InfluxException:\n");
+    //Log.info("Message: " + e.getMessage());
+    sBuilder.append("      ").append(e.getMessage());
+    String headers = e.headers()
+      .keySet()
+      .stream()
+      .reduce("\n", (set, key) -> set.concat(
+        String.format("        %s: %s\n", key, e.headers().get(key)))
+      );
+    sBuilder.append("\n      HTTP Response Headers:");
+    sBuilder.append(headers);
+    Log.info(sBuilder.toString());
+  }
+}

--- a/examples/src/main/java/example/WriteHttpExceptionHandled.java
+++ b/examples/src/main/java/example/WriteHttpExceptionHandled.java
@@ -1,3 +1,24 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package example;
 
 import com.influxdb.client.InfluxDBClient;


### PR DESCRIPTION
## Proposed Changes

Http Headers are already part of `InfluxException`.  In the `WriteApi` they can be accessed with an `EventListener`.  With `WriteApiBlocking` they get thrown in `write` method calls.

- print selected headers useful for debugging to error logs
- add an example of working with headers from `InfluxException`

Note that Cloud v3 and OSS v2 handle exceptional streamed or batched data on the server side a little bit differently.  It appears that with v3 cloud batches of data that include some invalid records along with valid ones, will still write the valid records and return a success HTTP status code.  OSS v2 on the other hand returns an error status triggering an exception.  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
