### PR TITLE
feat: Add read-only getters for `Point.fields` and `Point.tags`

### DIFF
--- a/client/src/main/java/com/influxdb/client/write/Point.java
+++ b/client/src/main/java/com/influxdb/client/write/Point.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -93,6 +94,24 @@ public final class Point {
         Arguments.checkNotNull(measurementName, "measurement");
 
         return new Point(measurementName);
+    }
+
+    /**
+     * Returns a read-only reference to the tags.
+     * @return The point tags as read-only map.
+     */
+    @Nonnull
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(this.tags);
+    }
+
+    /**
+     * Returns a read-only reference to the fields.
+     * @return The point fields as read-only map.
+     */
+    @Nonnull
+    public Map<String, Object> getFields() {
+        return Collections.unmodifiableMap(this.fields);
     }
 
     /**

--- a/client/src/test/java/com/influxdb/client/write/PointTest.java
+++ b/client/src/test/java/com/influxdb/client/write/PointTest.java
@@ -24,12 +24,16 @@ package com.influxdb.client.write;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.influxdb.client.domain.WritePrecision;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Jakub Bednar (bednar@github) (11/10/2018 12:57)
@@ -437,5 +441,22 @@ class PointTest {
                 .addFields(fields);
 
         Assertions.assertThat(point.toLineProtocol()).isEqualTo("h2o,location=europe accepted=true,level=2i,power=2.56");
+    }
+
+    @Test
+    void getFieldsGetTags() {
+        Point point = Point.measurement("h2 o")
+                .addTag("location", "europe")
+                .addField("level", 2);
+
+        Map<String, Object> fields = point.getFields();
+        Map<String, String> tags = point.getTags();
+
+        Assertions.assertThat(fields).isEqualTo(Map.of("level",2L));
+        Assertions.assertThat(tags).isEqualTo(Map.of("location","europe"));
+
+        // Assert that returned maps are immutable
+        assertThrows(UnsupportedOperationException.class, () -> fields.put("test", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> tags.put("test", "value"));
     }
 }


### PR DESCRIPTION
This makes testing easier.

## Proposed Changes

I am currently contributing to a Jenkins Plugin which uses InfluxDB. Testing this plugin currently requires the use of Java reflections in order to compare written tags and fields.

Adding read-only getter functions for `tags` and `fields` would make this more easy.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] `mvn test` completes successfully
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
