### PR TITLE
fix: migrate Maven OSS repository to Central Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1120,7 +1120,7 @@ jacoco-maven-plugin: 0.8.5, maven-checkstyle: 3.1.1, maven-javadoc: 3.2.0, maven
 1. [#40](https://github.com/influxdata/influxdb-client-java/issues/40): The client is hosted in Maven Central repository
     - Repackaged from `org.influxdata` to `com.influxdb`
     - Changed _groupId_ from `org.influxdata` to `com.influxdb`
-    - Snapshots are located in the _OSS Snapshot repository_: `https://oss.sonatype.org/content/repositories/snapshots/`
+    - Snapshots are located in the _OSS Snapshot repository_: `https://central.sonatype.com/repository/maven-snapshots/`
 
 ### Features
 1. [#34](https://github.com/influxdata/influxdb-client-java/issues/34): Auto-configure client from configuration file

--- a/client-kotlin/README.md
+++ b/client-kotlin/README.md
@@ -315,14 +315,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -334,6 +334,6 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```

--- a/client-legacy/README.md
+++ b/client-legacy/README.md
@@ -174,14 +174,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -193,6 +193,6 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -445,14 +445,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -464,6 +464,6 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```

--- a/client-scala/README.md
+++ b/client-scala/README.md
@@ -287,14 +287,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -306,6 +306,6 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```

--- a/client/README.md
+++ b/client/README.md
@@ -1334,14 +1334,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -1353,7 +1353,7 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -171,7 +171,7 @@
 		<repository>
 			<id>ossrh</id>
 			<name>OSS Snapshot repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/flux-dsl/README.md
+++ b/flux-dsl/README.md
@@ -1109,14 +1109,14 @@ dependencies {
 ```
 
 ### Snapshot Repository
-The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/).
+The snapshots are deployed into [OSS Snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 #### Maven
 ```xml
 <repository>
     <id>ossrh</id>
     <name>OSS Snapshot repository</name>
-    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     <releases>
         <enabled>false</enabled>
     </releases>
@@ -1128,6 +1128,6 @@ The snapshots are deployed into [OSS Snapshot repository](https://oss.sonatype.o
 #### Gradle
 ```
 repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://central.sonatype.com/repository/maven-snapshots" }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
         <site>
             <id>GitHubPages</id>
@@ -415,7 +415,7 @@
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This PR migrate deployment from Sonatype OSS repository to Central Portal. For more info see: https://central.sonatype.org/pages/ossrh-eol/