### PR TITLE
chore: upgrade junit and surfire version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 8.1.0 [unreleased]
 
+### Dependencies
+
+Update dependencies:
+
+#### Build:
+1. [#908](https://github.com/influxdata/influxdb-client-java/pull/908):
+   1. Add dependencies: 
+      - `junit-bom`
+      - `junit-platform-launcher`
+   2. Upgrade dependencies: 
+      - `surefire` to `3.5.5`
+      - `junit` to `5.13.4`
+
 ## 8.0.0 [2026-04-23]
 
 :warning: The `spring` module now targets Spring Boot 4.x. Applications using `com.influxdb:influxdb-client-java-spring` should upgrade to Spring Boot 4.x.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 Update dependencies:
 
 #### Build:
-1. [#908](https://github.com/influxdata/influxdb-client-java/pull/908):
-   1. Add dependencies: 
-      - `junit-bom`
-      - `junit-platform-launcher`
-   2. Upgrade dependencies: 
-      - `surefire` to `3.5.5`
-      - `junit` to `5.13.4`
+- [#908](https://github.com/influxdata/influxdb-client-java/pull/908):
+    - Add dependencies:
+        - `junit-bom`
+        - `junit-platform-launcher`
+    - Upgrade dependencies:
+        - `surefire` to `3.5.5`
+        - `junit` to `5.13.4`
 
 ## 8.0.0 [2026-04-23]
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency.gson.version>2.12.1</dependency.gson.version>
         <dependency.io.reactivex.rxjava3>3.1.10</dependency.io.reactivex.rxjava3>
 
-        <plugin.surefire.version>3.5.2</plugin.surefire.version>
+        <plugin.surefire.version>3.5.5</plugin.surefire.version>
         <plugin.javadoc.version>3.12.0</plugin.javadoc.version>
         <plugin.checkstyle.version>3.6.0</plugin.checkstyle.version>
         <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
@@ -123,7 +123,7 @@
 
         <pekko.version>1.6.0</pekko.version>
         <kotlin.version>2.1.10</kotlin.version>
-        <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <kotlin-coroutines.version>1.10.2</kotlin-coroutines.version>
         <mockito.version>5.0.0</mockito.version>
     </properties>
@@ -132,6 +132,12 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -663,9 +669,11 @@
             </dependency>
 
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Closes:
- #898
- #841
- #835 

## Proposed Changes

- Upgrade `surefire` version to 3.5.5
- Upgrade `junit-jupiter` to 5.13.4
- Add `junit-bom` for better dependency management for JUnit framework.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
